### PR TITLE
Improve README with configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,112 +1,67 @@
-# CLUV
+# cluv
 
-Name inspired by "Cluster" + "UV" and from  `clush` (clustershell)
+cluv — sync UV-based Python projects across HPC clusters.
 
-> WIP: This isn't even fully designed yet. Nothing is implemented, there are only stubs.
+## Status
 
-## Project Roadmap
+Early development. Core commands (`login`, `sync`) are functional. `status` shows live cluster data. `init` and `run` are not yet implemented.
 
-- [ ] Brainstorming phase
-  - [x] Pitch the idea for this project to some potential users / devs.
-  - [ ] Gather ideas / feedback in a structured way.
-- [ ] Design phase
-  - [ ] Triage the ideas and create an initial, minimal set of commands / features.
-  - [ ] Give an estimate of the time required to implement each command.
-  - [ ] Write some stubs for tests for the commands, to help refine the design
-  - [ ] Design a proof-of-concept solution for each command.
-- [ ] Implementation phase
+## Requirements
 
+- Python >= 3.13
+- [UV](https://docs.astral.sh/uv/)
+- SSH access configured for each cluster in `~/.ssh/config` (run `cluv login` to open ControlMaster sessions)
 
-## Assumptions
-- You have a project managed with UV on the **Mila** cluster
-	- Could also work later with a local project and using the mila cluster as the "main" cluster, but let's start with this simplifying assumption for now. 
-- Want to sync code and dispatch jobs to other clusters (DRAC / PAICE for now) where the user already has access with SSH.
-- Want to gather results from other clusters to the Mila cluster.
-- Project has a GitHub repo.
-- Same structure everywhere:
-	- Project in `$HOME/project_name`
-	- Checkpoints somewhere in `$SCRATCH`, with a symlink in the project folder at `$HOME/project_name/logs.
-- Wandb offline mode used on all the non-mila clusters.
+## Installation
 
-## Proposed Commands
+Install as a UV tool:
 
-## `cluv init`
-Akin to `uv init`, sets up the current project on all configured clusters.
-- Prompts to configure which clusters to use (config stored in pyproject.toml of the project)
-- Installs UV on all clusters
-	- Sets up the DRAC-specific uv.toml files to use the DRAC wheelhouse when necessary.
-- Sets up the project repo, creates the $SCRATCH checkpoint folder
-#### How it could work (proof-of-concept)
-- Over SSH. Setup UV.
-- Assume GitHub. Clone the project on each cluster. Configure the git credential-cache if necessary.
+```bash
+uv tool install git+https://github.com/mila-iqai/cluv
+```
 
-## `cluv sync [--cluster=all|<cluster>]`
+Or run directly from the repo without installing:
 
-- Synchronizes code across all clusters. Gathers results on the "main" cluster (mila)
-- Does `uv sync` that cluster as well
-	- (Important so that jobs can be run in OFFLINE mode)
+```bash
+uv run cluv <command>
+```
 
-#### How it could work (proof-of-concept)
-- Checks git state
-- Push to github
-	- TODO: Check syncing without github.
-- Over SSH, does a git fetch on all remote clusters
-- Gathers results from all other clusters to the Mila cluster using rsync.
+## Quick Start
 
-## `cluv run [--cluster=cluster] <command>`
+1. Add a `[tool.cluv]` section to your project's `pyproject.toml` (see [Configuration](#configuration) below).
+2. Establish SSH connections to all configured clusters:
+   ```bash
+   cluv login
+   ```
+3. Sync your project to all clusters and run `uv sync` on each:
+   ```bash
+   cluv sync
+   ```
 
-Similar in spirit to `uv run`, but runs a command in the synced project on a potentially remote cluster.
-- Idea is that this could maybe be a building block for other commands.
+## Configuration
 
-## `cluv status`
+Add a `[tool.cluv]` section to the `pyproject.toml` of your project:
 
-- Gives you an overview of the state of each cluster, and displays an overview of the state of your jobs across the clusters.
-- Displays the number of idle nodes, or the number of idle GPUs, or something similar, for each cluster
+```toml
+[tool.cluv]
+clusters = ["mila", "narval", "tamia"]   # SSH hostnames from ~/.ssh/config
+results_path = "results"                  # optional: rsync remote results back here
+```
 
+`clusters` must match SSH hostnames in `~/.ssh/config`. `results_path` is relative to the project root; if set, `cluv sync` rsyncs that directory back from each remote cluster.
 
-## `cluv launch [--cluster=cluster] <job_script.sh>`
+## Commands
 
-- Launch this job script on the given cluster.
+| Command | Description |
+|---------|-------------|
+| `cluv login` | Open SSH ControlMaster connections to all configured clusters. Run this first, or before any command that requires a live connection. |
+| `cluv sync` | Push local git changes, then on each cluster: clone or fetch the repo, check out the current branch, and run `uv sync`. Optionally rsyncs results back. |
+| `cluv status` | Display an overview of each cluster: partition availability, running/queued jobs, and storage usage. |
+| `cluv run` | Run a command in the synced project on a remote cluster. *(Not yet implemented.)* |
+| `cluv init` | Set up the project on all configured clusters for the first time. *(Not yet implemented.)* |
 
-To manage different clusters having different SLURM accounts / gpus / etc:
-	- **Simplest**: Launches the job script as-is. User has to have different job scripts for each cluster.
-	- Stretch goal: `cluv` applies some templating to the job script based on configuration in the `pyproject.toml`
+## DRAC Clusters
 
-#### How it could work (proof-of-concept)
-- Does `cluv sync --cluster=<cluster>`
-- Uses something like the `safe_sbatch` script / command instead of `sbatch` , and the job script uses the `code_checkpointing.sh` script to 
-#### Stretch goal: `--cluster=auto`
-Stretch goal: "auto" will use the "best" cluster for the job.
-- the least utilized cluster, or the cluster with fewest jobs in the queue
-- `sbatch --test-only` estimated start-time (if reliable)
-- (advanced), Based on job resource requirements, find the best cluster for it.
+DRAC clusters (Narval, Tamia, Rorqual, etc.) require a `uv.toml` that points to the DRAC wheelhouse for offline installs. Place a `uv.toml` in the project root on each DRAC cluster with the appropriate `find-links` or `index-url` pointing to the local wheelhouse path.
 
-
-## `cluv dashboard`
-
-Terminal UI showing jobs in a table, for each cluster:
-- Job ID
-- Job Name
-- Job State
-- Job Nodes
-- Job Resources
-- Job command
-- Wandb URL
-
-
-## Questions / commentaires
-
-- attention de pas briser les jobs qui roulent déjà quand on fait `cluv sync`
-
-- Hierarchie de cache avec UV?
-
-- Pourrait aider à inciter les gens à utilier différentes grappes de calcul
-	- Ce serait dommage qu'il faille utiliser un job script différent par cluster.
-
-- Launch,  interface terminal interactive pour choisir les clusters, les ressources, etc.
-- 
-
-
-
-
-
+DRAC clusters are detected automatically via the `$CC_CLUSTER` environment variable.


### PR DESCRIPTION
## Summary

- Rewrites the README as a clean user-facing doc, removing internal design notes, French text, and roadmap checkboxes
- Adds an annotated `[tool.cluv]` pyproject.toml configuration example
- Adds installation, quick start, commands table, and DRAC-specific setup notes

## Test plan

- [ ] Review rendered markdown on GitHub
- [ ] Verify the TOML example is valid