### PR TITLE
Prefix cluv-submitted job names for admin tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ wheels/
 # uv.lock
 .claude
 .vscode
+logs/

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -85,9 +85,9 @@ async def submit(
     # 5. Build env var dict: global SBATCH_* defaults merged with per-cluster overrides.
     env_vars: dict[str, str] = {**config.slurm}
     env_vars.update(config.cluster_configs.get(cluster, {}))
-    # SBATCH_COMMENT is not a recognized sbatch env var; pop it and pass as --comment flag.
-    user_comment = env_vars.pop("SBATCH_COMMENT", None)
-    comment = f"cluv:{user_comment}" if user_comment else "cluv"
+    # Prefix the job name with "cluv-" so admins can identify cluv-submitted jobs in sacct.
+    base_name = env_vars.get("SBATCH_JOB_NAME") or Path(job_script).stem
+    env_vars["SBATCH_JOB_NAME"] = f"cluv-{base_name}"
     env_vars["GIT_COMMIT"] = git_commit
 
     env_prefix = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env_vars.items())
@@ -95,7 +95,7 @@ async def submit(
     program_args_str = shlex.join(program_args)
 
     # 6. Submit.
-    remote_cmd = f"bash -l -c '{env_prefix} sbatch --parsable --comment={shlex.quote(comment)} --chdir={project_path} {sbatch_args_str} {remote_job_script} {program_args_str}'"
+    remote_cmd = f"bash -l -c '{env_prefix} sbatch --parsable --chdir={project_path} {sbatch_args_str} {remote_job_script} {program_args_str}'"
     console.print(
         f"Submitting job on [bold]{cluster}[/bold]: {job_script}"
         + (f" {sbatch_args_str}" if sbatch_args_str else "")

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -85,6 +85,8 @@ async def submit(
     # 5. Build env var dict: global SBATCH_* defaults merged with per-cluster overrides.
     env_vars: dict[str, str] = {**config.slurm}
     env_vars.update(config.cluster_configs.get(cluster, {}))
+    existing_comment = env_vars.get("SBATCH_COMMENT")
+    env_vars["SBATCH_COMMENT"] = f"cluv:{existing_comment}" if existing_comment else "cluv"
     env_vars["GIT_COMMIT"] = git_commit
 
     env_prefix = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env_vars.items())

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -85,8 +85,9 @@ async def submit(
     # 5. Build env var dict: global SBATCH_* defaults merged with per-cluster overrides.
     env_vars: dict[str, str] = {**config.slurm}
     env_vars.update(config.cluster_configs.get(cluster, {}))
-    existing_comment = env_vars.get("SBATCH_COMMENT")
-    env_vars["SBATCH_COMMENT"] = f"cluv:{existing_comment}" if existing_comment else "cluv"
+    # SBATCH_COMMENT is not a recognized sbatch env var; pop it and pass as --comment flag.
+    user_comment = env_vars.pop("SBATCH_COMMENT", None)
+    comment = f"cluv:{user_comment}" if user_comment else "cluv"
     env_vars["GIT_COMMIT"] = git_commit
 
     env_prefix = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env_vars.items())
@@ -94,7 +95,7 @@ async def submit(
     program_args_str = shlex.join(program_args)
 
     # 6. Submit.
-    remote_cmd = f"bash -l -c '{env_prefix} sbatch --parsable --chdir={project_path} {sbatch_args_str} {remote_job_script} {program_args_str}'"
+    remote_cmd = f"bash -l -c '{env_prefix} sbatch --parsable --comment={shlex.quote(comment)} --chdir={project_path} {sbatch_args_str} {remote_job_script} {program_args_str}'"
     console.print(
         f"Submitting job on [bold]{cluster}[/bold]: {job_script}"
         + (f" {sbatch_args_str}" if sbatch_args_str else "")

--- a/cluv/utils.py
+++ b/cluv/utils.py
@@ -1,6 +1,6 @@
 import os
+import socket
 import sys
-from pathlib import Path
 
 import rich.console
 
@@ -9,7 +9,7 @@ console = rich.console.Console(record=True, file=sys.stdout)
 
 
 def current_cluster() -> str | None:
-    if Path("/home/mila").exists():
+    if socket.gethostname().endswith(".mila.quebec"):
         return "mila"
     if "CC_CLUSTER" in os.environ:
         return os.environ["CC_CLUSTER"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -117,7 +117,7 @@ async def test_submit(remote: Remote):
     )
     assert isinstance(job_id, int)
 
-    comment = await remote.get_output(
-        f"sacct -j {job_id} --format=Comment --noheader --parsable2 | head -1"
+    job_name = await remote.get_output(
+        f"sacct -j {job_id} --format=JobName --noheader --parsable2 | head -1"
     )
-    assert comment.strip().startswith("cluv")
+    assert job_name.strip().startswith("cluv-")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -116,3 +116,8 @@ async def test_submit(remote: Remote):
         program_args=["python", "--version"],
     )
     assert isinstance(job_id, int)
+
+    comment = await remote.get_output(
+        f"sacct -j {job_id} --format=Comment --noheader --parsable2 | head -1"
+    )
+    assert comment.strip().startswith("cluv")


### PR DESCRIPTION
## Summary

- Prefixes all jobs submitted via `cluv submit` with `cluv-` in the job name (e.g. `cluv-job` for `scripts/job.sh`), so cluster admins can identify and filter them via `sacct`
- If the user already sets `SBATCH_JOB_NAME` in their config, that name is used as the suffix instead of the script stem
- Fixes `current_cluster()` Mila detection: `Path("/home/mila").exists()` is true on local machines with the Mila filesystem mounted, causing `login()` to skip connecting to Mila; now uses `socket.gethostname()` instead (all Mila nodes have FQDNs ending in `.mila.quebec`)

## Test plan

- [x] Integration test `test_submit[mila]` passes: submits a job and verifies `sacct` reports a job name starting with `cluv-`
- [x] All unit tests pass (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)