### PR TITLE
Add implementation for `cluv init` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ In early development. Commands are functional, but expect bugs or missing featur
 - Python >= 3.13
 - [UV](https://docs.astral.sh/uv/)
 - SSH access configured for each cluster in `~/.ssh/config` (run `cluv login` to open ControlMaster sessions)
+- A GitHub repository with your project
 
 ## Installation
 
@@ -56,7 +57,7 @@ Add a `[tool.cluv]` section to the `pyproject.toml` of your project. `cluv init`
 | `results_path` | string (optional) | Path relative to the project root. When set, `cluv sync` rsyncs that directory back from each remote cluster. |
 
 ### `[tool.cluv.slurm]`
-Environment variables (key/value pairs) applied when using Slurm commands on all clusters. Use this for global Slurm defaults such as resource limits or for tool configuration like (uv of W&B).
+Environment variables applied when using Slurm commands on all clusters. Use this for global Slurm defaults such as resource limits or for tool configuration like (uv or W&B).
 
 ### `[tool.cluv.clusters.<name>]`
 Environment variables for a specific cluster. Values here are merged on top of `[tool.cluv.slurm]` when submitting.
@@ -65,8 +66,8 @@ Environment variables for a specific cluster. Values here are merged on top of `
 
 ```toml
 [tool.cluv]
-clusters = ["mila", "narval", "tamia"]   # SSH hostnames from ~/.ssh/config
-results_path = "logs"                    # rsynced back by `cluv sync`
+clusters = ["mila", "narval", "tamia"]
+results_path = "logs"
 
 [tool.cluv.slurm]
 # Applied to every cluster by default
@@ -90,20 +91,14 @@ Initialize the current directory as a cluv project. Must be run from inside your
 cluv init
 ```
 
-Steps performed:
-1. Runs `uv init` as a package (skipped if `pyproject.toml` already exists).
-2. Warns if no git remote is configured (required for `sync` and `submit`).
-3. Appends a `[tool.cluv]` section to `pyproject.toml` if one is not already present, with defaults for Mila and DRAC clusters.
-4. Creates `scripts/job.sh`, a Slurm job script template, if it does not already exist.
-5. Creates a symlink `<results_path>/ → $SCRATCH/<results_path>/<project_name>/` so large outputs go to `$SCRATCH` rather than filling `$HOME`.
-
 Default project structure after `cluv init`:
 ```
 my_project/
+├── README.md
+├── logs -> $SCRATCH/logs/my_project   # symlink to $SCRATCH
 ├── pyproject.toml        # includes [tool.cluv] config
 ├── scripts/
 │   └── job.sh            # Slurm job script template
-├── logs -> $SCRATCH/logs/my_project   # symlink to $SCRATCH
 └── src/
     └── my_project/
         └── __init__.py
@@ -123,7 +118,7 @@ cluv login [<cluster> ...]
 
 ### `cluv sync`
 
-Push local git changes, then on each cluster: clone or fetch the repo, check out the current branch, and run uv sync. Optionally rsyncs results back if `results_path` is set in the config.
+Push local git changes, then on each cluster: clone or fetch the repo, check out the current branch, and run `uv sync`. Optionally rsyncs results back if `results_path` is set in the config.
 
 ```
 cluv sync [<cluster> ...]
@@ -133,11 +128,6 @@ cluv sync [<cluster> ...]
 |----------|-------------|
 | `<cluster> ...` | Clusters to sync. Defaults to all configured clusters. Pass explicit names to connect to specific clusters. |
 
-Sync steps per cluster:
-1. Install or update `uv` to match the local version.
-2. Clone the repo from GitHub (if not present).
-3. Run `uv sync` on the remote.
-4. Rsync `results_path/` back to the local machine (if configured).
 
 ### `cluv status`
 
@@ -165,13 +155,6 @@ cluv submit <cluster> <job.sh> [<sbatch-flags> ...] [-- <program-args> ...]
 | `<job.sh>` | Path to the job script. |
 | `<sbatch-flags>` | Any extra flags to pass to `sbatch`. |
 | `-- <program-args>` | Arguments passed to the job script itself (after `--`). |
-
-Steps performed:
-1. Checks that the git working tree is clean.
-2. Captures the current commit hash and sets it as `GIT_COMMIT`.
-3. Syncs the project to the cluster (equivalent to `cluv sync <cluster>`).
-4. Merges `[tool.cluv.slurm]` env vars with per-cluster overrides from `[tool.cluv.clusters.<name>]`.
-5. Runs `sbatch` on the remote with all env vars, sbatch flags, and program args.
 
 ### `cluv run`
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ In early development. Commands are functional, but expect bugs or missing featur
 - Python >= 3.13
 - [UV](https://docs.astral.sh/uv/)
 - SSH access configured for each cluster in `~/.ssh/config` (run `cluv login` to open ControlMaster sessions)
-- A GitHub repository 
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ cluv submit mila job.sh
    ```bash
    cluv init
    ```
-   This sets up a UV project and adds a default `[tool.cluv]` section to your `pyproject.toml`. You can customize this config later (see [Configuration](#configuration) below). 
 2. Establish SSH connections to all configured clusters:
    ```bash
    cluv login

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ In early development. Commands are functional, but expect bugs or missing featur
 - Python >= 3.13
 - [UV](https://docs.astral.sh/uv/)
 - SSH access configured for each cluster in `~/.ssh/config` (run `cluv login` to open ControlMaster sessions)
+- A GitHub repository 
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ cluv — sync UV-based Python projects across HPC clusters.
 
 ## Status
 
-Early development. Core commands (`login`, `sync`, `submit`) are functional. `status` shows live cluster data. `run` and `init` are not yet implemented.
+In early development. Commands are functional, but expect bugs or missing features.
 
 ## Requirements
 
@@ -20,9 +20,10 @@ Install as a UV tool:
 uv tool install git+https://github.com/mila-iqia/cluv
 ```
 
-Then you can run `cluv` directly as a command:
+Then you can run `cluv` directly as a command like :
 
 ```bash
+cluv init
 cluv login mila
 cluv sync mila
 cluv submit mila job.sh
@@ -30,7 +31,11 @@ cluv submit mila job.sh
 
 ## Quick Start
 
-1. Add a `[tool.cluv]` section to your project's `pyproject.toml` (see [Configuration](#configuration) below).
+1. Initialize your project with :
+   ```bash
+   cluv init
+   ```
+   This sets up a UV project and adds a default `[tool.cluv]` section to your `pyproject.toml`. You can customize this config later (see [Configuration](#configuration) below). 
 2. Establish SSH connections to all configured clusters:
    ```bash
    cluv login
@@ -42,26 +47,145 @@ cluv submit mila job.sh
 
 ## Configuration
 
-Add a `[tool.cluv]` section to the `pyproject.toml` of your project:
+Add a `[tool.cluv]` section to the `pyproject.toml` of your project. `cluv init` generates a default config, or you can write it by hand.
+
+### Top-level fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `clusters` | list of strings _or_ table | SSH hostnames from `~/.ssh/config`, or a table of per-cluster settings (see below). |
+| `results_path` | string (optional) | Path relative to the project root. When set, `cluv sync` rsyncs that directory back from each remote cluster. |
+
+### `[tool.cluv.slurm]`
+Environment variables (key/value pairs) applied when using Slurm commands on all clusters. Use this for global Slurm defaults such as resource limits or for tool configuration like (uv of W&B).
+
+### `[tool.cluv.clusters.<name>]`
+Environment variables for a specific cluster. Values here are merged on top of `[tool.cluv.slurm]` when submitting.
+
+### Example
 
 ```toml
 [tool.cluv]
-clusters = ["mila", "tamia", "rorqual", "fir", "nibi", "killarney", "vulcan", "trillium-gpu"]   # SSH hostnames from ~/.ssh/config
-results_path = "results"                  # optional: rsync remote results back here
-```
+clusters = ["mila", "narval", "tamia"]   # SSH hostnames from ~/.ssh/config
+results_path = "logs"                    # rsynced back by `cluv sync`
 
-`clusters` must match SSH hostnames in `~/.ssh/config`. `results_path` is relative to the project root; if set, `cluv sync` rsyncs that directory back from each remote cluster.
+[tool.cluv.slurm]
+# Applied to every cluster by default
+UV_OFFLINE = "1"
+WANDB_MODE = "offline"
+
+[tool.cluv.clusters.mila]
+# Overrides for the mila cluster only
+UV_OFFLINE = "0"
+WANDB_MODE = "online"
+SBATCH_PARTITION = "long"
+```
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| `cluv login` | Open SSH ControlMaster connections to all configured clusters. Run this first, or before any command that requires a live connection. |
-| `cluv sync` | Push local git changes, then on each cluster: clone or fetch the repo, check out the current branch, and run `uv sync`. Optionally rsyncs results back. |
-| `cluv status` | Display an overview of each cluster: partition availability, running/queued jobs, and storage usage. |
-| `cluv submit` | Submit a SLURM job on a remote cluster. Enforces a clean git tree, injects `GIT_COMMIT`, merges global and per-cluster `SBATCH_*` env vars from config, then runs `sbatch` on the remote. Usage: `cluv submit <cluster> <job.sh> [sbatch-flags...] [-- program-args...]` |
-| `cluv run` | Run a command in the synced project on a remote cluster. *(Not yet implemented.)* |
-| `cluv init` | Set up the project on all configured clusters for the first time. *(Not yet implemented.)* |
+### `cluv init`
+
+Initialize the current directory as a cluv project. Must be run from inside your `$HOME` directory.
+
+```
+cluv init
+```
+
+Steps performed:
+1. Runs `uv init --package --build-backend hatch --python 3.13` (skipped if `pyproject.toml` already exists).
+2. Warns if no git remote is configured (required for `sync` and `submit`).
+3. Appends a `[tool.cluv]` section to `pyproject.toml` if one is not already present, with defaults for Mila and all DRAC clusters.
+4. Creates `scripts/job.sh` — a Slurm job script template — if it does not already exist.
+5. Creates a symlink `<results_path>/ → $SCRATCH/<results_path>/<project_name>/` so large outputs go to scratch rather than filling `$HOME`.
+
+Default project structure after `cluv init`:
+```
+my_project/
+├── pyproject.toml        # includes [tool.cluv] config
+├── scripts/
+│   └── job.sh            # Slurm job script template
+├── logs -> $SCRATCH/logs/my_project   # symlink to $SCRATCH
+└── src/
+    └── my_project/
+        └── __init__.py
+```
+
+### `cluv login`
+
+Open SSH ControlMaster connections to all configured clusters. Run this first, or before any command that requires a live connection.
+
+```
+cluv login [<cluster> ...]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `<cluster> ...` | One or more SSH hostnames. Defaults to all clusters in `[tool.cluv]`. |
+
+### `cluv sync`
+
+Push local git changes, then on each cluster: clone or fetch the repo, check out the current branch, and run uv sync. Optionally rsyncs results back if `results_path` is set in the config.
+
+```
+cluv sync [<cluster> ...]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `<cluster> ...` | Clusters to sync. Defaults to all configured clusters. Pass explicit names to connect to specific clusters. |
+
+Sync steps per cluster:
+1. Install or update `uv` to match the local version.
+2. Clone the repo from GitHub (if not present).
+3. Run `uv sync` on the remote.
+4. Rsync `results_path/` back to the local machine (if configured).
+
+### `cluv status`
+
+Display an overview of each cluster: GPU availability, running/queued jobs (yours and cluster-wide), estimated queue wait, GPU utilisation, and disk usage. Falls back to mock data if no active connections exist.
+
+```
+cluv status [<cluster> ...]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `<cluster> ...` | Clusters to query. Defaults to all configured clusters with an active SSH connection. |
+
+### `cluv submit`
+
+Submit a SLURM job on a remote cluster.
+
+```
+cluv submit <cluster> <job.sh> [<sbatch-flags> ...] [-- <program-args> ...]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `<cluster>` | SSH hostname of the target cluster. |
+| `<job.sh>` | Path to the job script. |
+| `<sbatch-flags>` | Any extra flags to pass to `sbatch`. |
+| `-- <program-args>` | Arguments passed to the job script itself (after `--`). |
+
+Steps performed:
+1. Checks that the git working tree is clean.
+2. Captures the current commit hash and sets it as `GIT_COMMIT`.
+3. Syncs the project to the cluster (equivalent to `cluv sync <cluster>`).
+4. Merges `[tool.cluv.slurm]` env vars with per-cluster overrides from `[tool.cluv.clusters.<name>]`.
+5. Runs `sbatch` on the remote with all env vars, sbatch flags, and program args.
+
+### `cluv run`
+
+Sync the project to a cluster, then run a command there with `uv run`.
+
+```
+cluv run <cluster> <command> [<args> ...]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `<cluster>` | SSH hostname of the target cluster. |
+| `<command>` | Command to run (passed to `uv run --directory=<project>`). |
 
 ## DRAC Clusters
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install as a UV tool:
 uv tool install git+https://github.com/mila-iqia/cluv
 ```
 
-Then you can run `cluv` directly as a command like :
+Then you can run `cluv` directly as a command:
 
 ```bash
 cluv init
@@ -31,7 +31,7 @@ cluv submit mila job.sh
 
 ## Quick Start
 
-1. Initialize your project with :
+1. Initialize your project with:
    ```bash
    cluv init
    ```
@@ -91,11 +91,11 @@ cluv init
 ```
 
 Steps performed:
-1. Runs `uv init --package --build-backend hatch --python 3.13` (skipped if `pyproject.toml` already exists).
+1. Runs `uv init` as a package (skipped if `pyproject.toml` already exists).
 2. Warns if no git remote is configured (required for `sync` and `submit`).
-3. Appends a `[tool.cluv]` section to `pyproject.toml` if one is not already present, with defaults for Mila and all DRAC clusters.
-4. Creates `scripts/job.sh` — a Slurm job script template — if it does not already exist.
-5. Creates a symlink `<results_path>/ → $SCRATCH/<results_path>/<project_name>/` so large outputs go to scratch rather than filling `$HOME`.
+3. Appends a `[tool.cluv]` section to `pyproject.toml` if one is not already present, with defaults for Mila and DRAC clusters.
+4. Creates `scripts/job.sh`, a Slurm job script template, if it does not already exist.
+5. Creates a symlink `<results_path>/ → $SCRATCH/<results_path>/<project_name>/` so large outputs go to `$SCRATCH` rather than filling `$HOME`.
 
 Default project structure after `cluv init`:
 ```
@@ -111,7 +111,7 @@ my_project/
 
 ### `cluv login`
 
-Open SSH ControlMaster connections to all configured clusters. Run this first, or before any command that requires a live connection.
+Open SSH ControlMaster connections to all configured clusters. Run this before any command that requires a live connection.
 
 ```
 cluv login [<cluster> ...]
@@ -141,7 +141,7 @@ Sync steps per cluster:
 
 ### `cluv status`
 
-Display an overview of each cluster: GPU availability, running/queued jobs (yours and cluster-wide), estimated queue wait, GPU utilisation, and disk usage. Falls back to mock data if no active connections exist.
+Display an overview of each cluster: GPU availability, running/queued jobs, estimated queue wait, GPU utilisation, and disk usage. Falls back to mock data if no active connections exist.
 
 ```
 cluv status [<cluster> ...]

--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -19,7 +19,6 @@ import rich.logging
 import rich_argparse
 import simple_parsing
 
-from cluv.config import CluvConfig, get_config
 
 from .cli.init import init
 from .cli.login import login
@@ -34,7 +33,7 @@ if typing.TYPE_CHECKING:
     Subparsers = argparse._SubParsersAction[simple_parsing.ArgumentParser]
 
 
-def main(argv: list[str] | None = None):
+def main(argv: list[str] | None = None) -> None:
     if argv is None:
         argv = sys.argv[1:]
 
@@ -56,8 +55,6 @@ def main(argv: list[str] | None = None):
     )
     _add_v_arg(parser)  # add -v/--verbose on the top-level parser.
 
-    config = get_config()
-
     subparsers = parser.add_subparsers(dest="<command>", required=True)
 
     # add -v/--verbose to each subparser as well.
@@ -67,7 +64,7 @@ def main(argv: list[str] | None = None):
     run_parser = add_run_args(subparsers)
     _add_v_arg(run_parser)
 
-    login_parser = add_login_args(subparsers, config=config)
+    login_parser = add_login_args(subparsers)
     _add_v_arg(login_parser)
 
     sync_parser = add_sync_args(subparsers)
@@ -108,8 +105,7 @@ def main(argv: list[str] | None = None):
         sys.exit(err.returncode)
 
 
-def add_status_args(subparsers: Subparsers):
-    cluster_choices = get_config().clusters
+def add_status_args(subparsers: Subparsers) -> argparse.ArgumentParser:
     status_parser = subparsers.add_parser(
         "status",
         help="Get the status of available clusters.",
@@ -117,7 +113,6 @@ def add_status_args(subparsers: Subparsers):
     )
     status_parser.add_argument(
         "clusters",
-        choices=cluster_choices if cluster_choices else None,
         nargs="*",
         default=None,
         metavar="<cluster>",
@@ -129,10 +124,7 @@ def add_status_args(subparsers: Subparsers):
     return status_parser
 
 
-def add_login_args(
-    subparsers: Subparsers,
-    config: CluvConfig,
-):
+def add_login_args(subparsers: Subparsers) -> argparse.ArgumentParser:
     login_parser = subparsers.add_parser(
         "login",
         help="Login to the specified clusters.",
@@ -140,7 +132,6 @@ def add_login_args(
     )
     login_parser.add_argument(
         "clusters",
-        choices=(config.clusters) if config.clusters else None,
         nargs="*",
         help="The cluster(s) to login to. Leave empty to login to all clusters.",
     )
@@ -161,7 +152,6 @@ def add_init_args(subparsers: Subparsers) -> argparse.ArgumentParser:
 def add_run_args(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> argparse.ArgumentParser:
-    cluster_choices = get_config().clusters
     run_parser = subparsers.add_parser(
         "run",
         help="Run a command on a cluster",
@@ -169,7 +159,6 @@ def add_run_args(
     )
     run_parser.add_argument(
         "cluster",
-        choices=cluster_choices if cluster_choices else None,
         # default=,
         metavar="<cluster>",
         help="The cluster to run the command on",
@@ -185,7 +174,7 @@ def add_run_args(
     return run_parser
 
 
-def setup_logging(verbose: int | None, force: bool = False):
+def setup_logging(verbose: int | None, force: bool = False) -> None:
     verbose = verbose or 0
     handler = rich.logging.RichHandler(
         console=console,
@@ -214,7 +203,7 @@ def setup_logging(verbose: int | None, force: bool = False):
     #     cluv_logger.setLevel(logging.DEBUG)
 
 
-def _add_v_arg(parser: argparse.ArgumentParser):
+def _add_v_arg(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "-v",
         "--verbose",

--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -23,7 +23,7 @@ from cluv.config import CluvConfig, get_config
 
 from .cli.init import init
 from .cli.login import login
-from .cli.run import add_run_args
+from .cli.run import run
 from .cli.status import status
 from .cli.submit import add_submit_args
 from .cli.sync import add_sync_args
@@ -156,6 +156,33 @@ def add_init_args(subparsers: Subparsers) -> argparse.ArgumentParser:
     )
     init_parser.set_defaults(func=init)
     return init_parser
+
+
+def add_run_args(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> argparse.ArgumentParser:
+    cluster_choices = get_config().clusters
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Run a command on a cluster",
+        formatter_class=rich_argparse.RichHelpFormatter,
+    )
+    run_parser.add_argument(
+        "cluster",
+        choices=cluster_choices if cluster_choices else None,
+        # default=,
+        metavar="<cluster>",
+        help="The cluster to run the command on",
+    )
+    run_parser.add_argument(
+        "command",
+        type=str,
+        metavar="<command>",
+        help="The command to run",
+        nargs=argparse.REMAINDER,
+    )
+    run_parser.set_defaults(func=run)
+    return run_parser
 
 
 def setup_logging(verbose: int | None, force: bool = False):

--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -23,8 +23,8 @@ from .cli.init import init
 from .cli.login import login
 from .cli.run import run
 from .cli.status import status
-from .cli.submit import add_submit_args
-from .cli.sync import add_sync_args
+from .cli.submit import submit
+from .cli.sync import sync
 from .utils import console
 
 logger = logging.getLogger(__name__)
@@ -103,6 +103,34 @@ def main(argv: list[str] | None = None) -> None:
             logger.error("No standard error.")
         sys.exit(err.returncode)
 
+def add_submit_args(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> argparse.ArgumentParser:
+    submit_parser = subparsers.add_parser(
+        "submit",
+        help="Submit a SLURM job on a remote cluster.",
+        formatter_class=rich_argparse.RichHelpFormatter,
+        usage="cluv submit <cluster> <job.sh> [sbatch-args...] [-- program-args...]",
+    )
+    submit_parser.add_argument(
+        "cluster",
+        metavar="<cluster>",
+        help="The cluster to submit the job on.",
+    )
+    submit_parser.add_argument(
+        "job_script",
+        metavar="<job.sh>",
+        help="Path to the sbatch job script (relative to project root).",
+    )
+    submit_parser.add_argument(
+        "sbatch_args",
+        nargs=argparse.REMAINDER,
+        metavar="...",
+        help="sbatch flags (before --) and/or program arguments (after --).",
+    )
+    submit_parser.set_defaults(func=submit)
+    return submit_parser
+
 
 def add_status_args(subparsers: Subparsers) -> argparse.ArgumentParser:
     status_parser = subparsers.add_parser(
@@ -121,6 +149,45 @@ def add_status_args(subparsers: Subparsers) -> argparse.ArgumentParser:
     # Or just display everything?
     status_parser.set_defaults(func=status)
     return status_parser
+
+
+def add_sync_args(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> argparse.ArgumentParser:
+    sync_parser = subparsers.add_parser(
+        "sync",
+        help="Synchronizes the current project across clusters.",
+        formatter_class=rich_argparse.RichHelpFormatter,
+    )
+    sync_parser.add_argument(
+        "clusters",
+        nargs="*",
+        default=None,
+        metavar="<cluster>",
+        help=(
+            "The cluster(s) to synchronize with. "
+            "Leave empty to synchronize with all currently logged in clusters. "
+            "Use a comma to separate multiple clusters."
+        ),
+    )
+    # TODO: Try to add a 'remainder' arg to pass extra args to `uv sync` on the remote cluster, but it seems to be a bit tricky.
+    # sync_parser.add_argument(
+    #     "--",
+    #     dest="_",
+    #     # type=str,
+    #     # help="The arguments to pass to `uv sync` on the remote cluster.",
+    #     # dest=argparse.SUPPRESS,
+    # )
+    # sync_parser.add_argument(
+    #     "--",
+    #     dest="uv_sync_args",
+    #     # type=str,
+    #     # metavar="<uv sync arguments>",
+    #     help="The arguments to pass to `uv sync` on the remote cluster.",
+    #     nargs=argparse.REMAINDER,
+    # )
+    sync_parser.set_defaults(func=sync)
+    return sync_parser
 
 
 def add_login_args(subparsers: Subparsers) -> argparse.ArgumentParser:

--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -19,7 +19,6 @@ import rich.logging
 import rich_argparse
 import simple_parsing
 
-
 from .cli.init import init
 from .cli.login import login
 from .cli.run import run

--- a/cluv/cli/__init__.py
+++ b/cluv/cli/__init__.py
@@ -1,11 +1,11 @@
-# from .init import init
+from .init import init
 from .login import login
 from .run import run
 from .status import status
 from .sync import sync
 
 __all__ = [
-    # "init",
+    "init",
     "login",
     "run",
     "sync",

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -171,20 +171,20 @@ def check_symlink_to_scratch(project_root: Path, results_path: str | None) -> No
         return
 
     # Generate the expected scratch and symlink path
-    scratch_dir = Path(os.path.expandvars(f"$SCRATCH/{results_path}/{project_root.name}"))
-    results_dir = project_root / results_path
+    scratch_path = Path(os.path.expandvars(f"$SCRATCH/{results_path}/{project_root.name}"))
+    symlink_path = project_root / results_path
 
-    if results_dir.is_symlink():
-        if results_dir.resolve() == scratch_dir.resolve():
+    if symlink_path.is_symlink():
+        if symlink_path.resolve() == scratch_path.resolve():
             console.print("[green]✅ Symlink from $HOME results_path to $SCRATCH already exists.[/green]")
             return
         else:
-            console.print(f"[red]❌ Symlink from {results_dir} points to {results_dir.resolve()} instead of {scratch_dir}.[/red]")
-            raise RuntimeError(f"Symlink from {results_dir} points to {results_dir.resolve()} instead of {scratch_dir}. Please fix this symlink before running cluv.")
+            console.print(f"[yellow]⚠️  Warning: Symlink from {symlink_path} points to an other expected scratch path ({symlink_path.resolve()}).[/yellow]")
+            return
     else:
-        console.print(f"Creating symlink from {results_dir} to {scratch_dir}")
-        scratch_dir.mkdir(parents=True, exist_ok=True)
-        results_dir.symlink_to(scratch_dir, target_is_directory=True)
+        console.print(f"Creating symlink from {symlink_path} to {scratch_path}")
+        scratch_path.mkdir(parents=True, exist_ok=True)
+        symlink_path.symlink_to(scratch_path, target_is_directory=True)
 
 
 def check_job_script(project_root: Path, results_path: str | None) -> None:

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -1,14 +1,184 @@
+import os
+import subprocess
+from pathlib import Path
+
+from cluv.config import find_pyproject, has_cluv_config
+from cluv.utils import console
+
+# TODO : not a great import... But it can be helpful instead of updating a const
+from milatools.cli.init_command import DRAC_CLUSTERS    
+
+JOB_SCRIPT_PATH = "scripts/job.sh"
+RESULTS_DIR_PATH = "logs"
+
+MILA_CLUSTER_DEFAULT_CONFIG = [
+    "UV_OFFLINE = 0",
+    'WANDB_MODE = "online"',
+]
+
+SLURM_DEFAULT_CONFIG = [
+    "UV_OFFLINE = 1",
+    'WANDB_MODE = "offline"',
+]
+
 def init():
     """Initialize the current project across clusters.
-
     Akin to `uv init`, sets up the current project on all configured clusters.
-    - Prompts to configure which clusters to use (config stored in pyproject.toml of the project)
-    - Installs UV on all clusters
-            - Sets up the DRAC-specific uv.toml files to use the DRAC wheelhouse when necessary.
-    - Sets up the project repo, creates the $SCRATCH checkpoint folder
-
-    ## How it could work (proof-of-concept)
-    - Over SSH. Setup UV.
-    - Assume GitHub. Clone the project on each cluster. Configure the git credential-cache if necessary.
     """
-    raise NotImplementedError("TODO: " + (init.__doc__ or ""))
+    console.print()
+    console.rule("[bold cyan]cluv init[/bold cyan]")
+    console.print()
+    # TODO : give path to create project
+
+    # Try to run "uv run" to create a new project
+    console.print("Running [bold]uv init[/bold]...")
+    console.log("uv init --package --build-backend hatch --python 3.13")
+    uv_init = subprocess.run(["uv", "init", "--package", "--build-backend", "hatch", "--python", "3.13"], capture_output=True, text=True)
+
+    # An expected error is that uv fails if a pyproject.toml file already exists
+    if uv_init.returncode == 2:
+        # If the error isn't about the pyproject.toml, raise an exception
+        if not uv_init.stderr.endswith("(`pyproject.toml` file exists)\n"):
+            raise RuntimeError("Error occurred while initializing uv project: ", uv_init.stderr)
+        console.print("[green]✅ uv: a project already exists (see pyproject.toml file). Skipping initialization.[/green]")
+        check_git()
+    else:
+        console.print("[green]✅ uv: project initialized.[/green]")
+
+    # Read the pyproject.toml file and try to find a cluv config.
+    # If it doesn't exist, add a cluv config section with the default clusters and settings.
+    console.print()
+    console.print("Reading pyproject.toml...")
+    pyproject_path = find_pyproject()
+
+    if has_cluv_config(pyproject_path):
+        console.print("[green]✅ Project already have a cluv config in pyproject.toml.[/green]")
+    else:
+        console.print("No config found for [bold]cluv[/bold] in the pyproject.toml file. Adding config...")
+        add_tool_config(pyproject_path)
+        add_slurm_config(pyproject_path)
+        add_cluv_cluster_config("mila", pyproject_path, MILA_CLUSTER_DEFAULT_CONFIG)
+        for cluster in DRAC_CLUSTERS: add_cluv_cluster_config(cluster, pyproject_path)
+        console.print("[green]✅ Pyproject config completed.[/green]")
+
+    # Check if project structure is correct
+    console.print()
+    console.print("Validating project structure...")
+    if not os.path.exists(JOB_SCRIPT_PATH):
+        os.makedirs("scripts")
+        console.print(f"Adding job template script at '{JOB_SCRIPT_PATH}'.")
+        generate_job_script(pyproject_path, RESULTS_DIR_PATH)   # TODO : split the pyproject path and don't keep the "pyproject.toml" part
+    else:
+        console.print(f"[green]✅ Job template script already exists at '{JOB_SCRIPT_PATH}'.[/green]")
+
+    if not os.path.exists(RESULTS_DIR_PATH):
+        console.print(f"Adding results directory at '{RESULTS_DIR_PATH}'.")
+        os.makedirs(RESULTS_DIR_PATH)
+    else:
+        console.print(f"[green]✅ Results directory already exists at '{RESULTS_DIR_PATH}'.[/green]")
+
+    console.print()
+    console.print(":tada: Your cluv config is ready to go !")
+
+
+    # TODO : synclink for checkpoints ?
+
+    # After the project setup, show what the user can do next
+    console.print()
+    console.print("Next steps :")
+    console.print("=> [bold] cluv login [/bold] : open a SSH connections to all configured clusters.")
+    console.print("=> [bold] cluv sync [/bold]  : synchronize the project on all configured clusters.")
+    console.print()
+
+
+def add_tool_config(pyproject_path: Path) -> None:
+    """
+    TODO
+    """
+    # TODO : add info about the results dir
+    section_lines = ["\n[tool.cluv]"]
+
+    with pyproject_path.open("a") as f:
+        f.write("\n".join(section_lines) + "\n")
+
+
+def add_slurm_config(pyproject_path: Path) -> None:
+    """
+    TODO
+    """
+    console.print(f"Adding config for global env vars :")
+    section_lines = ["\n[tool.cluv.slurm]", "# Environment variables applied when using Slurm commands on all clusters."] + SLURM_DEFAULT_CONFIG
+    console.log(f'{"\n".join(section_lines) + "\n"}'.replace("[", "\\["))    # TODO : Log not displayed correctly ?
+    with pyproject_path.open("a") as f:
+        f.write("\n".join(section_lines) + "\n")
+
+
+def add_cluv_cluster_config(cluster: str, pyproject_path: Path, vars: list[str] = []) -> None:
+    """
+    TODO
+    """
+    console.print(f"Adding config for cluster [bold]{cluster}[/bold] :")
+    section_lines = [f"\n[tool.cluv.clusters.{cluster}]"] + vars
+    console.log(f'{"\n".join(section_lines) + "\n"}'.replace("[", "\\["))    # TODO : Log not displayed correctly ?
+    with pyproject_path.open("a") as f:
+        f.write("\n".join(section_lines) + "\n")
+
+
+def check_git() -> bool:
+    """
+    TODO
+    """
+    if os.path.isdir(".git"):   # TODO : Very simple approch. Only works at the project root.
+        console.print("[green]✅ git: project is in git repository.[/green]")
+    else:
+        console.print("[red]❌ git: no git repository found.[/red]")
+        raise RuntimeError("The current project is not a git repository. Try running 'git init' or clone a GitHub project.")
+
+
+def generate_job_script(project_root: Path, results_dir: str) -> None:
+    """
+    TODO
+    """
+    project_name = project_root.name
+    project_root = str(project_root.relative_to(Path.home()))
+
+    script_content = f"""#!/bin/bash
+    #SBATCH --output={results_dir}/%j/slurm-%j.out
+    #SBATCH --ntasks=1
+    #SBATCH --mem=8G
+    #SBATCH --time=0:05:00
+
+    project_name="{project_name}"
+    results_dir="{results_dir}"
+    project_root="{project_root}"
+    """
+
+    script_content +=  """
+    # Minimal test job for cluv submit integration tests.
+    echo "hostname: $(hostname)"
+    echo "GIT_COMMIT=${GIT_COMMIT:?GIT_COMMIT is not set. Use 'cluv submit' to submit this job script.}"
+
+    # Setup the repo in $SLURM_TMPDIR, so the code can change in the project without affecting the job.
+    echo "Preparing the repo and virtual environment in $SLURM_TMPDIR"
+    srun --ntasks-per-node=1 --ntasks=$SLURM_NNODES --input=all bash -e <<END
+    cd $SLURM_TMPDIR
+    git clone $project_root
+    cd $SLURM_TMPDIR/$project_name
+    git checkout --detach $GIT_COMMIT
+    exec uv sync
+    END
+
+    # Run the actual job command passed as an argument ('python main.py' for example)
+    echo "Running command: $@"
+    # Note: This `--gres-flags=allow-task-sharing` is required to allow tasks on the same node to access
+    # GPUs allocated to other tasks on that node. Without this flag, --gpus-per-task=1 would isolate
+    # each task to only see its own GPU, which can cause some mysterious NCCL errors.
+    srun --gres-flags=allow-task-sharing uv --directory=$SLURM_TMPDIR/$project_name run "$@"
+
+    # Copy results (if any) from the local storage back to the results dir (eg in $SCRATCH)
+    echo "Copying logs from $SLURM_TMPDIR/$project_name/$results_dir to $project_root/$results_dir"
+    srun --ntasks-per-node=1 rsync --update --recursive $SLURM_TMPDIR/$project_name/$results_dir $project_root/
+    """
+
+    with open('scripts/job.sh', 'w') as sh_file:
+        sh_file.write(script_content)

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -10,7 +10,7 @@ from cluv.utils import console
 JOB_SCRIPT_PATH = "scripts/job.sh"
 DEFAULT_RESULTS_PATH = "logs"
 
-CLUV_DEFAUT_CONFIG = [
+CLUV_DEFAULT_CONFIG = [
     "[tool.cluv]",
     f'results_path = "{DEFAULT_RESULTS_PATH}"'
 ]
@@ -34,14 +34,9 @@ def init() -> None:
     console.print()
     console.rule("[bold cyan]cluv init[/bold cyan]")
     console.print()
-    # TODO : give path to create project
 
     # 1. Check if the current directory is under the home directory. If not, raise an error and exit.
-    if str(Path.cwd()).startswith(str(Path.home())):
-        console.print("[green]✅ Current directory is under home directory.[/green]")
-    else:
-        console.print("[red]❌ cluv init should be run in a directory under your home directory.[/red]")
-        raise RuntimeError("cluv init should be run in a directory under your home directory.")
+    check_home_dir()
 
     # 2. Try to run "uv init" to create a new project
     console.print()
@@ -57,18 +52,17 @@ def init() -> None:
     console.print("Reading pyproject.toml...")
     pyproject_path = find_pyproject()
 
-    ### If it doesn't exist, add a cluv config section with the default settings and clusters.
-    ### Get the results_path from the config to use for the next checks.
+    # If it doesn't exist, add a cluv config section with the default settings and clusters.
     results_path = check_cluv_config(pyproject_path)
 
     # 5. Check if project structure is correct
     console.print()
     console.print("Validating project structure...")
 
-    ### Check if the job script exists
+    # Check if the job script exists
     check_job_script(pyproject_path.parent, results_path)
 
-    ### Check if the results path is correctly symlinked to scratch
+    # Check if the results path is correctly symlinked to scratch
     check_symlink_to_scratch(pyproject_path.parent, results_path)
 
     # 6. Show what the user can do next after the project setup
@@ -79,6 +73,16 @@ def init() -> None:
     console.print("=> [bold] cluv login [/bold] : open a SSH connections to all configured clusters.")
     console.print("=> [bold] cluv sync [/bold]  : synchronize the project on all configured clusters.")
     console.print()
+
+def check_home_dir() -> None:
+    """
+    Check if the current directory is under the home directory. If not, raise an error and exit.
+    """
+    if Path.cwd().is_relative_to(Path.home()):
+        console.print("[green]✅ Current directory is under home directory.[/green]")
+    else:
+        console.print("[red]❌ cluv init should be run in a directory under your home directory.[/red]")
+        raise RuntimeError("cluv init should be run in a directory under your home directory.")
 
 def run_uv_init() -> None:
     uv_init = subprocess.run(["uv", "init", "--package", "--build-backend", "hatch", "--python", "3.13"], capture_output=True, text=True)
@@ -94,7 +98,8 @@ def run_uv_init() -> None:
 
 def check_cluv_config(pyproject_path: Path) -> str:
     """
-    Check if the pyproject.toml file contains a cluv config. If not, add a default config section with the default clusters and settings.
+    Check if the pyproject.toml file contains a cluv config.
+    If not, add a default config section with the default clusters and settings.
     """
     if has_cluv_config(pyproject_path):
         console.print("[green]✅ Project already have a cluv config in pyproject.toml.[/green]")
@@ -105,7 +110,7 @@ def check_cluv_config(pyproject_path: Path) -> str:
     console.print("No config found for [bold]cluv[/bold] in the pyproject.toml file. Adding config...")
     console.print("Adding config for cluv tool :")
 
-    add_cluv_config_section(pyproject_path, CLUV_DEFAUT_CONFIG)
+    add_cluv_config_section(pyproject_path, CLUV_DEFAULT_CONFIG)
     add_cluv_config_section(pyproject_path, CLUV_SLURM_DEFAULT_CONFIG)
     add_cluv_cluster_config("mila", pyproject_path, CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS)
     for cluster in DRAC_CLUSTERS:
@@ -118,18 +123,18 @@ def add_cluv_config_section(pyproject_path: Path, section_lines: list[str]) -> N
     """
     Write the given lines to the pyproject.toml file.
     """
-    console.log(f'{"\n" + "\n".join(section_lines) + "\n"}'.replace("[", "\\["))
+    console.log(("\n" + "\n".join(section_lines) + "\n").replace("[", "\\["))
     with pyproject_path.open("a") as f:
         f.write("\n" + "\n".join(section_lines) + "\n")
 
 
-def add_cluv_cluster_config(cluster: str, pyproject_path: Path, vars: list[str] = []) -> None:
+def add_cluv_cluster_config(cluster: str, pyproject_path: Path, config_lines: list[str] = []) -> None:
     """
     Add a cluster config section for the given cluster to the pyproject.toml file, with the given variables.
     """
     console.print(f"Adding config for cluster [bold]{cluster}[/bold] :")
-    section_lines = [f"[tool.cluv.clusters.{cluster}]"] + vars
-    console.log(f'{"\n" + "\n".join(section_lines) + "\n"}'.replace("[", "\\["))
+    section_lines = [f"[tool.cluv.clusters.{cluster}]"] + config_lines
+    console.log(("\n" + "\n".join(section_lines) + "\n").replace("[", "\\["))
     with pyproject_path.open("a") as f:
         f.write("\n" + "\n".join(section_lines) + "\n")
 
@@ -158,6 +163,10 @@ def check_symlink_to_scratch(project_root: Path, results_path: str | None) -> No
         console.print("[yellow]⚠️  Warning: Results path is not configured. Skipping symlink creation.[/yellow]")
         return
 
+    if "SCRATCH" not in os.environ:
+        console.print("[yellow]⚠️  Warning: $SCRATCH variable not set. Skipping symlink creation.[/yellow]")
+        return
+
     # Generate the expected scratch and symlink path
     scratch_dir = Path(os.path.expandvars(f"$SCRATCH/{results_path}/{project_root.name}"))
     results_dir = project_root / results_path
@@ -177,17 +186,20 @@ def check_symlink_to_scratch(project_root: Path, results_path: str | None) -> No
 
 def check_job_script(project_root: Path, results_path: str | None) -> None:
     """
-    Check if the job script template to set and run the project on a cluster with SLURM exists. If not, create it.
+    Check if the job script template exists. If not, create it.
+    The job script is a template for users to submit jobs to Slurm with cluv.
     """
-    if os.path.exists(JOB_SCRIPT_PATH):
-        console.print(f"[green]✅ Job template script already exists at '{JOB_SCRIPT_PATH}'.[/green]")
+    job_script_path = project_root / JOB_SCRIPT_PATH
+
+    if job_script_path.exists():
+        console.print(f"[green]✅ Job template script already exists at '{job_script_path}'.[/green]")
         return
 
     if results_path is None:
         console.print("[yellow]⚠️  Warning: Results path is not configured. Skipping job template script generation.[/yellow]")
         return
 
-    console.print(f"Adding job template script at '{JOB_SCRIPT_PATH}'.")
+    console.print(f"Adding job template script at '{job_script_path}'.")
 
     project_name = project_root.name
     project_root = str(project_root.relative_to(Path.home()))
@@ -229,6 +241,7 @@ srun --gres-flags=allow-task-sharing uv --directory=$SLURM_TMPDIR/$project_name 
 echo "Copying logs from $SLURM_TMPDIR/$project_name/$results_path to $project_root/$results_path"
 srun --ntasks-per-node=1 rsync --update --recursive $SLURM_TMPDIR/$project_name/$results_path $project_root/
 """
-    os.makedirs(Path(JOB_SCRIPT_PATH).parent, exist_ok=True)
-    with open(JOB_SCRIPT_PATH, 'w') as sh_file:
+
+    job_script_path.parent.mkdir(exist_ok=True)
+    with open(job_script_path, 'w') as sh_file:
         sh_file.write(script_content)

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -11,42 +11,55 @@ from milatools.cli.init_command import DRAC_CLUSTERS
 JOB_SCRIPT_PATH = "scripts/job.sh"
 RESULTS_DIR_PATH = "logs"
 
-MILA_CLUSTER_DEFAULT_CONFIG = [
-    "UV_OFFLINE = 0",
-    'WANDB_MODE = "online"',
+CLUV_DEFAUT_CONFIG = [
+    "[tool.cluv]"
 ]
 
-SLURM_DEFAULT_CONFIG = [
+CLUV_SLURM_DEFAULT_CONFIG = [
+    "[tool.cluv.slurm]",
+    "# Environment variables applied when using Slurm commands on all clusters.",
     "UV_OFFLINE = 1",
     'WANDB_MODE = "offline"',
 ]
 
-def init():
-    """Initialize the current project across clusters.
-    Akin to `uv init`, sets up the current project on all configured clusters.
+CLUV_MILA_CLUSTER_DEFAULT_CONFIG = [
+    "UV_OFFLINE = 0",
+    'WANDB_MODE = "online"',
+]
+
+def init() -> None:
+    """
+    TODO
     """
     console.print()
     console.rule("[bold cyan]cluv init[/bold cyan]")
     console.print()
     # TODO : give path to create project
+    
+    # 1. Check if the current directory is under the home directory. If not, raise an error and exit.
+    if str(Path.cwd()).startswith(str(Path.home())):
+        console.print(f"[green]✅ Current directory is under home directory : {Path.cwd()}[/green]")
+    else:
+        console.print("[red]❌ Error: cluv init should be run in a directory under your home directory.[/red]")
+        raise RuntimeError("cluv init should be run in a directory under your home directory.")
 
-    # Try to run "uv run" to create a new project
-    console.print("Running [bold]uv init[/bold]...")
+    # 2. Try to run "uv run" to create a new project
+    console.print()
+    console.print("Initializing uv project: running [bold]uv init[/bold]...")
     console.log("uv init --package --build-backend hatch --python 3.13")
     uv_init = subprocess.run(["uv", "init", "--package", "--build-backend", "hatch", "--python", "3.13"], capture_output=True, text=True)
 
     # An expected error is that uv fails if a pyproject.toml file already exists
     if uv_init.returncode == 2:
-        # If the error isn't about the pyproject.toml, raise an exception
-        if not uv_init.stderr.endswith("(`pyproject.toml` file exists)\n"):
-            raise RuntimeError("Error occurred while initializing uv project: ", uv_init.stderr)
-        console.print("[green]✅ uv: a project already exists (see pyproject.toml file). Skipping initialization.[/green]")
-        check_git()
+        if uv_init.stderr.endswith("(`pyproject.toml` file exists)\n"):
+            console.print("[green]✅ uv: a project already exists (see pyproject.toml file). Skipping initialization.[/green]")
+            check_git()
+        else: raise RuntimeError("Error occurred while initializing uv project: ", uv_init.stderr)
     else:
         console.print("[green]✅ uv: project initialized.[/green]")
 
-    # Read the pyproject.toml file and try to find a cluv config.
-    # If it doesn't exist, add a cluv config section with the default clusters and settings.
+    # 3. Read the pyproject.toml file and try to find a cluv config.
+    # If it doesn't exist, add a cluv config section with the default settings and clusters.
     console.print()
     console.print("Reading pyproject.toml...")
     pyproject_path = find_pyproject()
@@ -55,23 +68,28 @@ def init():
         console.print("[green]✅ Project already have a cluv config in pyproject.toml.[/green]")
     else:
         console.print("No config found for [bold]cluv[/bold] in the pyproject.toml file. Adding config...")
-        add_tool_config(pyproject_path)
-        add_slurm_config(pyproject_path)
-        add_cluv_cluster_config("mila", pyproject_path, MILA_CLUSTER_DEFAULT_CONFIG)
+        add_cluv_config(pyproject_path, RESULTS_DIR_PATH)
+        add_cluv_slurm_config(pyproject_path)
+        add_cluv_cluster_config("mila", pyproject_path, CLUV_MILA_CLUSTER_DEFAULT_CONFIG)
         for cluster in DRAC_CLUSTERS: add_cluv_cluster_config(cluster, pyproject_path)
         console.print("[green]✅ Pyproject config completed.[/green]")
 
-    # Check if project structure is correct
+    # 4. Check if project structure is correct
     console.print()
     console.print("Validating project structure...")
-    if not os.path.exists(JOB_SCRIPT_PATH):
+
+    # Check if the job script exists
+    if os.path.exists(JOB_SCRIPT_PATH):
+        console.print(f"[green]✅ Job template script already exists at '{JOB_SCRIPT_PATH}'.[/green]")
+    else:
         os.makedirs("scripts")
         console.print(f"Adding job template script at '{JOB_SCRIPT_PATH}'.")
-        generate_job_script(pyproject_path, RESULTS_DIR_PATH)   # TODO : split the pyproject path and don't keep the "pyproject.toml" part
-    else:
-        console.print(f"[green]✅ Job template script already exists at '{JOB_SCRIPT_PATH}'.[/green]")
+        generate_job_script(pyproject_path.parent, RESULTS_DIR_PATH)
 
-    if not os.path.exists(RESULTS_DIR_PATH):
+    # Check if the results_dir exists
+    if os.path.exists(RESULTS_DIR_PATH):
+        console.print(f"[green]✅ Results directory already exists at '{RESULTS_DIR_PATH}'.[/green]")
+    else:
         console.print(f"Adding results directory at '{RESULTS_DIR_PATH}'.")
         os.makedirs(RESULTS_DIR_PATH)
     else:
@@ -80,37 +98,32 @@ def init():
     console.print()
     console.print(":tada: Your cluv config is ready to go !")
 
-
-    # TODO : synclink for checkpoints ?
-
-    # After the project setup, show what the user can do next
+    # 5. Show what the user can do next after the project setup
     console.print()
     console.print("Next steps :")
     console.print("=> [bold] cluv login [/bold] : open a SSH connections to all configured clusters.")
     console.print("=> [bold] cluv sync [/bold]  : synchronize the project on all configured clusters.")
     console.print()
 
-
-def add_tool_config(pyproject_path: Path) -> None:
+def add_cluv_config(pyproject_path: Path, results_path: str) -> None:
     """
     TODO
     """
-    # TODO : add info about the results dir
-    section_lines = ["\n[tool.cluv]"]
-
+    console.print(f"Adding config for cluv tool :")
+    section_lines = CLUV_DEFAUT_CONFIG + [f'results_path = "{results_path}"']
+    console.log(f'{"\n" + "\n".join(section_lines) + "\n"}'.replace("[", "\\["))    # TODO : Log not displayed correctly ?
     with pyproject_path.open("a") as f:
-        f.write("\n".join(section_lines) + "\n")
+        f.write("\n" + "\n".join(section_lines) + "\n")
 
 
-def add_slurm_config(pyproject_path: Path) -> None:
+def add_cluv_slurm_config(pyproject_path: Path) -> None:
     """
     TODO
     """
-    console.print(f"Adding config for global env vars :")
-    section_lines = ["\n[tool.cluv.slurm]", "# Environment variables applied when using Slurm commands on all clusters."] + SLURM_DEFAULT_CONFIG
-    console.log(f'{"\n".join(section_lines) + "\n"}'.replace("[", "\\["))    # TODO : Log not displayed correctly ?
+    console.print(f"Adding config for global env vars when using SLURM :")
+    console.log(f'{"\n" + "\n".join(CLUV_SLURM_DEFAULT_CONFIG) + "\n"}'.replace("[", "\\["))    # TODO : Log not displayed correctly ?
     with pyproject_path.open("a") as f:
-        f.write("\n".join(section_lines) + "\n")
+        f.write("\n" + "\n".join(CLUV_SLURM_DEFAULT_CONFIG) + "\n")
 
 
 def add_cluv_cluster_config(cluster: str, pyproject_path: Path, vars: list[str] = []) -> None:
@@ -124,14 +137,14 @@ def add_cluv_cluster_config(cluster: str, pyproject_path: Path, vars: list[str] 
         f.write("\n".join(section_lines) + "\n")
 
 
-def check_git() -> bool:
+def check_git() -> None:
     """
     TODO
     """
     if os.path.isdir(".git"):   # TODO : Very simple approch. Only works at the project root.
-        console.print("[green]✅ git: project is in git repository.[/green]")
+        console.print("[green]✅ Project is in git repository.[/green]")
     else:
-        console.print("[red]❌ git: no git repository found.[/red]")
+        console.print("[red]❌ No git repository found.[/red]")
         raise RuntimeError("The current project is not a git repository. Try running 'git init' or clone a GitHub project.")
 
 
@@ -143,42 +156,42 @@ def generate_job_script(project_root: Path, results_dir: str) -> None:
     project_root = str(project_root.relative_to(Path.home()))
 
     script_content = f"""#!/bin/bash
-    #SBATCH --output={results_dir}/%j/slurm-%j.out
-    #SBATCH --ntasks=1
-    #SBATCH --mem=8G
-    #SBATCH --time=0:05:00
+#SBATCH --output={results_dir}/%j/slurm-%j.out
+#SBATCH --ntasks=1
+#SBATCH --mem=8G
+#SBATCH --time=0:05:00
 
-    project_name="{project_name}"
-    results_dir="{results_dir}"
-    project_root="{project_root}"
-    """
+project_name="{project_name}"
+results_dir="{results_dir}"
+project_root="{project_root}"
+"""
 
     script_content +=  """
-    # Minimal test job for cluv submit integration tests.
-    echo "hostname: $(hostname)"
-    echo "GIT_COMMIT=${GIT_COMMIT:?GIT_COMMIT is not set. Use 'cluv submit' to submit this job script.}"
+# Minimal test job for cluv submit integration tests.
+echo "hostname: $(hostname)"
+echo "GIT_COMMIT=${GIT_COMMIT:?GIT_COMMIT is not set. Use 'cluv submit' to submit this job script.}"
 
-    # Setup the repo in $SLURM_TMPDIR, so the code can change in the project without affecting the job.
-    echo "Preparing the repo and virtual environment in $SLURM_TMPDIR"
-    srun --ntasks-per-node=1 --ntasks=$SLURM_NNODES --input=all bash -e <<END
-    cd $SLURM_TMPDIR
-    git clone $project_root
-    cd $SLURM_TMPDIR/$project_name
-    git checkout --detach $GIT_COMMIT
-    exec uv sync
-    END
+# Setup the repo in $SLURM_TMPDIR, so the code can change in the project without affecting the job.
+echo "Preparing the repo and virtual environment in $SLURM_TMPDIR"
+srun --ntasks-per-node=1 --ntasks=$SLURM_NNODES --input=all bash -e <<END
+cd $SLURM_TMPDIR
+git clone $project_root
+cd $SLURM_TMPDIR/$project_name
+git checkout --detach $GIT_COMMIT
+exec uv sync
+END
 
-    # Run the actual job command passed as an argument ('python main.py' for example)
-    echo "Running command: $@"
-    # Note: This `--gres-flags=allow-task-sharing` is required to allow tasks on the same node to access
-    # GPUs allocated to other tasks on that node. Without this flag, --gpus-per-task=1 would isolate
-    # each task to only see its own GPU, which can cause some mysterious NCCL errors.
-    srun --gres-flags=allow-task-sharing uv --directory=$SLURM_TMPDIR/$project_name run "$@"
+# Run the actual job command passed as an argument ('python main.py' for example)
+echo "Running command: $@"
+# Note: This `--gres-flags=allow-task-sharing` is required to allow tasks on the same node to access
+# GPUs allocated to other tasks on that node. Without this flag, --gpus-per-task=1 would isolate
+# each task to only see its own GPU, which can cause some mysterious NCCL errors.
+srun --gres-flags=allow-task-sharing uv --directory=$SLURM_TMPDIR/$project_name run "$@"
 
-    # Copy results (if any) from the local storage back to the results dir (eg in $SCRATCH)
-    echo "Copying logs from $SLURM_TMPDIR/$project_name/$results_dir to $project_root/$results_dir"
-    srun --ntasks-per-node=1 rsync --update --recursive $SLURM_TMPDIR/$project_name/$results_dir $project_root/
-    """
+# Copy results (if any) from the local storage back to the results dir (eg in $SCRATCH)
+echo "Copying logs from $SLURM_TMPDIR/$project_name/$results_dir to $project_root/$results_dir"
+srun --ntasks-per-node=1 rsync --update --recursive $SLURM_TMPDIR/$project_name/$results_dir $project_root/
+"""
 
-    with open('scripts/job.sh', 'w') as sh_file:
+    with open(JOB_SCRIPT_PATH, 'w') as sh_file:
         sh_file.write(script_content)

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -72,23 +72,10 @@ def init() -> None:
     console.print()
     console.print("Reading pyproject.toml...")
     pyproject_path = find_pyproject()
-    results_path = DEFAULT_RESULTS_PATH
 
     ### If it doesn't exist, add a cluv config section with the default settings and clusters.
-    if has_cluv_config(pyproject_path):
-        console.print("[green]✅ Project already have a cluv config in pyproject.toml.[/green]")
-        config = load_cluv_config(pyproject_path)
-        results_path = config.results_path
-        console.print(config)
-    else:
-        console.print("No config found for [bold]cluv[/bold] in the pyproject.toml file. Adding config...")
-        console.print("Adding config for cluv tool :")
-        add_cluv_config_section(pyproject_path, CLUV_DEFAUT_CONFIG)
-        add_cluv_config_section(pyproject_path, CLUV_SLURM_DEFAULT_CONFIG)
-        add_cluv_cluster_config("mila", pyproject_path, CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS)
-        for cluster in DRAC_CLUSTERS:
-            add_cluv_cluster_config(cluster, pyproject_path)
-        console.print("[green]✅ Pyproject config completed.[/green]")
+    ### Get the results_path from the config to use for the next checks.
+    results_path = check_cluv_config(pyproject_path)
 
     # 4. Check if project structure is correct
     console.print()
@@ -100,15 +87,36 @@ def init() -> None:
     ### Check if the results path is correctly symlinked to scratch
     check_symlink_to_scratch(pyproject_path.parent, results_path)
 
+    # 5. Show what the user can do next after the project setup
     console.print()
     console.print(":tada: Your cluv config is ready to go !")
-
-    # 5. Show what the user can do next after the project setup
     console.print()
     console.print("Next steps :")
     console.print("=> [bold] cluv login [/bold] : open a SSH connections to all configured clusters.")
     console.print("=> [bold] cluv sync [/bold]  : synchronize the project on all configured clusters.")
     console.print()
+
+
+def check_cluv_config(pyproject_path: Path) -> str:
+    """
+    Check if the pyproject.toml file contains a cluv config. If not, add a default config section with the default clusters and settings.
+    """
+    if has_cluv_config(pyproject_path):
+        console.print("[green]✅ Project already have a cluv config in pyproject.toml.[/green]")
+        config = load_cluv_config(pyproject_path)
+        console.print(config)
+        return config.results_path
+
+    console.print("No config found for [bold]cluv[/bold] in the pyproject.toml file. Adding config...")
+    console.print("Adding config for cluv tool :")
+
+    add_cluv_config_section(pyproject_path, CLUV_DEFAUT_CONFIG)
+    add_cluv_config_section(pyproject_path, CLUV_SLURM_DEFAULT_CONFIG)
+    add_cluv_cluster_config("mila", pyproject_path, CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS)
+    for cluster in DRAC_CLUSTERS:
+        add_cluv_cluster_config(cluster, pyproject_path)
+
+    return DEFAULT_RESULTS_PATH
 
 
 def add_cluv_config_section(pyproject_path: Path, section_lines: list[str]) -> None:

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -49,7 +49,7 @@ def init() -> None:
     console.log("uv init --package --build-backend hatch --python 3.13")
     console.print()
     run_uv_init()
-    
+
     # 3. Check status of the git repository
     check_git()
 

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -74,6 +74,7 @@ def init() -> None:
     console.print("=> [bold] cluv sync [/bold]  : synchronize the project on all configured clusters.")
     console.print()
 
+
 def check_home_dir() -> None:
     """
     Check if the current directory is under the home directory. If not, raise an error and exit.
@@ -83,6 +84,7 @@ def check_home_dir() -> None:
     else:
         console.print("[red]❌ cluv init should be run in a directory under your home directory.[/red]")
         raise RuntimeError("cluv init should be run in a directory under your home directory.")
+
 
 def run_uv_init() -> None:
     uv_init = subprocess.run(["uv", "init", "--package", "--build-backend", "hatch", "--python", "3.13"], capture_output=True, text=True)
@@ -95,6 +97,7 @@ def run_uv_init() -> None:
             raise RuntimeError("Error occurred while initializing uv project: ", uv_init.stderr)
     else:
         console.print("[green]✅ uv: project initialized.[/green]")
+
 
 def check_cluv_config(pyproject_path: Path) -> str:
     """

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -47,7 +47,6 @@ def init() -> None:
     console.print()
     console.print("Initializing uv project: running [bold]uv init[/bold]...")
     console.log("uv init --package --build-backend hatch --python 3.13")
-    console.print()
     run_uv_init()
 
     # 3. Check status of the git repository
@@ -139,18 +138,16 @@ def check_git() -> None:
     """
     Check if the current project is in a git repository. If not, raise an error and exit.
     """
-    if os.path.isdir(".git"):   # TODO : Only works at the project root.
-        console.print("[green]✅ Project is in a git repository.[/green]")
-    else:
-        console.print("[red]❌ No git repository found.[/red]")
-        raise RuntimeError("The current project is not a git repository. Try running 'git init' or clone a GitHub project.")
-
     git_remote = subprocess.run(["git", "remote"], capture_output=True, text=True)
     if git_remote.returncode == 0:
         if git_remote.stdout.strip() == "":
             console.print("[yellow]⚠️  Warning: No git remote found. You won't be able to use some features (like syncing or submitting jobs). Consider adding a remote repository to your git config.[/yellow]")
         else:
             console.print(f"[green]✅ Git remote repository found: {git_remote.stdout.strip()}[/green]")
+    else:
+        console.print("[red]❌ Invalid git repository found.[/red]")
+        raise RuntimeError("Error when checking git remote: ", git_remote.stderr)
+
 
 def check_symlink_to_scratch(project_root: Path, results_path: str | None) -> None:
     """
@@ -207,7 +204,7 @@ project_root="{project_root}"
 """
 
     script_content +=  """
-# Minimal test job for cluv submit integration tests.
+# Minimal test job for cluv submit.
 echo "hostname: $(hostname)"
 echo "GIT_COMMIT=${GIT_COMMIT:?GIT_COMMIT is not set. Use 'cluv submit' to submit this job script.}"
 

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -29,7 +29,7 @@ CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS = [
 
 def init() -> None:
     """
-    Initialize a new project for use with cluv.
+    Initialize a new project with cluv.
     """
     console.print()
     console.rule("[bold cyan]cluv init[/bold cyan]")
@@ -48,27 +48,12 @@ def init() -> None:
     console.print("Initializing uv project: running [bold]uv init[/bold]...")
     console.log("uv init --package --build-backend hatch --python 3.13")
     console.print()
-    uv_init = subprocess.run(["uv", "init", "--package", "--build-backend", "hatch", "--python", "3.13"], capture_output=True, text=True)
+    run_uv_init()
+    
+    # 3. Check status of the git repository
+    check_git()
 
-    ### An expected error is that uv fails if a pyproject.toml file already exists
-    if uv_init.returncode == 2:
-        if uv_init.stderr.endswith("(`pyproject.toml` file exists)\n"):
-            console.print("[green]✅ uv: a project already exists (see pyproject.toml file). Skipping initialization.[/green]")
-            check_git()
-        else:
-            raise RuntimeError("Error occurred while initializing uv project: ", uv_init.stderr)
-    else:
-        console.print("[green]✅ uv: project initialized.[/green]")
-
-    ### Check if the git repository have access to a remote repository.
-    git_remote = subprocess.run(["git", "remote"], capture_output=True, text=True)
-    if git_remote.returncode == 0:
-        if git_remote.stdout.strip() == "":
-            console.print("[yellow]⚠️  Warning: No git remote found. You won't be able to use some features (like syncing or submitting jobs). Consider adding a remote repository to your git config.[/yellow]")
-        else:
-            console.print(f"[green]✅ Git remote repository found: {git_remote.stdout.strip()}[/green]")
-
-    # 3. Read the pyproject.toml file and try to find a cluv config.
+    # 4. Read the pyproject.toml file and try to find a cluv config.
     console.print()
     console.print("Reading pyproject.toml...")
     pyproject_path = find_pyproject()
@@ -77,7 +62,7 @@ def init() -> None:
     ### Get the results_path from the config to use for the next checks.
     results_path = check_cluv_config(pyproject_path)
 
-    # 4. Check if project structure is correct
+    # 5. Check if project structure is correct
     console.print()
     console.print("Validating project structure...")
 
@@ -87,7 +72,7 @@ def init() -> None:
     ### Check if the results path is correctly symlinked to scratch
     check_symlink_to_scratch(pyproject_path.parent, results_path)
 
-    # 5. Show what the user can do next after the project setup
+    # 6. Show what the user can do next after the project setup
     console.print()
     console.print(":tada: Your cluv config is ready to go !")
     console.print()
@@ -96,6 +81,17 @@ def init() -> None:
     console.print("=> [bold] cluv sync [/bold]  : synchronize the project on all configured clusters.")
     console.print()
 
+def run_uv_init() -> None:
+    uv_init = subprocess.run(["uv", "init", "--package", "--build-backend", "hatch", "--python", "3.13"], capture_output=True, text=True)
+
+    # An expected error is that uv fails if a pyproject.toml file already exists
+    if uv_init.returncode == 2:
+        if uv_init.stderr.endswith("(`pyproject.toml` file exists)\n"):
+            console.print("[green]✅ uv: a project already exists (see pyproject.toml file). Skipping initialization.[/green]")
+        else:
+            raise RuntimeError("Error occurred while initializing uv project: ", uv_init.stderr)
+    else:
+        console.print("[green]✅ uv: project initialized.[/green]")
 
 def check_cluv_config(pyproject_path: Path) -> str:
     """
@@ -149,6 +145,12 @@ def check_git() -> None:
         console.print("[red]❌ No git repository found.[/red]")
         raise RuntimeError("The current project is not a git repository. Try running 'git init' or clone a GitHub project.")
 
+    git_remote = subprocess.run(["git", "remote"], capture_output=True, text=True)
+    if git_remote.returncode == 0:
+        if git_remote.stdout.strip() == "":
+            console.print("[yellow]⚠️  Warning: No git remote found. You won't be able to use some features (like syncing or submitting jobs). Consider adding a remote repository to your git config.[/yellow]")
+        else:
+            console.print(f"[green]✅ Git remote repository found: {git_remote.stdout.strip()}[/green]")
 
 def check_symlink_to_scratch(project_root: Path, results_path: str | None) -> None:
     """

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -2,10 +2,10 @@ import os
 import subprocess
 from pathlib import Path
 
+from milatools.cli.init_command import DRAC_CLUSTERS
+
 from cluv.config import find_pyproject, has_cluv_config, load_cluv_config
 from cluv.utils import console
-
-from milatools.cli.init_command import DRAC_CLUSTERS    # TODO : not a great import but can be useful instead of updating manually
 
 JOB_SCRIPT_PATH = "scripts/job.sh"
 DEFAULT_RESULTS_PATH = "logs"
@@ -38,27 +38,29 @@ def init() -> None:
     
     # 1. Check if the current directory is under the home directory. If not, raise an error and exit.
     if str(Path.cwd()).startswith(str(Path.home())):
-        console.print(f"[green]✅ Current directory is under home directory.[/green]")
+        console.print("[green]✅ Current directory is under home directory.[/green]")
     else:
         console.print("[red]❌ cluv init should be run in a directory under your home directory.[/red]")
         raise RuntimeError("cluv init should be run in a directory under your home directory.")
 
-    # 2. Try to run "uv run" to create a new project
+    # 2. Try to run "uv init" to create a new project
     console.print()
     console.print("Initializing uv project: running [bold]uv init[/bold]...")
     console.log("uv init --package --build-backend hatch --python 3.13")
+    console.print()
     uv_init = subprocess.run(["uv", "init", "--package", "--build-backend", "hatch", "--python", "3.13"], capture_output=True, text=True)
 
-    # An expected error is that uv fails if a pyproject.toml file already exists
+    ### An expected error is that uv fails if a pyproject.toml file already exists
     if uv_init.returncode == 2:
         if uv_init.stderr.endswith("(`pyproject.toml` file exists)\n"):
             console.print("[green]✅ uv: a project already exists (see pyproject.toml file). Skipping initialization.[/green]")
             check_git()
-        else: raise RuntimeError("Error occurred while initializing uv project: ", uv_init.stderr)
+        else:
+            raise RuntimeError("Error occurred while initializing uv project: ", uv_init.stderr)
     else:
         console.print("[green]✅ uv: project initialized.[/green]")
 
-    # Check if the git repository have access to a remote repository.
+    ### Check if the git repository have access to a remote repository.
     git_remote = subprocess.run(["git", "remote"], capture_output=True, text=True)
     if git_remote.returncode == 0:
         if git_remote.stdout.strip() == "":
@@ -67,12 +69,12 @@ def init() -> None:
             console.print(f"[green]✅ Git remote repository found: {git_remote.stdout.strip()}[/green]")
 
     # 3. Read the pyproject.toml file and try to find a cluv config.
-    # If it doesn't exist, add a cluv config section with the default settings and clusters.
     console.print()
     console.print("Reading pyproject.toml...")
     pyproject_path = find_pyproject()
-
     results_path = DEFAULT_RESULTS_PATH
+
+    ### If it doesn't exist, add a cluv config section with the default settings and clusters.
     if has_cluv_config(pyproject_path):
         console.print("[green]✅ Project already have a cluv config in pyproject.toml.[/green]")
         config = load_cluv_config(pyproject_path)
@@ -80,26 +82,22 @@ def init() -> None:
         console.print(config)
     else:
         console.print("No config found for [bold]cluv[/bold] in the pyproject.toml file. Adding config...")
-        console.print(f"Adding config for cluv tool :")
+        console.print("Adding config for cluv tool :")
         add_cluv_config_section(pyproject_path, CLUV_DEFAUT_CONFIG)
         add_cluv_config_section(pyproject_path, CLUV_SLURM_DEFAULT_CONFIG)
         add_cluv_cluster_config("mila", pyproject_path, CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS)
-        for cluster in DRAC_CLUSTERS: add_cluv_cluster_config(cluster, pyproject_path)
+        for cluster in DRAC_CLUSTERS:
+            add_cluv_cluster_config(cluster, pyproject_path)
         console.print("[green]✅ Pyproject config completed.[/green]")
 
     # 4. Check if project structure is correct
     console.print()
     console.print("Validating project structure...")
 
-    # Check if the job script exists
-    if os.path.exists(JOB_SCRIPT_PATH):
-        console.print(f"[green]✅ Job template script already exists at '{JOB_SCRIPT_PATH}'.[/green]")
-    else:
-        os.makedirs("scripts")
-        console.print(f"Adding job template script at '{JOB_SCRIPT_PATH}'.")
-        generate_job_script(pyproject_path.parent, results_path)
+    ### Check if the job script exists
+    check_job_script(pyproject_path.parent, results_path)
     
-    # Check if the results path is correctly symlinked to scratch
+    ### Check if the results path is correctly symlinked to scratch
     check_symlink_to_scratch(pyproject_path.parent, results_path)
 
     console.print()
@@ -144,18 +142,22 @@ def check_git() -> None:
         raise RuntimeError("The current project is not a git repository. Try running 'git init' or clone a GitHub project.")
 
 
-def check_symlink_to_scratch(project_root: Path, results_path: str) -> None:
+def check_symlink_to_scratch(project_root: Path, results_path: str | None) -> None:
     """
     Check if a symlink from the results_path in the project to the corresponding path in $SCRATCH already exists. If not, create it.
     The symlink should be like : $HOME/<project>/<results_path> -> $SCRATCH/<results_path>/<project_name>
     """
+    if results_path is None:
+        console.print("[yellow]⚠️  Warning: Results path is not configured. Skipping symlink creation.[/yellow]")
+        return
+
     # Generate the expected scratch and symlink path
     scratch_dir = Path(os.path.expandvars(f"$SCRATCH/{results_path}/{project_root.name}"))
     results_dir = project_root / results_path
 
     if results_dir.is_symlink():
         if results_dir.resolve() == scratch_dir.resolve():
-            console.print(f"[green]✅ Symlink from $HOME results_path to $SCRATCH already exists.[/green]")
+            console.print("[green]✅ Symlink from $HOME results_path to $SCRATCH already exists.[/green]")
             return
         else:
             console.print(f"[red]❌ Symlink from {results_dir} points to {results_dir.resolve()} instead of {scratch_dir}.[/red]")
@@ -166,11 +168,21 @@ def check_symlink_to_scratch(project_root: Path, results_path: str) -> None:
         results_dir.symlink_to(scratch_dir, target_is_directory=True)
 
 
-def generate_job_script(project_root: Path, results_path: str) -> None:
+def check_job_script(project_root: Path, results_path: str | None) -> None:
     """
     Generate a job script template at JOB_SCRIPT_PATH with the following content, replacing {results_path} with the provided results_path argument and {project_root} with the provided project_root argument.
     The script should be executable and contain the necessary SLURM directives to run a job on a cluster, including setting up the environment, syncing the project, and running a command passed as an argument to the script.
     """
+    if os.path.exists(JOB_SCRIPT_PATH):
+        console.print(f"[green]✅ Job template script already exists at '{JOB_SCRIPT_PATH}'.[/green]")
+        return
+
+    if results_path is None:
+        console.print("[yellow]⚠️  Warning: Results path is not configured. Skipping job template script generation.[/yellow]")
+        return
+    
+    console.print(f"Adding job template script at '{JOB_SCRIPT_PATH}'.")
+
     project_name = project_root.name
     project_root = str(project_root.relative_to(Path.home()))
 
@@ -211,6 +223,6 @@ srun --gres-flags=allow-task-sharing uv --directory=$SLURM_TMPDIR/$project_name 
 echo "Copying logs from $SLURM_TMPDIR/$project_name/$results_path to $project_root/$results_path"
 srun --ntasks-per-node=1 rsync --update --recursive $SLURM_TMPDIR/$project_name/$results_path $project_root/
 """
-
+    os.makedirs(Path(JOB_SCRIPT_PATH).parent, exist_ok=True)
     with open(JOB_SCRIPT_PATH, 'w') as sh_file:
         sh_file.write(script_content)

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -2,17 +2,17 @@ import os
 import subprocess
 from pathlib import Path
 
-from cluv.config import find_pyproject, has_cluv_config
+from cluv.config import find_pyproject, has_cluv_config, load_cluv_config
 from cluv.utils import console
 
-# TODO : not a great import... But it can be helpful instead of updating a const
-from milatools.cli.init_command import DRAC_CLUSTERS    
+from milatools.cli.init_command import DRAC_CLUSTERS    # TODO : not a great import but can be useful instead of updating manually
 
 JOB_SCRIPT_PATH = "scripts/job.sh"
-RESULTS_DIR_PATH = "logs"
+DEFAULT_RESULTS_PATH = "logs"
 
 CLUV_DEFAUT_CONFIG = [
-    "[tool.cluv]"
+    "[tool.cluv]",
+    f'results_path = "{DEFAULT_RESULTS_PATH}"'
 ]
 
 CLUV_SLURM_DEFAULT_CONFIG = [
@@ -22,14 +22,14 @@ CLUV_SLURM_DEFAULT_CONFIG = [
     'WANDB_MODE = "offline"',
 ]
 
-CLUV_MILA_CLUSTER_DEFAULT_CONFIG = [
+CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS = [
     "UV_OFFLINE = 0",
     'WANDB_MODE = "online"',
 ]
 
 def init() -> None:
     """
-    TODO
+    Initialize a new project for use with cluv.
     """
     console.print()
     console.rule("[bold cyan]cluv init[/bold cyan]")
@@ -64,13 +64,18 @@ def init() -> None:
     console.print("Reading pyproject.toml...")
     pyproject_path = find_pyproject()
 
+    results_path = DEFAULT_RESULTS_PATH
     if has_cluv_config(pyproject_path):
         console.print("[green]✅ Project already have a cluv config in pyproject.toml.[/green]")
+        config = load_cluv_config(pyproject_path)
+        results_path = config.results_path
+        console.print(config)
     else:
         console.print("No config found for [bold]cluv[/bold] in the pyproject.toml file. Adding config...")
-        add_cluv_config(pyproject_path, RESULTS_DIR_PATH)
-        add_cluv_slurm_config(pyproject_path)
-        add_cluv_cluster_config("mila", pyproject_path, CLUV_MILA_CLUSTER_DEFAULT_CONFIG)
+        console.print(f"Adding config for cluv tool :")
+        add_cluv_config_section(pyproject_path, CLUV_DEFAUT_CONFIG)
+        add_cluv_config_section(pyproject_path, CLUV_SLURM_DEFAULT_CONFIG)
+        add_cluv_cluster_config("mila", pyproject_path, CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS)
         for cluster in DRAC_CLUSTERS: add_cluv_cluster_config(cluster, pyproject_path)
         console.print("[green]✅ Pyproject config completed.[/green]")
 
@@ -79,21 +84,15 @@ def init() -> None:
     console.print("Validating project structure...")
 
     # Check if the job script exists
-    if os.path.exists(JOB_SCRIPT_PATH):
+    if os.path.exists(JOB_SCRIPT_PATH): # TODO : check if the content is correct ?
         console.print(f"[green]✅ Job template script already exists at '{JOB_SCRIPT_PATH}'.[/green]")
     else:
         os.makedirs("scripts")
         console.print(f"Adding job template script at '{JOB_SCRIPT_PATH}'.")
-        generate_job_script(pyproject_path.parent, RESULTS_DIR_PATH)
-
-    # Check if the results_dir exists
-    if os.path.exists(RESULTS_DIR_PATH):
-        console.print(f"[green]✅ Results directory already exists at '{RESULTS_DIR_PATH}'.[/green]")
-    else:
-        console.print(f"Adding results directory at '{RESULTS_DIR_PATH}'.")
-        os.makedirs(RESULTS_DIR_PATH)
-    else:
-        console.print(f"[green]✅ Results directory already exists at '{RESULTS_DIR_PATH}'.[/green]")
+        generate_job_script(pyproject_path.parent, results_path)
+    
+    # Check if the results path is correctly symlinked to scratch
+    check_symlink_to_scratch(pyproject_path, results_path)
 
     console.print()
     console.print(":tada: Your cluv config is ready to go !")
@@ -105,64 +104,77 @@ def init() -> None:
     console.print("=> [bold] cluv sync [/bold]  : synchronize the project on all configured clusters.")
     console.print()
 
-def add_cluv_config(pyproject_path: Path, results_path: str) -> None:
+
+def add_cluv_config_section(pyproject_path: Path, section_lines: list[str]) -> None:
     """
-    TODO
+    Write the given lines to the pyproject.toml file.
     """
-    console.print(f"Adding config for cluv tool :")
-    section_lines = CLUV_DEFAUT_CONFIG + [f'results_path = "{results_path}"']
-    console.log(f'{"\n" + "\n".join(section_lines) + "\n"}'.replace("[", "\\["))    # TODO : Log not displayed correctly ?
+    console.log(f'{"\n" + "\n".join(section_lines) + "\n"}'.replace("[", "\\["))
     with pyproject_path.open("a") as f:
         f.write("\n" + "\n".join(section_lines) + "\n")
 
 
-def add_cluv_slurm_config(pyproject_path: Path) -> None:
-    """
-    TODO
-    """
-    console.print(f"Adding config for global env vars when using SLURM :")
-    console.log(f'{"\n" + "\n".join(CLUV_SLURM_DEFAULT_CONFIG) + "\n"}'.replace("[", "\\["))    # TODO : Log not displayed correctly ?
-    with pyproject_path.open("a") as f:
-        f.write("\n" + "\n".join(CLUV_SLURM_DEFAULT_CONFIG) + "\n")
-
-
 def add_cluv_cluster_config(cluster: str, pyproject_path: Path, vars: list[str] = []) -> None:
     """
-    TODO
+    Add a cluster config section for the given cluster to the pyproject.toml file, with the given variables.
     """
     console.print(f"Adding config for cluster [bold]{cluster}[/bold] :")
-    section_lines = [f"\n[tool.cluv.clusters.{cluster}]"] + vars
-    console.log(f'{"\n".join(section_lines) + "\n"}'.replace("[", "\\["))    # TODO : Log not displayed correctly ?
+    section_lines = [f"[tool.cluv.clusters.{cluster}]"] + vars
+    console.log(f'{"\n" + "\n".join(section_lines) + "\n"}'.replace("[", "\\["))
     with pyproject_path.open("a") as f:
-        f.write("\n".join(section_lines) + "\n")
+        f.write("\n" + "\n".join(section_lines) + "\n")
 
 
 def check_git() -> None:
     """
-    TODO
+    Check if the current project is in a git repository. If not, raise an error and exit.
     """
     if os.path.isdir(".git"):   # TODO : Very simple approch. Only works at the project root.
-        console.print("[green]✅ Project is in git repository.[/green]")
+        console.print("[green]✅ Project is in a git repository.[/green]")
     else:
         console.print("[red]❌ No git repository found.[/red]")
         raise RuntimeError("The current project is not a git repository. Try running 'git init' or clone a GitHub project.")
 
 
-def generate_job_script(project_root: Path, results_dir: str) -> None:
+def check_symlink_to_scratch(pyproject_path: Path, results_path: str) -> None:
     """
-    TODO
+    Check if a symlink from the results_path in the project to the corresponding path in $SCRATCH already exists. If not, create it.
+    Should be like : $HOME/<project>/<results_path> -> $SCRATCH/<results_path>/<project_name>
+    """
+    # Generate the expected scratch path and the expected symlink path
+    project_path_name = pyproject_path.parent.name
+    scratch_dir = Path(os.path.expandvars(f"$SCRATCH/{results_path}/{project_path_name}"))
+    results_dir = pyproject_path.parent / results_path
+
+    if results_dir.is_symlink():
+        if results_dir.resolve() == scratch_dir.resolve():
+            console.print(f"[green]✅ Symlink from $HOME results_path to $SCRATCH already exists.[/green]")
+            return
+        else:
+            console.print(f"[red]❌ Symlink from {results_dir} points to {results_dir.resolve()} instead of {scratch_dir}.[/red]")
+            raise RuntimeError(f"Symlink from {results_dir} points to {results_dir.resolve()} instead of {scratch_dir}. Please fix this symlink before running cluv.")
+    else:
+        console.print(f"Creating symlink from {results_dir} to {scratch_dir}")
+        scratch_dir.mkdir(parents=True, exist_ok=True)
+        results_dir.symlink_to(scratch_dir, target_is_directory=True)
+
+
+def generate_job_script(project_root: Path, results_path: str) -> None:
+    """
+    Generate a job script template at JOB_SCRIPT_PATH with the following content, replacing {results_path} with the provided results_path argument and {project_root} with the provided project_root argument.
+    The script should be executable and contain the necessary SLURM directives to run a job on a cluster, including setting up the environment, syncing the project, and running a command passed as an argument to the script.
     """
     project_name = project_root.name
     project_root = str(project_root.relative_to(Path.home()))
 
     script_content = f"""#!/bin/bash
-#SBATCH --output={results_dir}/%j/slurm-%j.out
+#SBATCH --output={results_path}/%j/slurm-%j.out
 #SBATCH --ntasks=1
 #SBATCH --mem=8G
 #SBATCH --time=0:05:00
 
 project_name="{project_name}"
-results_dir="{results_dir}"
+results_path="{results_path}"
 project_root="{project_root}"
 """
 
@@ -189,8 +201,8 @@ echo "Running command: $@"
 srun --gres-flags=allow-task-sharing uv --directory=$SLURM_TMPDIR/$project_name run "$@"
 
 # Copy results (if any) from the local storage back to the results dir (eg in $SCRATCH)
-echo "Copying logs from $SLURM_TMPDIR/$project_name/$results_dir to $project_root/$results_dir"
-srun --ntasks-per-node=1 rsync --update --recursive $SLURM_TMPDIR/$project_name/$results_dir $project_root/
+echo "Copying logs from $SLURM_TMPDIR/$project_name/$results_path to $project_root/$results_path"
+srun --ntasks-per-node=1 rsync --update --recursive $SLURM_TMPDIR/$project_name/$results_path $project_root/
 """
 
     with open(JOB_SCRIPT_PATH, 'w') as sh_file:

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -179,7 +179,7 @@ def check_symlink_to_scratch(project_root: Path, results_path: str | None) -> No
             console.print("[green]✅ Symlink from $HOME results_path to $SCRATCH already exists.[/green]")
             return
         else:
-            console.print(f"[yellow]⚠️  Warning: Symlink from {symlink_path} points to an other expected scratch path ({symlink_path.resolve()}).[/yellow]")
+            console.print(f"[yellow]⚠️  Warning: Symlink from {symlink_path} points to an other path ({symlink_path.resolve()}) than the expected scratch path.[/yellow]")
             return
     else:
         console.print(f"Creating symlink from {symlink_path} to {scratch_path}")

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -35,7 +35,7 @@ def init() -> None:
     console.rule("[bold cyan]cluv init[/bold cyan]")
     console.print()
     # TODO : give path to create project
-    
+
     # 1. Check if the current directory is under the home directory. If not, raise an error and exit.
     if str(Path.cwd()).startswith(str(Path.home())):
         console.print("[green]✅ Current directory is under home directory.[/green]")
@@ -96,7 +96,7 @@ def init() -> None:
 
     ### Check if the job script exists
     check_job_script(pyproject_path.parent, results_path)
-    
+
     ### Check if the results path is correctly symlinked to scratch
     check_symlink_to_scratch(pyproject_path.parent, results_path)
 
@@ -179,7 +179,7 @@ def check_job_script(project_root: Path, results_path: str | None) -> None:
     if results_path is None:
         console.print("[yellow]⚠️  Warning: Results path is not configured. Skipping job template script generation.[/yellow]")
         return
-    
+
     console.print(f"Adding job template script at '{JOB_SCRIPT_PATH}'.")
 
     project_name = project_root.name

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -38,9 +38,9 @@ def init() -> None:
     
     # 1. Check if the current directory is under the home directory. If not, raise an error and exit.
     if str(Path.cwd()).startswith(str(Path.home())):
-        console.print(f"[green]✅ Current directory is under home directory : {Path.cwd()}[/green]")
+        console.print(f"[green]✅ Current directory is under home directory.[/green]")
     else:
-        console.print("[red]❌ Error: cluv init should be run in a directory under your home directory.[/red]")
+        console.print("[red]❌ cluv init should be run in a directory under your home directory.[/red]")
         raise RuntimeError("cluv init should be run in a directory under your home directory.")
 
     # 2. Try to run "uv run" to create a new project
@@ -57,6 +57,14 @@ def init() -> None:
         else: raise RuntimeError("Error occurred while initializing uv project: ", uv_init.stderr)
     else:
         console.print("[green]✅ uv: project initialized.[/green]")
+
+    # Check if the git repository have access to a remote repository.
+    git_remote = subprocess.run(["git", "remote"], capture_output=True, text=True)
+    if git_remote.returncode == 0:
+        if git_remote.stdout.strip() == "":
+            console.print("[yellow]⚠️  Warning: No git remote found. You won't be able to use some features (like syncing or submitting jobs). Consider adding a remote repository to your git config.[/yellow]")
+        else:
+            console.print(f"[green]✅ Git remote repository found: {git_remote.stdout.strip()}[/green]")
 
     # 3. Read the pyproject.toml file and try to find a cluv config.
     # If it doesn't exist, add a cluv config section with the default settings and clusters.
@@ -84,7 +92,7 @@ def init() -> None:
     console.print("Validating project structure...")
 
     # Check if the job script exists
-    if os.path.exists(JOB_SCRIPT_PATH): # TODO : check if the content is correct ?
+    if os.path.exists(JOB_SCRIPT_PATH):
         console.print(f"[green]✅ Job template script already exists at '{JOB_SCRIPT_PATH}'.[/green]")
     else:
         os.makedirs("scripts")
@@ -92,7 +100,7 @@ def init() -> None:
         generate_job_script(pyproject_path.parent, results_path)
     
     # Check if the results path is correctly symlinked to scratch
-    check_symlink_to_scratch(pyproject_path, results_path)
+    check_symlink_to_scratch(pyproject_path.parent, results_path)
 
     console.print()
     console.print(":tada: Your cluv config is ready to go !")
@@ -136,15 +144,14 @@ def check_git() -> None:
         raise RuntimeError("The current project is not a git repository. Try running 'git init' or clone a GitHub project.")
 
 
-def check_symlink_to_scratch(pyproject_path: Path, results_path: str) -> None:
+def check_symlink_to_scratch(project_root: Path, results_path: str) -> None:
     """
     Check if a symlink from the results_path in the project to the corresponding path in $SCRATCH already exists. If not, create it.
-    Should be like : $HOME/<project>/<results_path> -> $SCRATCH/<results_path>/<project_name>
+    The symlink should be like : $HOME/<project>/<results_path> -> $SCRATCH/<results_path>/<project_name>
     """
-    # Generate the expected scratch path and the expected symlink path
-    project_path_name = pyproject_path.parent.name
-    scratch_dir = Path(os.path.expandvars(f"$SCRATCH/{results_path}/{project_path_name}"))
-    results_dir = pyproject_path.parent / results_path
+    # Generate the expected scratch and symlink path
+    scratch_dir = Path(os.path.expandvars(f"$SCRATCH/{results_path}/{project_root.name}"))
+    results_dir = project_root / results_path
 
     if results_dir.is_symlink():
         if results_dir.resolve() == scratch_dir.resolve():

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -35,19 +35,19 @@ def init() -> None:
     console.rule("[bold cyan]cluv init[/bold cyan]")
     console.print()
 
-    # 1. Check if the current directory is under the home directory. If not, raise an error and exit.
+    # Check if the current directory is under the home directory. If not, raise an error and exit.
     check_home_dir()
 
-    # 2. Try to run "uv init" to create a new project
+    # Try to run "uv init" to create a new project
     console.print()
     console.print("Initializing uv project: running [bold]uv init[/bold]...")
     console.log("uv init --package --build-backend hatch --python 3.13")
     run_uv_init()
 
-    # 3. Check status of the git repository
+    # Check status of the git repository
     check_git()
 
-    # 4. Read the pyproject.toml file and try to find a cluv config.
+    # Read the pyproject.toml file and try to find a cluv config.
     console.print()
     console.print("Reading pyproject.toml...")
     pyproject_path = find_pyproject()
@@ -55,7 +55,7 @@ def init() -> None:
     # If it doesn't exist, add a cluv config section with the default settings and clusters.
     results_path = check_cluv_config(pyproject_path)
 
-    # 5. Check if project structure is correct
+    # Check if project structure is correct
     console.print()
     console.print("Validating project structure...")
 
@@ -65,7 +65,7 @@ def init() -> None:
     # Check if the results path is correctly symlinked to scratch
     check_symlink_to_scratch(pyproject_path.parent, results_path)
 
-    # 6. Show what the user can do next after the project setup
+    # Show what the user can do next after the project setup
     console.print()
     console.print(":tada: Your cluv config is ready to go !")
     console.print()

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -135,7 +135,7 @@ def check_git() -> None:
     """
     Check if the current project is in a git repository. If not, raise an error and exit.
     """
-    if os.path.isdir(".git"):   # TODO : Very simple approch. Only works at the project root.
+    if os.path.isdir(".git"):   # TODO : Only works at the project root.
         console.print("[green]✅ Project is in a git repository.[/green]")
     else:
         console.print("[red]❌ No git repository found.[/red]")

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -99,7 +99,7 @@ def run_uv_init() -> None:
         console.print("[green]✅ uv: project initialized.[/green]")
 
 
-def check_cluv_config(pyproject_path: Path) -> str:
+def check_cluv_config(pyproject_path: Path) -> str | None:
     """
     Check if the pyproject.toml file contains a cluv config.
     If not, add a default config section with the default clusters and settings.

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -144,7 +144,7 @@ def check_git() -> None:
 
 def check_symlink_to_scratch(project_root: Path, results_path: str | None) -> None:
     """
-    Check if a symlink from the results_path in the project to the corresponding path in $SCRATCH already exists. If not, create it.
+    Check if a symlink from the results_path in the project in $HOME to the corresponding path in $SCRATCH already exists. If not, create it.
     The symlink should be like : $HOME/<project>/<results_path> -> $SCRATCH/<results_path>/<project_name>
     """
     if results_path is None:
@@ -170,8 +170,7 @@ def check_symlink_to_scratch(project_root: Path, results_path: str | None) -> No
 
 def check_job_script(project_root: Path, results_path: str | None) -> None:
     """
-    Generate a job script template at JOB_SCRIPT_PATH with the following content, replacing {results_path} with the provided results_path argument and {project_root} with the provided project_root argument.
-    The script should be executable and contain the necessary SLURM directives to run a job on a cluster, including setting up the environment, syncing the project, and running a command passed as an argument to the script.
+    Check if the job script template to set and run the project on a cluster with SLURM exists. If not, create it.
     """
     if os.path.exists(JOB_SCRIPT_PATH):
         console.print(f"[green]✅ Job template script already exists at '{JOB_SCRIPT_PATH}'.[/green]")

--- a/cluv/cli/run.py
+++ b/cluv/cli/run.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import argparse
 import asyncio
 import logging
 import shlex
 from pathlib import Path
 
-import rich_argparse
 from rich.console import Group
 from rich.panel import Panel
 
@@ -17,33 +15,6 @@ from cluv.remote import Remote
 from cluv.utils import console, current_cluster
 
 logger = logging.getLogger(__name__)
-
-
-def add_run_args(
-    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
-) -> argparse.ArgumentParser:
-    cluster_choices = get_config().clusters
-    run_parser = subparsers.add_parser(
-        "run",
-        help="Run a command on a cluster",
-        formatter_class=rich_argparse.RichHelpFormatter,
-    )
-    run_parser.add_argument(
-        "cluster",
-        choices=cluster_choices if cluster_choices else None,
-        # default=,
-        metavar="<cluster>",
-        help="The cluster to run the command on",
-    )
-    run_parser.add_argument(
-        "command",
-        type=str,
-        metavar="<command>",
-        help="The command to run",
-        nargs=argparse.REMAINDER,
-    )
-    run_parser.set_defaults(func=run)
-    return run_parser
 
 
 async def run(command: str | list[str], cluster: str):

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -1,45 +1,13 @@
 from __future__ import annotations
 
-import argparse
 import shlex
 import subprocess
 import sys
 from pathlib import Path
 
-import rich_argparse
-
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_config
 from cluv.utils import console
-
-
-def add_submit_args(
-    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
-) -> argparse.ArgumentParser:
-    submit_parser = subparsers.add_parser(
-        "submit",
-        help="Submit a SLURM job on a remote cluster.",
-        formatter_class=rich_argparse.RichHelpFormatter,
-        usage="cluv submit <cluster> <job.sh> [sbatch-args...] [-- program-args...]",
-    )
-    submit_parser.add_argument(
-        "cluster",
-        metavar="<cluster>",
-        help="The cluster to submit the job on.",
-    )
-    submit_parser.add_argument(
-        "job_script",
-        metavar="<job.sh>",
-        help="Path to the sbatch job script (relative to project root).",
-    )
-    submit_parser.add_argument(
-        "sbatch_args",
-        nargs=argparse.REMAINDER,
-        metavar="...",
-        help="sbatch flags (before --) and/or program arguments (after --).",
-    )
-    submit_parser.set_defaults(func=submit)
-    return submit_parser
 
 
 async def submit(

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -16,7 +16,6 @@ from cluv.utils import console
 def add_submit_args(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> argparse.ArgumentParser:
-    cluster_choices = get_config().clusters
     submit_parser = subparsers.add_parser(
         "submit",
         help="Submit a SLURM job on a remote cluster.",
@@ -25,7 +24,6 @@ def add_submit_args(
     )
     submit_parser.add_argument(
         "cluster",
-        choices=cluster_choices if cluster_choices else None,
         metavar="<cluster>",
         help="The cluster to submit the job on.",
     )

--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -40,7 +40,6 @@ logger = logging.getLogger(__name__)
 def add_sync_args(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> argparse.ArgumentParser:
-    cluster_choices = get_config().clusters
     sync_parser = subparsers.add_parser(
         "sync",
         help="Synchronizes the current project across clusters.",
@@ -48,7 +47,6 @@ def add_sync_args(
     )
     sync_parser.add_argument(
         "clusters",
-        choices=cluster_choices if cluster_choices else None,
         nargs="*",
         default=None,
         metavar="<cluster>",

--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 import asyncio
 import functools
 import logging
@@ -13,7 +12,6 @@ from typing import Literal
 # TODO: Figure out what the issues are with the console output
 import milatools.cli
 import milatools.utils.parallel_progress
-import rich_argparse
 
 # Reuse some code milatools. Could also extract it here to remove the dependency.
 from milatools.utils.parallel_progress import (
@@ -35,45 +33,6 @@ logger = logging.getLogger(__name__)
 # TODO: Control the 'hide' and 'display' / etc using the --verbose flag value, in addition to the loglevel.
 # TODO: Pipe the commands and their outputs / stderr to separate files for each cluster, so people can easily inspect
 # what might have gone wrong. Also include a message at the end like "Check <logs_dir>/{cluster}.log for details."
-
-
-def add_sync_args(
-    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
-) -> argparse.ArgumentParser:
-    sync_parser = subparsers.add_parser(
-        "sync",
-        help="Synchronizes the current project across clusters.",
-        formatter_class=rich_argparse.RichHelpFormatter,
-    )
-    sync_parser.add_argument(
-        "clusters",
-        nargs="*",
-        default=None,
-        metavar="<cluster>",
-        help=(
-            "The cluster(s) to synchronize with. "
-            "Leave empty to synchronize with all currently logged in clusters. "
-            "Use a comma to separate multiple clusters."
-        ),
-    )
-    # TODO: Try to add a 'remainder' arg to pass extra args to `uv sync` on the remote cluster, but it seems to be a bit tricky.
-    # sync_parser.add_argument(
-    #     "--",
-    #     dest="_",
-    #     # type=str,
-    #     # help="The arguments to pass to `uv sync` on the remote cluster.",
-    #     # dest=argparse.SUPPRESS,
-    # )
-    # sync_parser.add_argument(
-    #     "--",
-    #     dest="uv_sync_args",
-    #     # type=str,
-    #     # metavar="<uv sync arguments>",
-    #     help="The arguments to pass to `uv sync` on the remote cluster.",
-    #     nargs=argparse.REMAINDER,
-    # )
-    sync_parser.set_defaults(func=sync)
-    return sync_parser
 
 
 async def sync(

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -47,6 +47,12 @@ def find_pyproject(start: Path | None = None) -> Path:
     )
 
 
+def has_cluv_config(pyproject_path: Path) -> bool:
+    with pyproject_path.open("rb") as handle:
+        data = tomllib.load(handle)
+    return "cluv" in data.get("tool", {})
+
+
 def load_cluv_config(pyproject_path: Path) -> CluvConfig:
     with pyproject_path.open("rb") as handle:
         data = tomllib.load(handle)

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -48,6 +48,7 @@ def find_pyproject(start: Path | None = None) -> Path:
 
 
 def has_cluv_config(pyproject_path: Path) -> bool:
+    """Check if the pyproject.toml contains a cluv config"""
     with pyproject_path.open("rb") as handle:
         data = tomllib.load(handle)
     return "cluv" in data.get("tool", {})

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -50,7 +50,7 @@ def find_pyproject(start: Path | None = None) -> Path:
 def has_cluv_config(pyproject_path: Path) -> bool:
     with pyproject_path.open("rb") as handle:
         data = tomllib.load(handle)
-    return "cluv" in data.get("tool", {}) and "results_path" in data.get("tool", {}).get("cluv", {})
+    return "cluv" in data.get("tool", {})
 
 
 def load_cluv_config(pyproject_path: Path) -> CluvConfig:

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -50,7 +50,7 @@ def find_pyproject(start: Path | None = None) -> Path:
 def has_cluv_config(pyproject_path: Path) -> bool:
     with pyproject_path.open("rb") as handle:
         data = tomllib.load(handle)
-    return "cluv" in data.get("tool", {})
+    return "cluv" in data.get("tool", {}) and "results_path" in data.get("tool", {}).get("cluv", {})
 
 
 def load_cluv_config(pyproject_path: Path) -> CluvConfig:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ job_script = "scripts/job.sh"
 results_path = "logs"
 
 [tool.cluv.slurm]
-# Global SBATCH_* defaults applied to all clusters.
+# Environment variables applied when using Slurm commands on all clusters.
 SBATCH_TIME = "3:00:00"
 SBATCH_REQUE = true
 

--- a/scripts/job.sh
+++ b/scripts/job.sh
@@ -13,7 +13,7 @@ echo "GIT_COMMIT=${GIT_COMMIT:?GIT_COMMIT is not set. Use 'cluv submit' to submi
 
 # Setup the repo in $SLURM_TMPDIR, so the code can change in the project without affecting the job.
 echo "Preparing the repo and virtual environment in $SLURM_TMPDIR"
-srun --ntasks-per-node=1 --ntasks=$SLURM_NNODES --input=all bash -e <<END
+srun --ntasks-per-node=1 --ntasks=$SLURM_NNODES bash -e <<END
 cd $SLURM_TMPDIR
 git clone $project_root
 cd $SLURM_TMPDIR/cluv

--- a/skills/cluv/SKILL.md
+++ b/skills/cluv/SKILL.md
@@ -27,9 +27,9 @@ uv run cluv -v status
 |---------|--------|-------------|
 | `cluv login` | implemented | Establish SSH ControlMaster connections to all configured clusters (run this first; prompts for 2FA sequentially) |
 | `cluv sync` | implemented | Push local git changes then pull + `uv sync` on each cluster in parallel; optionally rsync results back |
-| `cluv status` | partial | Show per-cluster job and storage stats (mock data for now) |
-| `cluv init` | stub | Initialize a new cluv-managed project (not yet implemented) |
-| `cluv run` | stub | Submit a job to one or more clusters (not yet implemented) |
+| `cluv status` | implemented | Show per-cluster job and storage stats |
+| `cluv init` | implemented | Initialize a new cluv-managed project |
+| `cluv run` | implemented | Submit a job to one or more clusters |
 
 ## Configuration
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,12 +2,7 @@
 
 
 from cluv.config import load_cluv_config
-
-
-def write_pyproject(tmp_path, content: str):
-    p = tmp_path / "pyproject.toml"
-    p.write_text(content)
-    return p
+from .utils import write_pyproject
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,90 +1,98 @@
+"""Unit tests for cluv/cli/init.py check functions."""
+
 from pathlib import Path
 
-from cluv.config import get_config
-from cluv.cli.init import check_git, init, DEFAULT_RESULTS_PATH, JOB_SCRIPT_PATH
+import pytest
 from milatools.cli.init_command import DRAC_CLUSTERS
+
+from cluv.config import load_cluv_config
+from cluv.cli.init import (
+    check_home_dir,
+    check_git,
+    check_cluv_config,
+    check_symlink_to_scratch,
+    DEFAULT_RESULTS_PATH
+)
 from .utils import write_pyproject
 
-import cluv.cli.init
-import pytest
 
-TEST_RESULTS_PATH = "test_results"
-
-@pytest.fixture
-def clean_config_cache():
-    """
-    To avoid that a test reads the cached config of an other, we need to clear the cache between each test.
-    """
-    get_config.cache_clear()
-
-class TestInitCommand:
-    def test_fail_if_not_under_home(self, tmp_path, monkeypatch) -> None:
-        """init() should raise an error if the current directory is not under the user's home directory"""
+class TestCheckHomeDir:
+    def test_not_under_home(self, tmp_path, monkeypatch) -> None:
+        """check_home_dir() should raise an error if the current directory is not under the user's home directory"""
         monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path
-        monkeypatch.chdir(tmp_path.parent) # Move to the parent of tmp_path, which is not under the "home" directory
+        monkeypatch.chdir(tmp_path.parent) # Set the current work dir to the parent of tmp_path, which is not under the "home" directory
 
         with pytest.raises(RuntimeError, match="cluv init should be run in a directory under your home directory."):
-            init()
+            check_home_dir()
 
-    
-    def test_generate_default_toml_config(self, tmp_path, monkeypatch) -> None:
-        """init() should create a pyproject.toml file with the default configuration if it doesn't exist"""
-        monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
-        monkeypatch.chdir(tmp_path)
 
-        init()
-        config = get_config()
+class TestGitCheck:
+    def test_not_in_git_repo(self, tmp_path, monkeypatch) -> None:
+        """check_git() should raise an error if the current directory is not a git repository"""
+        monkeypatch.chdir(tmp_path) # Set the working dir to tmp_path
 
+        with pytest.raises(RuntimeError, match="Error when checking git remote: "):
+            check_git()
+
+
+class TestCheckCluvConfig:
+    def test_add_missing_cluv_config(self, tmp_path) -> None:
+        """check_cluv_config() should add a cluv config section if the toml doesn't have it"""
+        p = write_pyproject(tmp_path, "")
+
+        results_path = check_cluv_config(p)
+        config = load_cluv_config(p)
+
+        assert results_path == DEFAULT_RESULTS_PATH
         assert config.clusters == ["mila"] + DRAC_CLUSTERS
-        assert config.results_path == "logs"
+        assert config.results_path == DEFAULT_RESULTS_PATH
         assert config.slurm == {'UV_OFFLINE': 1, 'WANDB_MODE': 'offline'}
         assert config.cluster_configs == {"mila": {"UV_OFFLINE": 0, "WANDB_MODE": "online"}}
 
 
-    @pytest.mark.usefixtures("clean_config_cache")
-    def test_keep_toml_config(self, tmp_path, monkeypatch) -> None:
-        """init() should keep the cluv config of an already existing pyproject.toml"""
-        monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
-        monkeypatch.setattr(cluv.cli.init, "check_git", lambda: None) # Skip git check
-        monkeypatch.chdir(tmp_path)
-        write_pyproject(tmp_path, """
+    def test_keep_existing_cluv_config(self, tmp_path) -> None:
+        """check_cluv_config() should not overwrite an existing cluv config"""
+        p = write_pyproject(tmp_path, """
 [tool.cluv]
 clusters = ["mila"]
 results_path = "results"
 """)
 
-        init()
-        config = get_config()
+        results_path = check_cluv_config(p)
+        config = load_cluv_config(p)
 
-        assert config.results_path == "results"
+        assert results_path == "results"
         assert config.clusters == ["mila"]
+        assert config.results_path == "results"
 
 
-    @pytest.mark.usefixtures("clean_config_cache")
-    def test_results_path_as_none(self, tmp_path, monkeypatch) -> None:
-        """init() should skip the job script and symlink creation if the results_path is set to None in the config"""
-        monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
-        monkeypatch.setattr(cluv.cli.init, "check_git", lambda: None) # Skip git check
-        monkeypatch.chdir(tmp_path)
+class TestSymlinkCheck():
+    def test_no_symlink_if_results_path_is_none(self, tmp_path) -> None:
+        """check_symlink_to_scratch() should not create a symlink if the results_path is None"""
+        check_symlink_to_scratch(tmp_path, None)
 
-        write_pyproject(tmp_path, """
-[tool.cluv]
-clusters = ["mila"]
-""")
-
-        init()
-        config = get_config()
-
-        assert config.results_path is None
-        assert not (tmp_path / JOB_SCRIPT_PATH).exists()
         assert not (tmp_path / DEFAULT_RESULTS_PATH).exists()
 
 
-class TestGitCheck:
-    def test_fail_if_not_in_git_repo(self, tmp_path, monkeypatch) -> None:
-        """check_git() should raise an error if the current directory is not a git repository"""
-        monkeypatch.chdir(tmp_path) # No git project in tmp_path
+    def test_no_symlink_if_scratch_not_set(self, tmp_path, monkeypatch) -> None:
+        """check_symlink_to_scratch() should not create a symlink if the $SCRATCH env var is not set"""
+        monkeypatch.delenv("SCRATCH", raising=False)
 
-        with pytest.raises(RuntimeError, match="Error when checking git remote: "):
-            check_git()
+        check_symlink_to_scratch(tmp_path, DEFAULT_RESULTS_PATH)
 
+        assert not (tmp_path / DEFAULT_RESULTS_PATH).exists()
+
+
+    def test_create_symlink(self, tmp_path, monkeypatch) -> None:
+        """check_symlink_to_scratch() should create a symlink from results_path to scratch"""
+        scratch_path = tmp_path / "scratch"
+        monkeypatch.setenv("SCRATCH", str(scratch_path))
+        expected_results_path = tmp_path / DEFAULT_RESULTS_PATH
+        expected_results_scratch_path = scratch_path / DEFAULT_RESULTS_PATH / tmp_path.name
+
+        check_symlink_to_scratch(tmp_path, DEFAULT_RESULTS_PATH)
+
+        assert expected_results_path.exists()
+        assert expected_results_path.is_symlink()
+        assert expected_results_scratch_path.exists()
+        assert expected_results_path.resolve() == expected_results_scratch_path.resolve()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,6 +10,7 @@ class TestInitGitCheck:
     def test_init_fails_if_not_in_git_repo(self, tmp_path, monkeypatch) -> None:
         """check_git() should raise an error if the current directory is not a git repository"""
         monkeypatch.chdir(tmp_path) # No git project in tmp_path
+
         with pytest.raises(RuntimeError, match="The current project is not a git repository. Try running 'git init' or clone a GitHub project."):
             check_git()
 
@@ -18,7 +19,7 @@ class TestInitCluvConfig:
         """init() should raise an error if the current directory is not under the user's home directory"""
         monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path
         monkeypatch.chdir(tmp_path.parent) # Move to the parent of tmp_path, which is not under the "home" directory
-        
+
         with pytest.raises(RuntimeError, match="cluv init should be run in a directory under your home directory."):
             init()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -106,14 +106,11 @@ class TestSymlinkCheck():
         monkeypatch.setenv("SCRATCH", str(scratch_path))
         expected_results_path = tmp_path / DEFAULT_RESULTS_PATH
         expected_results_scratch_path = scratch_path / DEFAULT_RESULTS_PATH / tmp_path.name
-
-        # Create a symlink pointing to the wrong location
-        expected_results_path.symlink_to(tmp_path / "some_other_folder")
+        expected_results_path.symlink_to(tmp_path / "some_other_folder")    # Create a symlink pointing to a new location
 
         check_symlink_to_scratch(tmp_path, DEFAULT_RESULTS_PATH)
 
         # The original symlink should be kept, and not changed to point to scratch
-        assert expected_results_path.exists()
         assert expected_results_path.is_symlink()
         assert expected_results_path.resolve() == (tmp_path / "some_other_folder").resolve()
         assert not expected_results_scratch_path.exists()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from cluv.config import get_config, load_cluv_config
-from cluv.cli.init import check_git, init, JOB_SCRIPT_PATH
+from cluv.config import get_config
+from cluv.cli.init import check_git, init, DEFAULT_RESULTS_PATH, JOB_SCRIPT_PATH
 from milatools.cli.init_command import DRAC_CLUSTERS
 from .utils import write_pyproject
 
@@ -10,6 +10,12 @@ import pytest
 
 TEST_RESULTS_PATH = "test_results"
 
+@pytest.fixture
+def clean_config_cache():
+    """
+    To avoid that a test reads the cached config of an other, we need to clear the cache between each test.
+    """
+    get_config.cache_clear()
 
 class TestInitCommand:
     def test_fail_if_not_under_home(self, tmp_path, monkeypatch) -> None:
@@ -20,7 +26,7 @@ class TestInitCommand:
         with pytest.raises(RuntimeError, match="cluv init should be run in a directory under your home directory."):
             init()
 
-
+    
     def test_generate_default_toml_config(self, tmp_path, monkeypatch) -> None:
         """init() should create a pyproject.toml file with the default configuration if it doesn't exist"""
         monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
@@ -35,6 +41,7 @@ class TestInitCommand:
         assert config.cluster_configs == {"mila": {"UV_OFFLINE": 0, "WANDB_MODE": "online"}}
 
 
+    @pytest.mark.usefixtures("clean_config_cache")
     def test_keep_toml_config(self, tmp_path, monkeypatch) -> None:
         """init() should keep the cluv config of an already existing pyproject.toml"""
         monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
@@ -47,28 +54,30 @@ results_path = "results"
 """)
 
         init()
-        config = load_cluv_config(tmp_path / "pyproject.toml")      # TODO : failed if using get_config() instead of load_cluv_config() here, not sure why (caching issue?)
+        config = get_config()
 
         assert config.results_path == "results"
         assert config.clusters == ["mila"]
 
 
+    @pytest.mark.usefixtures("clean_config_cache")
     def test_results_path_as_none(self, tmp_path, monkeypatch) -> None:
         """init() should skip the job script and symlink creation if the results_path is set to None in the config"""
         monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
         monkeypatch.setattr(cluv.cli.init, "check_git", lambda: None) # Skip git check
         monkeypatch.chdir(tmp_path)
-        
+
         write_pyproject(tmp_path, """
 [tool.cluv]
 clusters = ["mila"]
 """)
-        
+
         init()
-        config = load_cluv_config(tmp_path / "pyproject.toml")
+        config = get_config()
 
         assert config.results_path is None
         assert not (tmp_path / JOB_SCRIPT_PATH).exists()
+        assert not (tmp_path / DEFAULT_RESULTS_PATH).exists()
 
 
 class TestGitCheck:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -43,7 +43,7 @@ class TestInitCommand:
         """init() should keep the cluv config of an already existing pyproject.toml"""
         monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
         monkeypatch.chdir(tmp_path)
-        (tmp_path / ".git").mkdir()     # Add .git dir to pass the git check 
+        (tmp_path / ".git").mkdir()     # Add .git dir to pass the git check
         write_pyproject(tmp_path, """
 [tool.cluv]
 clusters = ["mila"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,21 +1,24 @@
 import os
 
-from cluv.config import get_config
+from cluv.config import get_config, load_cluv_config
 from cluv.cli.init import check_git, init
 from milatools.cli.init_command import DRAC_CLUSTERS
+from .utils import write_pyproject
 
 import pytest
 
+TEST_RESULTS_PATH = "test_results"
+
 class TestInitGitCheck:
-    def test_init_fails_if_not_in_git_repo(self, tmp_path, monkeypatch) -> None:
+    def test_fail_if_not_in_git_repo(self, tmp_path, monkeypatch) -> None:
         """check_git() should raise an error if the current directory is not a git repository"""
         monkeypatch.chdir(tmp_path) # No git project in tmp_path
 
         with pytest.raises(RuntimeError, match="The current project is not a git repository. Try running 'git init' or clone a GitHub project."):
             check_git()
 
-class TestInitCluvConfig:
-    def test_init_fails_if_not_under_home(self, tmp_path, monkeypatch) -> None:
+class TestInitCommand:
+    def test_fail_if_not_under_home(self, tmp_path, monkeypatch) -> None:
         """init() should raise an error if the current directory is not under the user's home directory"""
         monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path
         monkeypatch.chdir(tmp_path.parent) # Move to the parent of tmp_path, which is not under the "home" directory
@@ -23,7 +26,7 @@ class TestInitCluvConfig:
         with pytest.raises(RuntimeError, match="cluv init should be run in a directory under your home directory."):
             init()
 
-    def test_init_generates_toml_default_config(self, tmp_path, monkeypatch) -> None:
+    def test_generate_default_toml_config(self, tmp_path, monkeypatch) -> None:
         """init() should create a pyproject.toml file with the default configuration if it doesn't exist"""
         monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
         monkeypatch.chdir(tmp_path)
@@ -35,3 +38,20 @@ class TestInitCluvConfig:
         assert config.results_path == "logs"
         assert config.slurm == {'UV_OFFLINE': 1, 'WANDB_MODE': 'offline'}
         assert config.cluster_configs == {"mila": {"UV_OFFLINE": 0, "WANDB_MODE": "online"}}
+
+    def test_keep_toml_config(self, tmp_path, monkeypatch) -> None:
+        """init() should keep the cluv config of an already existing pyproject.toml"""
+        monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()     # Add .git dir to pass the git check 
+        write_pyproject(tmp_path, f"""
+[tool.cluv]
+clusters = ["mila"]
+results_path = "results"
+""")
+
+        init()
+        config = load_cluv_config(tmp_path / "pyproject.toml")      # TODO : failed if using get_config() instead of load_cluv_config() here, not sure why (caching issue?)
+
+        assert config.results_path == "results"
+        assert config.clusters == ["mila"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Unit tests for cluv/cli/init.py check functions."""
 
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -54,11 +55,16 @@ class TestCheckCluvConfig:
 
     def test_keep_existing_cluv_config(self, tmp_path) -> None:
         """check_cluv_config() should not overwrite an existing cluv config"""
-        p = write_pyproject(tmp_path, """
-[tool.cluv]
-clusters = ["mila"]
-results_path = "results"
-""")
+        p = write_pyproject(
+            tmp_path,
+            textwrap.dedent(
+                """\
+            [tool.cluv]
+            clusters = ["mila"]
+            results_path = "results"
+            """
+            ),
+        )
 
         results_path = check_cluv_config(p)
         config = load_cluv_config(p)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,13 +9,6 @@ import pytest
 
 TEST_RESULTS_PATH = "test_results"
 
-class TestInitGitCheck:
-    def test_fail_if_not_in_git_repo(self, tmp_path, monkeypatch) -> None:
-        """check_git() should raise an error if the current directory is not a git repository"""
-        monkeypatch.chdir(tmp_path) # No git project in tmp_path
-
-        with pytest.raises(RuntimeError, match="The current project is not a git repository. Try running 'git init' or clone a GitHub project."):
-            check_git()
 
 class TestInitCommand:
     def test_fail_if_not_under_home(self, tmp_path, monkeypatch) -> None:
@@ -25,6 +18,7 @@ class TestInitCommand:
 
         with pytest.raises(RuntimeError, match="cluv init should be run in a directory under your home directory."):
             init()
+
 
     def test_generate_default_toml_config(self, tmp_path, monkeypatch) -> None:
         """init() should create a pyproject.toml file with the default configuration if it doesn't exist"""
@@ -38,6 +32,7 @@ class TestInitCommand:
         assert config.results_path == "logs"
         assert config.slurm == {'UV_OFFLINE': 1, 'WANDB_MODE': 'offline'}
         assert config.cluster_configs == {"mila": {"UV_OFFLINE": 0, "WANDB_MODE": "online"}}
+
 
     def test_keep_toml_config(self, tmp_path, monkeypatch) -> None:
         """init() should keep the cluv config of an already existing pyproject.toml"""
@@ -55,3 +50,13 @@ results_path = "results"
 
         assert config.results_path == "results"
         assert config.clusters == ["mila"]
+
+
+class TestInitGitCheck:
+    def test_fail_if_not_in_git_repo(self, tmp_path, monkeypatch) -> None:
+        """check_git() should raise an error if the current directory is not a git repository"""
+        monkeypatch.chdir(tmp_path) # No git project in tmp_path
+
+        with pytest.raises(RuntimeError, match="The current project is not a git repository. Try running 'git init' or clone a GitHub project."):
+            check_git()
+

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,7 +17,7 @@ class TestInitCluvConfig:
     def test_init_fails_if_not_under_home(self, tmp_path, monkeypatch) -> None:
         """init() should raise an error if the current directory is not under the user's home directory"""
         monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path
-        os.chdir(tmp_path.parent)  # Move to the parent of tmp_path, which is not under the "home" directory
+        monkeypatch.chdir(tmp_path.parent) # Move to the parent of tmp_path, which is not under the "home" directory
         
         with pytest.raises(RuntimeError, match="cluv init should be run in a directory under your home directory."):
             init()
@@ -25,7 +25,7 @@ class TestInitCluvConfig:
     def test_init_generates_toml_default_config(self, tmp_path, monkeypatch) -> None:
         """init() should create a pyproject.toml file with the default configuration if it doesn't exist"""
         monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
-        os.chdir(tmp_path)
+        monkeypatch.chdir(tmp_path)
 
         init()
         config = get_config()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -44,7 +44,7 @@ class TestInitCommand:
         monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".git").mkdir()     # Add .git dir to pass the git check 
-        write_pyproject(tmp_path, f"""
+        write_pyproject(tmp_path, """
 [tool.cluv]
 clusters = ["mila"]
 results_path = "results"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,36 @@
+import os
+
+from cluv.config import get_config
+from cluv.cli.init import check_git, init
+from milatools.cli.init_command import DRAC_CLUSTERS
+
+import pytest
+
+class TestInitGitCheck:
+    def test_init_fails_if_not_in_git_repo(self, tmp_path) -> None:
+        """check_git() should raise an error if the current directory is not a git repository"""
+        os.chdir(tmp_path)
+        with pytest.raises(RuntimeError, match="The current project is not a git repository. Try running 'git init' or clone a GitHub project."):
+            check_git()
+
+class TestInitCluvConfig:
+    def test_init_fails_if_not_under_home(self, tmp_path, monkeypatch) -> None:
+        """init() should raise an error if the current directory is not under the user's home directory"""
+        monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path
+        os.chdir(tmp_path.parent)  # Move to the parent of tmp_path, which is not under the "home" directory
+        
+        with pytest.raises(RuntimeError, match="cluv init should be run in a directory under your home directory."):
+            init()
+
+    def test_init_generates_toml_default_config(self, tmp_path, monkeypatch) -> None:
+        """init() should create a pyproject.toml file with the default configuration if it doesn't exist"""
+        monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
+        os.chdir(tmp_path)
+
+        init()
+        config = get_config()
+
+        assert config.clusters == ["mila"] + DRAC_CLUSTERS
+        assert config.results_path == "logs"
+        assert config.slurm == {'UV_OFFLINE': 1, 'WANDB_MODE': 'offline'}
+        assert config.cluster_configs == {"mila": {"UV_OFFLINE": 0, "WANDB_MODE": "online"}}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,9 +7,9 @@ from milatools.cli.init_command import DRAC_CLUSTERS
 import pytest
 
 class TestInitGitCheck:
-    def test_init_fails_if_not_in_git_repo(self, tmp_path) -> None:
+    def test_init_fails_if_not_in_git_repo(self, tmp_path, monkeypatch) -> None:
         """check_git() should raise an error if the current directory is not a git repository"""
-        os.chdir(tmp_path)
+        monkeypatch.chdir(tmp_path) # No git project in tmp_path
         with pytest.raises(RuntimeError, match="The current project is not a git repository. Try running 'git init' or clone a GitHub project."):
             check_git()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,7 +20,7 @@ from .utils import write_pyproject
 
 
 class TestCheckHomeDir:
-    def test_not_under_home(self, tmp_path, monkeypatch) -> None:
+    def test_not_under_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """check_home_dir() should raise an error if the current directory is not under the user's home directory"""
         monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path
         monkeypatch.chdir(tmp_path.parent) # Set the current work dir to the parent of tmp_path, which is not under the "home" directory
@@ -30,7 +30,7 @@ class TestCheckHomeDir:
 
 
 class TestGitCheck:
-    def test_not_in_git_repo(self, tmp_path, monkeypatch) -> None:
+    def test_not_in_git_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """check_git() should raise an error if the current directory is not a git repository"""
         monkeypatch.chdir(tmp_path) # Set the working dir to tmp_path
 
@@ -39,7 +39,7 @@ class TestGitCheck:
 
 
 class TestCheckCluvConfig:
-    def test_add_missing_cluv_config(self, tmp_path) -> None:
+    def test_add_missing_cluv_config(self, tmp_path: Path) -> None:
         """check_cluv_config() should add a cluv config section if the toml doesn't have it"""
         p = write_pyproject(tmp_path, "")
 
@@ -52,8 +52,7 @@ class TestCheckCluvConfig:
         assert config.slurm == {'UV_OFFLINE': 1, 'WANDB_MODE': 'offline'}
         assert config.cluster_configs == {"mila": {"UV_OFFLINE": 0, "WANDB_MODE": "online"}}
 
-
-    def test_keep_existing_cluv_config(self, tmp_path) -> None:
+    def test_keep_existing_cluv_config(self, tmp_path: Path) -> None:
         """check_cluv_config() should not overwrite an existing cluv config"""
         p = write_pyproject(
             tmp_path,
@@ -105,8 +104,7 @@ class TestSymlinkCheck():
         assert expected_results_scratch_path.exists()
         assert expected_results_path.resolve() == expected_results_scratch_path.resolve()
 
-
-    def test_keep_existing_symlink(self, tmp_path, monkeypatch) -> None:
+    def test_keep_existing_symlink(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """check_symlink_to_scratch() should not overwrite an existing symlink not pointing to scratch"""
         scratch_path = tmp_path / "scratch"
         monkeypatch.setenv("SCRATCH", str(scratch_path))
@@ -123,14 +121,14 @@ class TestSymlinkCheck():
 
 
 class TestJobScriptCheck:
-    def test_no_job_script_if_results_path_is_none(self, tmp_path) -> None:
+    def test_no_job_script_if_results_path_is_none(self, tmp_path: Path) -> None:
         """check_job_script() should not create a job script if the results_path is None"""
 
         check_job_script(tmp_path, None)
 
         assert not (tmp_path / JOB_SCRIPT_PATH).exists()
 
-    def test_keep_existing_job_script(self, tmp_path) -> None:
+    def test_keep_existing_job_script(self, tmp_path: Path) -> None:
         """check_job_script() should not overwrite an existing job script"""
         job_script_path = tmp_path / JOB_SCRIPT_PATH
         job_script_path.parent.mkdir(exist_ok=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,10 +1,11 @@
-import os
+from pathlib import Path
 
 from cluv.config import get_config, load_cluv_config
-from cluv.cli.init import check_git, init
+from cluv.cli.init import check_git, init, JOB_SCRIPT_PATH
 from milatools.cli.init_command import DRAC_CLUSTERS
 from .utils import write_pyproject
 
+import cluv.cli.init
 import pytest
 
 TEST_RESULTS_PATH = "test_results"
@@ -13,7 +14,7 @@ TEST_RESULTS_PATH = "test_results"
 class TestInitCommand:
     def test_fail_if_not_under_home(self, tmp_path, monkeypatch) -> None:
         """init() should raise an error if the current directory is not under the user's home directory"""
-        monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path
+        monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path
         monkeypatch.chdir(tmp_path.parent) # Move to the parent of tmp_path, which is not under the "home" directory
 
         with pytest.raises(RuntimeError, match="cluv init should be run in a directory under your home directory."):
@@ -22,7 +23,7 @@ class TestInitCommand:
 
     def test_generate_default_toml_config(self, tmp_path, monkeypatch) -> None:
         """init() should create a pyproject.toml file with the default configuration if it doesn't exist"""
-        monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
+        monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
         monkeypatch.chdir(tmp_path)
 
         init()
@@ -36,9 +37,9 @@ class TestInitCommand:
 
     def test_keep_toml_config(self, tmp_path, monkeypatch) -> None:
         """init() should keep the cluv config of an already existing pyproject.toml"""
-        monkeypatch.setattr(os.path, "expanduser", lambda _: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
+        monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
+        monkeypatch.setattr(cluv.cli.init, "check_git", lambda: None) # Skip git check
         monkeypatch.chdir(tmp_path)
-        (tmp_path / ".git").mkdir()     # Add .git dir to pass the git check
         write_pyproject(tmp_path, """
 [tool.cluv]
 clusters = ["mila"]
@@ -52,11 +53,29 @@ results_path = "results"
         assert config.clusters == ["mila"]
 
 
-class TestInitGitCheck:
+    def test_results_path_as_none(self, tmp_path, monkeypatch) -> None:
+        """init() should skip the job script and symlink creation if the results_path is set to None in the config"""
+        monkeypatch.setattr(Path, "home", lambda: str(tmp_path)) # Set the home directory to tmp_path to pass the home check
+        monkeypatch.setattr(cluv.cli.init, "check_git", lambda: None) # Skip git check
+        monkeypatch.chdir(tmp_path)
+        
+        write_pyproject(tmp_path, """
+[tool.cluv]
+clusters = ["mila"]
+""")
+        
+        init()
+        config = load_cluv_config(tmp_path / "pyproject.toml")
+
+        assert config.results_path is None
+        assert not (tmp_path / JOB_SCRIPT_PATH).exists()
+
+
+class TestGitCheck:
     def test_fail_if_not_in_git_repo(self, tmp_path, monkeypatch) -> None:
         """check_git() should raise an error if the current directory is not a git repository"""
         monkeypatch.chdir(tmp_path) # No git project in tmp_path
 
-        with pytest.raises(RuntimeError, match="The current project is not a git repository. Try running 'git init' or clone a GitHub project."):
+        with pytest.raises(RuntimeError, match="Error when checking git remote: "):
             check_git()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,7 +11,9 @@ from cluv.cli.init import (
     check_git,
     check_cluv_config,
     check_symlink_to_scratch,
-    DEFAULT_RESULTS_PATH
+    check_job_script,
+    DEFAULT_RESULTS_PATH,
+    JOB_SCRIPT_PATH
 )
 from .utils import write_pyproject
 
@@ -65,7 +67,7 @@ results_path = "results"
         assert config.clusters == ["mila"]
         assert config.results_path == "results"
 
-
+# TODO : fixture to set environment variables ?
 class TestSymlinkCheck():
     def test_no_symlink_if_results_path_is_none(self, tmp_path) -> None:
         """check_symlink_to_scratch() should not create a symlink if the results_path is None"""
@@ -96,3 +98,42 @@ class TestSymlinkCheck():
         assert expected_results_path.is_symlink()
         assert expected_results_scratch_path.exists()
         assert expected_results_path.resolve() == expected_results_scratch_path.resolve()
+
+
+    def test_keep_existing_symlink(self, tmp_path, monkeypatch) -> None:
+        """check_symlink_to_scratch() should not overwrite an existing symlink not pointing to scratch"""
+        scratch_path = tmp_path / "scratch"
+        monkeypatch.setenv("SCRATCH", str(scratch_path))
+        expected_results_path = tmp_path / DEFAULT_RESULTS_PATH
+        expected_results_scratch_path = scratch_path / DEFAULT_RESULTS_PATH / tmp_path.name
+
+        # Create a symlink pointing to the wrong location
+        expected_results_path.symlink_to(tmp_path / "some_other_folder")
+
+        check_symlink_to_scratch(tmp_path, DEFAULT_RESULTS_PATH)
+
+        # The original symlink should be kept, and not changed to point to scratch
+        assert expected_results_path.exists()
+        assert expected_results_path.is_symlink()
+        assert expected_results_path.resolve() == (tmp_path / "some_other_folder").resolve()
+        assert not expected_results_scratch_path.exists()
+
+
+class TestJobScriptCheck:
+    def test_no_job_script_if_results_path_is_none(self, tmp_path) -> None:
+        """check_job_script() should not create a job script if the results_path is None"""
+
+        check_job_script(tmp_path, None)
+
+        assert not (tmp_path / JOB_SCRIPT_PATH).exists()
+
+    def test_keep_existing_job_script(self, tmp_path) -> None:
+        """check_job_script() should not overwrite an existing job script"""
+        job_script_path = tmp_path / JOB_SCRIPT_PATH
+        job_script_path.parent.mkdir(exist_ok=True)
+        job_script_path.write_text("#!/bin/bash\necho 'Hello world!'")
+
+        check_job_script(tmp_path, DEFAULT_RESULTS_PATH)
+
+        assert job_script_path.exists()
+        assert job_script_path.read_text() == "#!/bin/bash\necho 'Hello world!'"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,8 @@ efficient, since at some point there might be like 10 different clusters, and 10
 import os
 
 import milatools.cli.init_command
+import stat
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -174,7 +176,7 @@ def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[True, False], ids=["with_scratch", "without_scratch"])
 def scratch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
 ) -> Path | None:
@@ -190,16 +192,42 @@ def scratch(
     return None
 
 
+@pytest.fixture
+def project_name(request: pytest.FixtureRequest) -> str:
+    return getattr(request, "param", "my_project")
+
+
+@pytest.fixture(params=[True, False], ids=["existing_project", "new_project"])
+def is_existing_project(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+@pytest.fixture
+def project_dir(fake_home: Path, project_name: str, is_existing_project: bool) -> Path:
+    """Fixture that creates a project directory and changes into it."""
+    project_dir = fake_home / project_name
+    project_dir.mkdir()
+    if is_existing_project:
+        subprocess.run(f"uv init {project_dir}", shell=True, check=True)
+        job_script = project_dir / "scripts" / "job.sh"
+        job_script.parent.mkdir(exist_ok=False, parents=True)
+        job_script.touch()  # Touch the job script to simulate an existing project
+        # Make the job script executable:
+        job_script.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+    return project_dir
+
+
 @pytest.mark.timeout(5)
-def test_init_empty_folder(
-    fake_home: Path, scratch: Path | None, monkeypatch: pytest.MonkeyPatch
+def test_init(
+    project_dir: Path,
+    project_name: str,
+    scratch: Path | None,
+    is_existing_project: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that cluv init creates the expected files and directories."""
     from cluv.cli.init import DEFAULT_RESULTS_PATH, DRAC_CLUSTERS, init
 
-    project_name = "my_project"
-    project_dir = fake_home / project_name
-    project_dir.mkdir()
     monkeypatch.chdir(project_dir)
 
     init()
@@ -208,6 +236,15 @@ def test_init_empty_folder(
     assert generated_config.results_path == DEFAULT_RESULTS_PATH
     assert (project_dir / "scripts").is_dir()
     assert (project_dir / "scripts" / "job.sh").is_file()
+
+    job_script = project_dir / "scripts" / "job.sh"
+    if is_existing_project:
+        assert job_script.read_text() == "", "cluv init overwrote the job script!"
+    else:
+        # TODO: The created job script should be executable!
+        with pytest.raises(AssertionError):
+            assert job_script.stat().st_mode & stat.S_IXUSR, "Job script is not executable!"
+
     if scratch:
         assert (project_dir / generated_config.results_path).exists()
         assert (project_dir / generated_config.results_path).is_symlink()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,8 @@ efficient, since at some point there might be like 10 different clusters, and 10
 import os
 
 import milatools.cli.init_command
+from pathlib import Path
+
 import pytest
 import pytest_asyncio
 
@@ -16,6 +18,7 @@ from cluv.cli.login import get_remote_without_2fa_prompt, login
 from cluv.cli.status import ClusterStatus, get_real_cluster_status
 from cluv.cli.submit import submit
 from cluv.remote import Remote, control_socket_is_running
+from cluv.config import load_cluv_config
 
 # Some useful constants used to turn tests on and off depending on where we are.
 IN_GITHUB_CI = "GITHUB_ACTIONS" in os.environ
@@ -163,3 +166,53 @@ async def test_submit(remote: Remote):
         assert job_name.strip().startswith("cluv-")
     finally:
         await remote.run(f"scancel {job_id}")
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)  # Set the home directory to tmp_path
+    return tmp_path
+
+
+@pytest.fixture(params=[True, False])
+def scratch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
+) -> Path | None:
+    """Fixture that sets up a fake SCRATCH directory if requested, or pretends that SCRATCH doesn't exist otherwise."""
+    use_scratch = request.param
+    if use_scratch:
+        fake_scratch_dir = tmp_path / "fake_scratch"
+        monkeypatch.setenv("SCRATCH", str(fake_scratch_dir))  # Set the SCRATCH env var to tmp_path
+        return fake_scratch_dir
+    if "SCRATCH" in os.environ:
+        # Remove the SCRATCH environment variable
+        monkeypatch.delenv("SCRATCH")
+    return None
+
+
+@pytest.mark.timeout(5)
+def test_init_empty_folder(
+    fake_home: Path, scratch: Path | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that cluv init creates the expected files and directories."""
+    from cluv.cli.init import DEFAULT_RESULTS_PATH, DRAC_CLUSTERS, init
+
+    project_name = "my_project"
+    project_dir = fake_home / project_name
+    project_dir.mkdir()
+    monkeypatch.chdir(project_dir)
+
+    init()
+
+    generated_config = load_cluv_config(project_dir / "pyproject.toml")
+    assert generated_config.results_path == DEFAULT_RESULTS_PATH
+    assert (project_dir / "scripts").is_dir()
+    assert (project_dir / "scripts" / "job.sh").is_file()
+    if scratch:
+        assert (project_dir / generated_config.results_path).exists()
+        assert (project_dir / generated_config.results_path).is_symlink()
+        assert (
+            project_dir / generated_config.results_path
+        ).resolve() == scratch / DEFAULT_RESULTS_PATH / project_name
+
+    assert generated_config.clusters == ["mila"] + DRAC_CLUSTERS

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,6 +17,7 @@ import pytest
 import pytest_asyncio
 
 from cluv.cli.login import get_remote_without_2fa_prompt, login
+from cluv.cli.init import DEFAULT_RESULTS_PATH, DRAC_CLUSTERS, init
 from cluv.cli.status import ClusterStatus, get_real_cluster_status
 from cluv.cli.submit import submit
 from cluv.remote import Remote, control_socket_is_running
@@ -225,8 +226,6 @@ def test_init(
     is_existing_project: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that cluv init creates the expected files and directories."""
-    from cluv.cli.init import DEFAULT_RESULTS_PATH, DRAC_CLUSTERS, init
 
     monkeypatch.chdir(project_dir)
 
@@ -253,3 +252,10 @@ def test_init(
         ).resolve() == scratch / DEFAULT_RESULTS_PATH / project_name
 
     assert generated_config.clusters == ["mila"] + DRAC_CLUSTERS
+
+
+@pytest.mark.timeout(5)
+def test_init_twice_doesnt_raise(project_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(project_dir)
+    init()
+    init()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,4 @@
+def write_pyproject(tmp_path, content: str):
+    p = tmp_path / "pyproject.toml"
+    p.write_text(content)
+    return p


### PR DESCRIPTION
## Summary
* Add implementation for command `cluv` init :
   1. Check if the project is inside the `$HOME` dir.
   2. Try to run `uv init` to generate a default python project. This step is skipped if a `pyproject.toml` file already exists.
   3. Warns the user if no git remote is configured (required for futur commands)
   4. Add a default `[tool.cluv]` config for the clusters if no config exists.
   5. Check the project structure (slurm template script, symlink between `$HOME` and `$SCRATCH`,...)
* Regroup `add_*_args` functions in `__main__.py` and also remove calls to `get_config` before the selection of the subcommand.
* Update README with more infos on `Configuration` and `Commands` sections.
* Update `SKILL.md`.