### PR TITLE
Validate that each cluster in the config has a corresponding SSH hostname when using `cluv init`

### DIFF
--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -6,6 +6,7 @@ from milatools.cli.init_command import DRAC_CLUSTERS
 
 from cluv.config import find_pyproject, has_cluv_config, load_cluv_config
 from cluv.utils import console
+from cluv.ssh import get_ssh_hostnames
 
 JOB_SCRIPT_PATH = "scripts/job.sh"
 DEFAULT_RESULTS_PATH = "logs"
@@ -55,6 +56,7 @@ def init() -> None:
     # If it doesn't exist, add a cluv config section with the default settings and clusters.
     check_cluv_config(pyproject_path)
     config = load_cluv_config(pyproject_path)
+    check_ssh_hostnames(config.clusters)
 
     # Check if project structure is correct
     console.print()
@@ -182,6 +184,21 @@ def check_symlink_to_scratch(project_root: Path, results_path: str | None) -> No
         console.print(f"Creating symlink from {symlink_path} to {scratch_path}")
         scratch_path.mkdir(parents=True, exist_ok=True)
         symlink_path.symlink_to(scratch_path, target_is_directory=True)
+
+
+def check_ssh_hostnames(clusters: list[str]) -> None:
+    """
+    Check if the names of the clusters in the cluv config are present in the SSH config file. If not, print a warning.
+    """
+    ssh_hostnames = get_ssh_hostnames()
+    missing_clusters = set(clusters).difference(ssh_hostnames)
+
+    if len(missing_clusters) > 0:
+        console.print(f"[yellow]⚠️  Warning: Missing SSH config for {len(missing_clusters)} clusters. Try to run [bold]mila init[/bold] to add all available clusters.[/yellow]")
+        for cluster in missing_clusters:
+            console.print(f"[yellow]    - {cluster}[/yellow]")
+    else:
+        console.print("[green]✅ All clusters in the cluv config are present in your SSH config.[/green]")
 
 
 def check_job_script(project_root: Path, results_path: str | None) -> None:

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -53,17 +53,18 @@ def init() -> None:
     pyproject_path = find_pyproject()
 
     # If it doesn't exist, add a cluv config section with the default settings and clusters.
-    results_path = check_cluv_config(pyproject_path)
+    check_cluv_config(pyproject_path)
+    config = load_cluv_config(pyproject_path)
 
     # Check if project structure is correct
     console.print()
     console.print("Validating project structure...")
 
     # Check if the job script exists
-    check_job_script(pyproject_path.parent, results_path)
+    check_job_script(pyproject_path.parent, config.results_path)
 
     # Check if the results path is correctly symlinked to scratch
-    check_symlink_to_scratch(pyproject_path.parent, results_path)
+    check_symlink_to_scratch(pyproject_path.parent, config.results_path)
 
     # Show what the user can do next after the project setup
     console.print()
@@ -99,16 +100,14 @@ def run_uv_init() -> None:
         console.print("[green]✅ uv: project initialized.[/green]")
 
 
-def check_cluv_config(pyproject_path: Path) -> str | None:
+def check_cluv_config(pyproject_path: Path) -> None:
     """
     Check if the pyproject.toml file contains a cluv config.
     If not, add a default config section with the default clusters and settings.
     """
     if has_cluv_config(pyproject_path):
         console.print("[green]✅ Project already have a cluv config in pyproject.toml.[/green]")
-        config = load_cluv_config(pyproject_path)
-        console.print(config)
-        return config.results_path
+        return
 
     console.print("No config found for [bold]cluv[/bold] in the pyproject.toml file. Adding config...")
     console.print("Adding config for cluv tool :")
@@ -118,8 +117,6 @@ def check_cluv_config(pyproject_path: Path) -> str | None:
     add_cluv_cluster_config("mila", pyproject_path, CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS)
     for cluster in DRAC_CLUSTERS:
         add_cluv_cluster_config(cluster, pyproject_path)
-
-    return DEFAULT_RESULTS_PATH
 
 
 def add_cluv_config_section(pyproject_path: Path, section_lines: list[str]) -> None:

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -10,13 +10,12 @@ from cluv.ssh import get_ssh_hostnames
 
 JOB_SCRIPT_PATH = "scripts/job.sh"
 DEFAULT_RESULTS_PATH = "logs"
+CONFIG_SEPARATOR = [""]
 
 CLUV_DEFAULT_CONFIG = [
     "[tool.cluv]",
-    f'results_path = "{DEFAULT_RESULTS_PATH}"'
-]
-
-CLUV_SLURM_DEFAULT_CONFIG = [
+    f'results_path = "{DEFAULT_RESULTS_PATH}"',
+    "",
     "[tool.cluv.slurm]",
     "# Environment variables applied when using Slurm commands on all clusters.",
     "UV_OFFLINE = 1",
@@ -114,11 +113,11 @@ def check_cluv_config(pyproject_path: Path) -> None:
     console.print("No config found for [bold]cluv[/bold] in the pyproject.toml file. Adding config...")
     console.print("Adding config for cluv tool :")
 
-    add_cluv_config_section(pyproject_path, CLUV_DEFAULT_CONFIG)
-    add_cluv_config_section(pyproject_path, CLUV_SLURM_DEFAULT_CONFIG)
-    add_cluv_cluster_config("mila", pyproject_path, CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS)
+    cluv_config = CLUV_DEFAULT_CONFIG
+    cluv_config += CONFIG_SEPARATOR + generate_cluster_config("mila", CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS)
     for cluster in DRAC_CLUSTERS:
-        add_cluv_cluster_config(cluster, pyproject_path)
+        cluv_config += CONFIG_SEPARATOR + generate_cluster_config(cluster)
+    add_cluv_config_section(pyproject_path, cluv_config)
 
 
 def add_cluv_config_section(pyproject_path: Path, section_lines: list[str]) -> None:
@@ -130,15 +129,11 @@ def add_cluv_config_section(pyproject_path: Path, section_lines: list[str]) -> N
         f.write("\n" + "\n".join(section_lines) + "\n")
 
 
-def add_cluv_cluster_config(cluster: str, pyproject_path: Path, config_lines: list[str] = []) -> None:
+def generate_cluster_config(cluster: str, config_lines: list[str] = []) -> list[str]:
     """
-    Add a cluster config section for the given cluster to the pyproject.toml file, with the given variables.
+    Generate a cluster config section for the given cluster, with the given variables.
     """
-    console.print(f"Adding config for cluster [bold]{cluster}[/bold] :")
-    section_lines = [f"[tool.cluv.clusters.{cluster}]"] + config_lines
-    console.log(("\n" + "\n".join(section_lines) + "\n").replace("[", "\\["))
-    with pyproject_path.open("a") as f:
-        f.write("\n" + "\n".join(section_lines) + "\n")
+    return[f"[tool.cluv.clusters.{cluster}]"] + config_lines
 
 
 def check_git() -> None:

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
+import textwrap
 
 from milatools.cli.init_command import DRAC_CLUSTERS
 
@@ -10,17 +11,17 @@ from cluv.ssh import get_ssh_hostnames
 
 JOB_SCRIPT_PATH = "scripts/job.sh"
 DEFAULT_RESULTS_PATH = "logs"
-CONFIG_SEPARATOR = [""]
 
-CLUV_DEFAULT_CONFIG = [
-    "[tool.cluv]",
-    f'results_path = "{DEFAULT_RESULTS_PATH}"',
-    "",
-    "[tool.cluv.slurm]",
-    "# Environment variables applied when using Slurm commands on all clusters.",
-    "UV_OFFLINE = 1",
-    'WANDB_MODE = "offline"',
-]
+CLUV_DEFAULT_CONFIG = textwrap.dedent(f"""\
+    [tool.cluv]
+    results_path = "{DEFAULT_RESULTS_PATH}"
+
+    [tool.cluv.slurm]
+    # Environment variables applied when using Slurm commands on all clusters.
+    UV_OFFLINE = 1
+    WANDB_MODE = "offline"
+    """
+)
 
 CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS = [
     "UV_OFFLINE = 0",
@@ -55,6 +56,8 @@ def init() -> None:
     # If it doesn't exist, add a cluv config section with the default settings and clusters.
     check_cluv_config(pyproject_path)
     config = load_cluv_config(pyproject_path)
+
+    # Compare the cluster names in the config to the SSH hostnames.
     check_ssh_hostnames(config.clusters)
 
     # Check if project structure is correct
@@ -114,26 +117,26 @@ def check_cluv_config(pyproject_path: Path) -> None:
     console.print("Adding config for cluv tool :")
 
     cluv_config = CLUV_DEFAULT_CONFIG
-    cluv_config += CONFIG_SEPARATOR + generate_cluster_config("mila", CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS)
+    cluv_config += generate_cluster_config("mila", CLUV_CLUSTER_MILA_DEFAULT_ARGUMENTS)
     for cluster in DRAC_CLUSTERS:
-        cluv_config += CONFIG_SEPARATOR + generate_cluster_config(cluster)
+        cluv_config += generate_cluster_config(cluster)
     add_cluv_config_section(pyproject_path, cluv_config)
 
 
-def add_cluv_config_section(pyproject_path: Path, section_lines: list[str]) -> None:
+def add_cluv_config_section(pyproject_path: Path, section_lines: str) -> None:
     """
     Write the given lines to the pyproject.toml file.
     """
-    console.log(("\n" + "\n".join(section_lines) + "\n").replace("[", "\\["))
+    console.log("\n" + section_lines.replace("[", "\\["))
     with pyproject_path.open("a") as f:
-        f.write("\n" + "\n".join(section_lines) + "\n")
+        f.write("\n" + section_lines)
 
 
-def generate_cluster_config(cluster: str, config_lines: list[str] = []) -> list[str]:
+def generate_cluster_config(cluster: str, config_lines: list[str] = []) -> str:
     """
     Generate a cluster config section for the given cluster, with the given variables.
     """
-    return[f"[tool.cluv.clusters.{cluster}]"] + config_lines
+    return f"\n[tool.cluv.clusters.{cluster}]\n" + "\n".join(config_lines) + ("\n" if len(config_lines) > 0 else "")
 
 
 def check_git() -> None:

--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -109,22 +109,23 @@ async def sync_task_function(
     num_tasks = 4 if config.results_path else 3
 
     _update_progress(0, "Checking/Installing UV", num_tasks)
-    await install_uv([remote])
+    await install_uv(remote)
 
     _update_progress(1, "Setting up project", num_tasks)
-    await clone_project([remote], project_path)
+    await clone_project(remote, project_path)
 
     _update_progress(2, "Running 'uv sync'", num_tasks)
     await remote.run(f"bash -l -c 'uv --directory={project_path} sync --quiet'")
 
     if config.results_path:
         _update_progress(3, "Fetching results", num_tasks)
-        await fetch_results([remote], config.results_path)
+        await fetch_results(remote, config.results_path)
 
     _update_progress(num_tasks, "Done", num_tasks)
 
 
-async def install_uv(remotes: list[Remote]):
+async def install_uv(remote: Remote):
+    # todo: These parts are common. No need to do them for each cluster. Not a big deal though.
     if not shutil.which("uv"):
         logger.error(
             "`uv` is not installed on this machine. Please install `uv` to ensure it's installed on the remote clusters as well."
@@ -141,50 +142,23 @@ async def install_uv(remotes: list[Remote]):
         f"[green]Using uv version {uv_version_here} everywhere, since this is the version on this machine.[/green]"
     )
 
-    uv_paths = await asyncio.gather(
-        *(
-            remote.get_output("bash -l -c 'which uv'", warn=True, hide=True, display=False)
-            for remote in remotes
-        )
-    )
-    uv_paths = [uv_path.strip() for uv_path in uv_paths]
-    clusters_without_uv = [
-        remote.hostname for remote, uv_path in zip(remotes, uv_paths) if not uv_path
-    ]
-    if clusters_without_uv:
-        logger.info(f"Installing uv on the following clusters: {clusters_without_uv}")
-    await asyncio.gather(
-        *(
-            remote.run("curl -LsSf https://astral.sh/uv/install.sh | sh")
-            for remote in remotes
-            if remote.hostname in clusters_without_uv
-        )
-    )
-    uv_versions = await asyncio.gather(
-        *(
-            remote.get_output("bash -l -c 'uv --version'", hide=True, display=False)
-            for remote in remotes
-        )
-    )
-    uv_versions = [uv_version.strip().split()[1] for uv_version in uv_versions]
-    remotes_with_different_uv_versions = [
-        remote
-        for remote, version in zip(remotes, uv_versions)
-        if version.strip() != uv_version_here
-    ]
-    if remotes_with_different_uv_versions:
-        logger.info(
-            f"Updating uv to version {uv_version_here} on the following clusters: {[remote.hostname for remote in remotes_with_different_uv_versions]}"
-        )
-        await asyncio.gather(
-            *(
-                remote.run(f"bash -l -c 'uv self update {uv_version_here}'", hide=True)
-                for remote in remotes_with_different_uv_versions
-            )
-        )
+    uv_path = await remote.get_output("bash -l -c 'which uv'", warn=True, hide=True, display=False)
+    uv_path = uv_path.strip()
+    cluster_doesnt_have_uv = not uv_path
+    if cluster_doesnt_have_uv:
+        logger.info(f"Installing uv on {remote.hostname}.")
+        await remote.run("curl -LsSf https://astral.sh/uv/install.sh | sh")
+
+    uv_version = await remote.get_output("bash -l -c 'uv --version'", hide=True, display=False)
+    uv_version = uv_version.strip().split()[1]
+
+    uv_version_is_different = uv_version.strip() != uv_version_here
+    if uv_version_is_different:
+        logger.info(f"Updating uv to version {uv_version_here} on the {remote.hostname} cluster.")
+        await remote.run(f"bash -l -c 'uv self update {uv_version_here}'", hide=True)
 
 
-async def clone_project(remotes: list[Remote], project_path: PurePosixPath):
+async def clone_project(remote: Remote, project_path: PurePosixPath):
     """Setup the project repo on all the remote clusters.
 
     New idea:
@@ -192,6 +166,8 @@ async def clone_project(remotes: list[Remote], project_path: PurePosixPath):
     - Worry about authentication later, just raise an error if need be for now.
 
     """
+    # TODO: This git info is shared, but currently repeatedly executed for each cluster.
+    # Could be done only once.
     current_git_branch = subprocess.getoutput("git rev-parse --abbrev-ref HEAD").strip()
     git_remote_name = subprocess.getoutput(
         f"git config --get branch.{current_git_branch}.remote"
@@ -203,55 +179,24 @@ async def clone_project(remotes: list[Remote], project_path: PurePosixPath):
     # TODO: Scp the ~/.git-credentials file if needed?
     # Or configure the config credential-helper to store first?
 
-    # For each cluster where the project isn't cloned yet, clone it.
-    _clusters_without_clones_result = await asyncio.gather(
-        *(
-            remote.run(
-                f"test -d {project_path}",
-                warn=True,
-                hide=True,
-                display=False,
-            )
-            for remote in remotes
+    # If the project isn't cloned yet, clone it.
+    _is_cloned_on_cluster = (
+        await remote.run(
+            f"test -d {project_path}",
+            warn=True,
+            hide=True,
+            display=False,
         )
-    )
-    clusters_without_clones = [
-        remote
-        for remote, result in zip(remotes, _clusters_without_clones_result)
-        if result.returncode != 0
-    ]
-    logger.debug(
-        f"Clusters where the project isn't cloned yet: {[remote.hostname for remote in clusters_without_clones]}   "
-    )
-    await asyncio.gather(
-        *(
-            remote.run(f"git clone {github_repo_url} {project_path}", hide=True)
-            for remote in clusters_without_clones
-        )
-    )
-
-    await asyncio.gather(
-        *(
-            remote.run(f"git -C {project_path} fetch --all --prune", hide=True)
-            for remote in remotes
-        )
-    )
-
-    # TODO: Look into why the command still has the Controlpath explicitly there, even if the ssh config already has it.
-    await asyncio.gather(
-        *(
-            remote.run(
-                f"git -C {project_path} checkout {current_git_branch}",
-                # warn=True,
-                hide=False,
-            )
-            for remote in remotes
-        )
-    )
-    await asyncio.gather(*(remote.run(f"git -C {project_path} pull") for remote in remotes))
+    ).returncode == 0
+    if not _is_cloned_on_cluster:
+        logger.debug(f"Project isn't cloned yet on {remote.hostname}.")
+    await remote.run(f"git clone {github_repo_url} {project_path}", hide=True)
+    await remote.run(f"git -C {project_path} fetch --all --prune", hide=True)
+    await remote.run(f"git -C {project_path} checkout {current_git_branch}", hide=False)
+    await remote.run(f"git -C {project_path} pull")
 
 
-async def fetch_results(remotes: list[Remote], results_path: Path | str):
+async def fetch_results(remote: Remote, results_path: Path | str):
     """Fetches results from all remote clusters to the current (mila for now) cluster using rsync."""
     results_path = Path(results_path)
     assert not results_path.is_absolute()
@@ -269,32 +214,24 @@ async def fetch_results(remotes: list[Remote], results_path: Path | str):
 
     results_path.mkdir(parents=True, exist_ok=True)
 
-    await asyncio.gather(
-        *(create_results_dir_with_symlink_to_scratch(remote, results_path) for remote in remotes)
-    )
-
-    await asyncio.gather(
-        *(
-            run(
-                # Using --full-form flags (not -avz) for better readability.
-                (
-                    "rsync",
-                    "--archive",
-                    "--verbose",
-                    "--compress",
-                    "--copy-links",
-                    f"{remote.hostname}:{results_path_relative_to_home}",
-                    str((Path.home() / results_path_relative_to_home).parent),
-                    # shlex.split(
-                    #     f"rsync --archive --verbose --compress --copy-links "
-                    #     f"{remote.hostname}:{results_path_relative_to_home} {(Path.home() / results_path_relative_to_home).parent}"
-                    # )
-                ),
-                warn=True,
-                hide=False,
-            )
-            for remote in remotes
-        )
+    await create_results_dir_with_symlink_to_scratch(remote, results_path)
+    await run(
+        # Using --full-form flags (not -avz) for better readability.
+        (
+            "rsync",
+            "--archive",
+            "--verbose",
+            "--compress",
+            "--copy-links",
+            f"{remote.hostname}:{results_path_relative_to_home}",
+            str((Path.home() / results_path_relative_to_home).parent),
+            # shlex.split(
+            #     f"rsync --archive --verbose --compress --copy-links "
+            #     f"{remote.hostname}:{results_path_relative_to_home} {(Path.home() / results_path_relative_to_home).parent}"
+            # )
+        ),
+        warn=True,
+        hide=False,
     )
 
 

--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -112,7 +112,7 @@ async def sync_task_function(
     await install_uv(remote)
 
     _update_progress(1, "Setting up project", num_tasks)
-    await clone_project(remote, project_path)
+    await clone_project(remote)
 
     _update_progress(2, "Running 'uv sync'", num_tasks)
     await remote.run(f"bash -l -c 'uv --directory={project_path} sync --quiet'")
@@ -158,13 +158,12 @@ async def install_uv(remote: Remote):
         await remote.run(f"bash -l -c 'uv self update {uv_version_here}'", hide=True)
 
 
-async def clone_project(remote: Remote, project_path: PurePosixPath):
+async def clone_project(remote: Remote):
     """Setup the project repo on all the remote clusters.
 
     New idea:
     - Assume GitHub. Push to GitHub if needed. Clone from github on the remotes.
     - Worry about authentication later, just raise an error if need be for now.
-
     """
     # TODO: This git info is shared, but currently repeatedly executed for each cluster.
     # Could be done only once.
@@ -179,10 +178,13 @@ async def clone_project(remote: Remote, project_path: PurePosixPath):
     # TODO: Scp the ~/.git-credentials file if needed?
     # Or configure the config credential-helper to store first?
 
+    # Get the path to the root of the git repository
+    git_root_path = PurePosixPath(subprocess.getoutput("git rev-parse --show-toplevel").strip()).relative_to(Path.home())
+
     # If the project isn't cloned yet, clone it.
     _is_cloned_on_cluster = (
         await remote.run(
-            f"test -d {project_path}",
+            f"test -d {git_root_path}",
             warn=True,
             hide=True,
             display=False,
@@ -190,10 +192,10 @@ async def clone_project(remote: Remote, project_path: PurePosixPath):
     ).returncode == 0
     if not _is_cloned_on_cluster:
         logger.debug(f"Project isn't cloned yet on {remote.hostname}.")
-        await remote.run(f"git clone {github_repo_url} {project_path}", hide=True)
-    await remote.run(f"git -C {project_path} fetch --all --prune", hide=True)
-    await remote.run(f"git -C {project_path} checkout {current_git_branch}", hide=False)
-    await remote.run(f"git -C {project_path} pull")
+        await remote.run(f"git clone {github_repo_url} {git_root_path}", hide=True)
+    await remote.run(f"git -C {git_root_path} fetch --all --prune", hide=True)
+    await remote.run(f"git -C {git_root_path} checkout {current_git_branch}", hide=False)
+    await remote.run(f"git -C {git_root_path} pull")
 
 
 async def fetch_results(remote: Remote, results_path: Path | str):

--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -190,7 +190,7 @@ async def clone_project(remote: Remote, project_path: PurePosixPath):
     ).returncode == 0
     if not _is_cloned_on_cluster:
         logger.debug(f"Project isn't cloned yet on {remote.hostname}.")
-    await remote.run(f"git clone {github_repo_url} {project_path}", hide=True)
+        await remote.run(f"git clone {github_repo_url} {project_path}", hide=True)
     await remote.run(f"git -C {project_path} fetch --all --prune", hide=True)
     await remote.run(f"git -C {project_path} checkout {current_git_branch}", hide=False)
     await remote.run(f"git -C {project_path} pull")

--- a/cluv/ssh.py
+++ b/cluv/ssh.py
@@ -6,9 +6,6 @@ SSH_CONFIG_PATH = Path.home() / ".ssh" / "config"
 def get_ssh_hostnames() -> set[str]:
     if not SSH_CONFIG_PATH.exists():
         return set()
-    ssh_config = paramiko.SSHConfig()
-
-    with SSH_CONFIG_PATH.open() as f:
-        ssh_config.parse(f)
+    ssh_config = paramiko.SSHConfig.from_path(SSH_CONFIG_PATH)
 
     return ssh_config.get_hostnames()

--- a/cluv/ssh.py
+++ b/cluv/ssh.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import paramiko
+
+SSH_CONFIG_PATH = Path.home() / ".ssh" / "config"
+
+def get_ssh_hostnames() -> set[str]:
+    if not SSH_CONFIG_PATH.exists():
+        return set()
+    ssh_config = paramiko.SSHConfig()
+
+    with SSH_CONFIG_PATH.open() as f:
+        ssh_config.parse(f)
+
+    return ssh_config.get_hostnames()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,14 @@
 """Unit tests for cluv/config.py — pure, no I/O beyond tmp_path."""
 
+from pathlib import Path
 
 from cluv.config import load_cluv_config
-from .utils import write_file
+
+
+def write_file(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "pyproject.toml"
+    p.write_text(content)
+    return p
 
 
 # ---------------------------------------------------------------------------
@@ -11,24 +17,24 @@ from .utils import write_file
 
 
 class TestClustersListFormat:
-    def test_cluster_names(self, tmp_path):
-        p = write_file(tmp_path / "pyproject.toml", """
+    def test_cluster_names(self, tmp_path: Path) -> None:
+        p = write_file(tmp_path , """
 [tool.cluv]
 clusters = ["mila", "narval", "rorqual"]
 """)
         cfg = load_cluv_config(p)
         assert cfg.clusters == ["mila", "narval", "rorqual"]
 
-    def test_no_per_cluster_configs(self, tmp_path):
-        p = write_file(tmp_path / "pyproject.toml", """
+    def test_no_per_cluster_configs(self, tmp_path: Path) -> None:
+        p = write_file(tmp_path, """
 [tool.cluv]
 clusters = ["mila"]
 """)
         cfg = load_cluv_config(p)
         assert cfg.cluster_configs == {}
 
-    def test_results_path_preserved(self, tmp_path):
-        p = write_file(tmp_path / "pyproject.toml", """
+    def test_results_path_preserved(self, tmp_path: Path) -> None:
+        p = write_file(tmp_path, """
 [tool.cluv]
 clusters = ["mila"]
 results_path = "results"
@@ -43,8 +49,8 @@ results_path = "results"
 
 
 class TestClustersTableFormat:
-    def test_cluster_names_from_keys(self, tmp_path):
-        p = write_file(tmp_path / "pyproject.toml", """
+    def test_cluster_names_from_keys(self, tmp_path: Path) -> None:
+        p = write_file(tmp_path, """
 [tool.cluv.clusters.mila]
 [tool.cluv.clusters.rorqual]
 SBATCH_ACCOUNT = "def-me"
@@ -52,16 +58,16 @@ SBATCH_ACCOUNT = "def-me"
         cfg = load_cluv_config(p)
         assert set(cfg.clusters) == {"mila", "rorqual"}
 
-    def test_empty_cluster_section_included(self, tmp_path):
-        p = write_file(tmp_path / "pyproject.toml", """
+    def test_empty_cluster_section_included(self, tmp_path: Path) -> None:
+        p = write_file(tmp_path, """
 [tool.cluv.clusters.mila]
 """)
         cfg = load_cluv_config(p)
         assert "mila" in cfg.clusters
         assert cfg.cluster_configs.get("mila", {}) == {}
 
-    def test_per_cluster_sbatch_vars(self, tmp_path):
-        p = write_file(tmp_path / "pyproject.toml", """
+    def test_per_cluster_sbatch_vars(self, tmp_path: Path) -> None:
+        p = write_file(tmp_path, """
 [tool.cluv.clusters.rorqual]
 SBATCH_ACCOUNT = "def-bengioy"
 SBATCH_PARTITION = "main"
@@ -70,8 +76,8 @@ SBATCH_PARTITION = "main"
         assert cfg.cluster_configs["rorqual"]["SBATCH_ACCOUNT"] == "def-bengioy"
         assert cfg.cluster_configs["rorqual"]["SBATCH_PARTITION"] == "main"
 
-    def test_cluster_with_no_vars_not_in_cluster_configs(self, tmp_path):
-        p = write_file(tmp_path / "pyproject.toml", """
+    def test_cluster_with_no_vars_not_in_cluster_configs(self, tmp_path: Path) -> None:
+        p = write_file(tmp_path, """
 [tool.cluv.clusters.mila]
 [tool.cluv.clusters.rorqual]
 SBATCH_ACCOUNT = "def-bengioy"
@@ -87,8 +93,8 @@ SBATCH_ACCOUNT = "def-bengioy"
 
 
 class TestGlobalSlurm:
-    def test_global_slurm_vars_parsed(self, tmp_path):
-        p = write_file(tmp_path / "pyproject.toml", """
+    def test_global_slurm_vars_parsed(self, tmp_path: Path) -> None:
+        p = write_file(tmp_path, """
 [tool.cluv.slurm]
 SBATCH_TIME = "1:00:00"
 SBATCH_GPUS = "1"
@@ -99,8 +105,8 @@ SBATCH_GPUS = "1"
         assert cfg.slurm["SBATCH_TIME"] == "1:00:00"
         assert cfg.slurm["SBATCH_GPUS"] == "1"
 
-    def test_missing_slurm_section_defaults_to_empty(self, tmp_path):
-        p = write_file(tmp_path / "pyproject.toml", """
+    def test_missing_slurm_section_defaults_to_empty(self, tmp_path: Path) -> None:
+        p = write_file(tmp_path, """
 [tool.cluv.clusters.mila]
 """)
         cfg = load_cluv_config(p)
@@ -113,16 +119,16 @@ SBATCH_GPUS = "1"
 
 
 class TestEdgeCases:
-    def test_no_cluv_section_returns_empty_clusters(self, tmp_path):
-        p = write_file(tmp_path / "pyproject.toml", """
+    def test_no_cluv_section_returns_empty_clusters(self, tmp_path: Path) -> None:
+        p = write_file(tmp_path, """
 [project]
 name = "foo"
 """)
         cfg = load_cluv_config(p)
         assert cfg.clusters == []
 
-    def test_full_config_round_trip(self, tmp_path):
-        p = write_file(tmp_path / "pyproject.toml", """
+    def test_full_config_round_trip(self, tmp_path: Path) -> None:
+        p = write_file(tmp_path, """
 [tool.cluv.slurm]
 SBATCH_TIME = "3:00:00"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,27 +12,27 @@ from .utils import write_file
 
 class TestClustersListFormat:
     def test_cluster_names(self, tmp_path):
-        p = write_file(tmp_path, """
+        p = write_file(tmp_path / "pyproject.toml", """
 [tool.cluv]
 clusters = ["mila", "narval", "rorqual"]
-""", "pyproject.toml")
+""")
         cfg = load_cluv_config(p)
         assert cfg.clusters == ["mila", "narval", "rorqual"]
 
     def test_no_per_cluster_configs(self, tmp_path):
-        p = write_file(tmp_path, """
+        p = write_file(tmp_path / "pyproject.toml", """
 [tool.cluv]
 clusters = ["mila"]
-""", "pyproject.toml")
+""")
         cfg = load_cluv_config(p)
         assert cfg.cluster_configs == {}
 
     def test_results_path_preserved(self, tmp_path):
-        p = write_file(tmp_path, """
+        p = write_file(tmp_path / "pyproject.toml", """
 [tool.cluv]
 clusters = ["mila"]
 results_path = "results"
-""", "pyproject.toml")
+""")
         cfg = load_cluv_config(p)
         assert cfg.results_path == "results"
 
@@ -44,38 +44,38 @@ results_path = "results"
 
 class TestClustersTableFormat:
     def test_cluster_names_from_keys(self, tmp_path):
-        p = write_file(tmp_path, """
+        p = write_file(tmp_path / "pyproject.toml", """
 [tool.cluv.clusters.mila]
 [tool.cluv.clusters.rorqual]
 SBATCH_ACCOUNT = "def-me"
-""", "pyproject.toml")
+""")
         cfg = load_cluv_config(p)
         assert set(cfg.clusters) == {"mila", "rorqual"}
 
     def test_empty_cluster_section_included(self, tmp_path):
-        p = write_file(tmp_path, """
+        p = write_file(tmp_path / "pyproject.toml", """
 [tool.cluv.clusters.mila]
-""", "pyproject.toml")
+""")
         cfg = load_cluv_config(p)
         assert "mila" in cfg.clusters
         assert cfg.cluster_configs.get("mila", {}) == {}
 
     def test_per_cluster_sbatch_vars(self, tmp_path):
-        p = write_file(tmp_path, """
+        p = write_file(tmp_path / "pyproject.toml", """
 [tool.cluv.clusters.rorqual]
 SBATCH_ACCOUNT = "def-bengioy"
 SBATCH_PARTITION = "main"
-""", "pyproject.toml")
+""")
         cfg = load_cluv_config(p)
         assert cfg.cluster_configs["rorqual"]["SBATCH_ACCOUNT"] == "def-bengioy"
         assert cfg.cluster_configs["rorqual"]["SBATCH_PARTITION"] == "main"
 
     def test_cluster_with_no_vars_not_in_cluster_configs(self, tmp_path):
-        p = write_file(tmp_path, """
+        p = write_file(tmp_path / "pyproject.toml", """
 [tool.cluv.clusters.mila]
 [tool.cluv.clusters.rorqual]
 SBATCH_ACCOUNT = "def-bengioy"
-""", "pyproject.toml")
+""")
         cfg = load_cluv_config(p)
         assert "mila" not in cfg.cluster_configs
         assert "rorqual" in cfg.cluster_configs
@@ -88,21 +88,21 @@ SBATCH_ACCOUNT = "def-bengioy"
 
 class TestGlobalSlurm:
     def test_global_slurm_vars_parsed(self, tmp_path):
-        p = write_file(tmp_path, """
+        p = write_file(tmp_path / "pyproject.toml", """
 [tool.cluv.slurm]
 SBATCH_TIME = "1:00:00"
 SBATCH_GPUS = "1"
 
 [tool.cluv.clusters.mila]
-""", "pyproject.toml")
+""")
         cfg = load_cluv_config(p)
         assert cfg.slurm["SBATCH_TIME"] == "1:00:00"
         assert cfg.slurm["SBATCH_GPUS"] == "1"
 
     def test_missing_slurm_section_defaults_to_empty(self, tmp_path):
-        p = write_file(tmp_path, """
+        p = write_file(tmp_path / "pyproject.toml", """
 [tool.cluv.clusters.mila]
-""", "pyproject.toml")
+""")
         cfg = load_cluv_config(p)
         assert cfg.slurm == {}
 
@@ -114,15 +114,15 @@ SBATCH_GPUS = "1"
 
 class TestEdgeCases:
     def test_no_cluv_section_returns_empty_clusters(self, tmp_path):
-        p = write_file(tmp_path, """
+        p = write_file(tmp_path / "pyproject.toml", """
 [project]
 name = "foo"
-""", "pyproject.toml")
+""")
         cfg = load_cluv_config(p)
         assert cfg.clusters == []
 
     def test_full_config_round_trip(self, tmp_path):
-        p = write_file(tmp_path, """
+        p = write_file(tmp_path / "pyproject.toml", """
 [tool.cluv.slurm]
 SBATCH_TIME = "3:00:00"
 
@@ -132,7 +132,7 @@ SBATCH_PARTITION = "long"
 [tool.cluv.clusters.rorqual]
 SBATCH_ACCOUNT = "def-bengioy"
 SBATCH_PARTITION = "main"
-""", "pyproject.toml")
+""")
         cfg = load_cluv_config(p)
         assert set(cfg.clusters) == {"mila", "rorqual"}
         assert cfg.slurm == {"SBATCH_TIME": "3:00:00"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@
 
 
 from cluv.config import load_cluv_config
-from .utils import write_pyproject
+from .utils import write_file
 
 
 # ---------------------------------------------------------------------------
@@ -12,27 +12,27 @@ from .utils import write_pyproject
 
 class TestClustersListFormat:
     def test_cluster_names(self, tmp_path):
-        p = write_pyproject(tmp_path, """
+        p = write_file(tmp_path, """
 [tool.cluv]
 clusters = ["mila", "narval", "rorqual"]
-""")
+""", "pyproject.toml")
         cfg = load_cluv_config(p)
         assert cfg.clusters == ["mila", "narval", "rorqual"]
 
     def test_no_per_cluster_configs(self, tmp_path):
-        p = write_pyproject(tmp_path, """
+        p = write_file(tmp_path, """
 [tool.cluv]
 clusters = ["mila"]
-""")
+""", "pyproject.toml")
         cfg = load_cluv_config(p)
         assert cfg.cluster_configs == {}
 
     def test_results_path_preserved(self, tmp_path):
-        p = write_pyproject(tmp_path, """
+        p = write_file(tmp_path, """
 [tool.cluv]
 clusters = ["mila"]
 results_path = "results"
-""")
+""", "pyproject.toml")
         cfg = load_cluv_config(p)
         assert cfg.results_path == "results"
 
@@ -44,38 +44,38 @@ results_path = "results"
 
 class TestClustersTableFormat:
     def test_cluster_names_from_keys(self, tmp_path):
-        p = write_pyproject(tmp_path, """
+        p = write_file(tmp_path, """
 [tool.cluv.clusters.mila]
 [tool.cluv.clusters.rorqual]
 SBATCH_ACCOUNT = "def-me"
-""")
+""", "pyproject.toml")
         cfg = load_cluv_config(p)
         assert set(cfg.clusters) == {"mila", "rorqual"}
 
     def test_empty_cluster_section_included(self, tmp_path):
-        p = write_pyproject(tmp_path, """
+        p = write_file(tmp_path, """
 [tool.cluv.clusters.mila]
-""")
+""", "pyproject.toml")
         cfg = load_cluv_config(p)
         assert "mila" in cfg.clusters
         assert cfg.cluster_configs.get("mila", {}) == {}
 
     def test_per_cluster_sbatch_vars(self, tmp_path):
-        p = write_pyproject(tmp_path, """
+        p = write_file(tmp_path, """
 [tool.cluv.clusters.rorqual]
 SBATCH_ACCOUNT = "def-bengioy"
 SBATCH_PARTITION = "main"
-""")
+""", "pyproject.toml")
         cfg = load_cluv_config(p)
         assert cfg.cluster_configs["rorqual"]["SBATCH_ACCOUNT"] == "def-bengioy"
         assert cfg.cluster_configs["rorqual"]["SBATCH_PARTITION"] == "main"
 
     def test_cluster_with_no_vars_not_in_cluster_configs(self, tmp_path):
-        p = write_pyproject(tmp_path, """
+        p = write_file(tmp_path, """
 [tool.cluv.clusters.mila]
 [tool.cluv.clusters.rorqual]
 SBATCH_ACCOUNT = "def-bengioy"
-""")
+""", "pyproject.toml")
         cfg = load_cluv_config(p)
         assert "mila" not in cfg.cluster_configs
         assert "rorqual" in cfg.cluster_configs
@@ -88,21 +88,21 @@ SBATCH_ACCOUNT = "def-bengioy"
 
 class TestGlobalSlurm:
     def test_global_slurm_vars_parsed(self, tmp_path):
-        p = write_pyproject(tmp_path, """
+        p = write_file(tmp_path, """
 [tool.cluv.slurm]
 SBATCH_TIME = "1:00:00"
 SBATCH_GPUS = "1"
 
 [tool.cluv.clusters.mila]
-""")
+""", "pyproject.toml")
         cfg = load_cluv_config(p)
         assert cfg.slurm["SBATCH_TIME"] == "1:00:00"
         assert cfg.slurm["SBATCH_GPUS"] == "1"
 
     def test_missing_slurm_section_defaults_to_empty(self, tmp_path):
-        p = write_pyproject(tmp_path, """
+        p = write_file(tmp_path, """
 [tool.cluv.clusters.mila]
-""")
+""", "pyproject.toml")
         cfg = load_cluv_config(p)
         assert cfg.slurm == {}
 
@@ -114,15 +114,15 @@ SBATCH_GPUS = "1"
 
 class TestEdgeCases:
     def test_no_cluv_section_returns_empty_clusters(self, tmp_path):
-        p = write_pyproject(tmp_path, """
+        p = write_file(tmp_path, """
 [project]
 name = "foo"
-""")
+""", "pyproject.toml")
         cfg = load_cluv_config(p)
         assert cfg.clusters == []
 
     def test_full_config_round_trip(self, tmp_path):
-        p = write_pyproject(tmp_path, """
+        p = write_file(tmp_path, """
 [tool.cluv.slurm]
 SBATCH_TIME = "3:00:00"
 
@@ -132,7 +132,7 @@ SBATCH_PARTITION = "long"
 [tool.cluv.clusters.rorqual]
 SBATCH_ACCOUNT = "def-bengioy"
 SBATCH_PARTITION = "main"
-""")
+""", "pyproject.toml")
         cfg = load_cluv_config(p)
         assert set(cfg.clusters) == {"mila", "rorqual"}
         assert cfg.slurm == {"SBATCH_TIME": "3:00:00"}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -43,10 +43,9 @@ class TestCheckCluvConfig:
         """check_cluv_config() should add a cluv config section if the toml doesn't have it"""
         p = write_pyproject(tmp_path, "")
 
-        results_path = check_cluv_config(p)
+        check_cluv_config(p)
         config = load_cluv_config(p)
 
-        assert results_path == DEFAULT_RESULTS_PATH
         assert config.clusters == ["mila"] + DRAC_CLUSTERS
         assert config.results_path == DEFAULT_RESULTS_PATH
         assert config.slurm == {'UV_OFFLINE': 1, 'WANDB_MODE': 'offline'}
@@ -65,10 +64,9 @@ class TestCheckCluvConfig:
             ),
         )
 
-        results_path = check_cluv_config(p)
+        check_cluv_config(p)
         config = load_cluv_config(p)
 
-        assert results_path == "results"
         assert config.clusters == ["mila"]
         assert config.results_path == "results"
 
@@ -103,6 +101,7 @@ class TestSymlinkCheck():
         assert expected_results_path.is_symlink()
         assert expected_results_scratch_path.exists()
         assert expected_results_path.resolve() == expected_results_scratch_path.resolve()
+
 
     def test_keep_existing_symlink(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """check_symlink_to_scratch() should not overwrite an existing symlink not pointing to scratch"""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,7 +16,6 @@ from cluv.cli.init import (
     DEFAULT_RESULTS_PATH,
     JOB_SCRIPT_PATH
 )
-from .utils import write_file
 
 
 class TestCheckHomeDir:
@@ -41,7 +40,8 @@ class TestGitCheck:
 class TestCheckCluvConfig:
     def test_add_missing_cluv_config(self, tmp_path: Path) -> None:
         """check_cluv_config() should add a cluv config section if the toml doesn't have it"""
-        p = write_file(tmp_path / "pyproject.toml", "")
+        p = tmp_path / "pyproject.toml"
+        p.touch()
 
         check_cluv_config(p)
         config = load_cluv_config(p)
@@ -53,16 +53,14 @@ class TestCheckCluvConfig:
 
     def test_keep_existing_cluv_config(self, tmp_path: Path) -> None:
         """check_cluv_config() should not overwrite an existing cluv config"""
-        p = write_file(
-            tmp_path / "pyproject.toml",
-            textwrap.dedent(
-                """\
+        p = tmp_path / "pyproject.toml"
+        p.write_text(textwrap.dedent(
+            """\
             [tool.cluv]
             clusters = ["mila"]
             results_path = "results"
             """
-            )
-        )
+        ))
 
         check_cluv_config(p)
         config = load_cluv_config(p)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,7 +41,7 @@ class TestGitCheck:
 class TestCheckCluvConfig:
     def test_add_missing_cluv_config(self, tmp_path: Path) -> None:
         """check_cluv_config() should add a cluv config section if the toml doesn't have it"""
-        p = write_file(tmp_path, "", "pyproject.toml")
+        p = write_file(tmp_path / "pyproject.toml", "")
 
         check_cluv_config(p)
         config = load_cluv_config(p)
@@ -54,15 +54,14 @@ class TestCheckCluvConfig:
     def test_keep_existing_cluv_config(self, tmp_path: Path) -> None:
         """check_cluv_config() should not overwrite an existing cluv config"""
         p = write_file(
-            tmp_path,
+            tmp_path / "pyproject.toml",
             textwrap.dedent(
                 """\
             [tool.cluv]
             clusters = ["mila"]
             results_path = "results"
             """
-            ),
-            "pyproject.toml"
+            )
         )
 
         check_cluv_config(p)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,7 +16,7 @@ from cluv.cli.init import (
     DEFAULT_RESULTS_PATH,
     JOB_SCRIPT_PATH
 )
-from .utils import write_pyproject
+from .utils import write_file
 
 
 class TestCheckHomeDir:
@@ -41,7 +41,7 @@ class TestGitCheck:
 class TestCheckCluvConfig:
     def test_add_missing_cluv_config(self, tmp_path: Path) -> None:
         """check_cluv_config() should add a cluv config section if the toml doesn't have it"""
-        p = write_pyproject(tmp_path, "")
+        p = write_file(tmp_path, "", "pyproject.toml")
 
         check_cluv_config(p)
         config = load_cluv_config(p)
@@ -53,7 +53,7 @@ class TestCheckCluvConfig:
 
     def test_keep_existing_cluv_config(self, tmp_path: Path) -> None:
         """check_cluv_config() should not overwrite an existing cluv config"""
-        p = write_pyproject(
+        p = write_file(
             tmp_path,
             textwrap.dedent(
                 """\
@@ -62,6 +62,7 @@ class TestCheckCluvConfig:
             results_path = "results"
             """
             ),
+            "pyproject.toml"
         )
 
         check_cluv_config(p)

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -14,7 +14,7 @@ class TestGetHostnames:
     def test_returns_empty_set_when_no_file(self):
         assert cluv_ssh.get_ssh_hostnames() == set()
 
-    def test_returns_empty_set_for_empty_file(self, tmp_path):
+    def test_returns_default_wildcard_for_empty_file(self, tmp_path):
         write_file(tmp_path, "", "config")
         assert cluv_ssh.get_ssh_hostnames() == set("*")
 

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -1,12 +1,14 @@
 """Unit tests for cluv/ssh.py — pure, no real SSH config touched."""
 
-import cluv.ssh as cluv_ssh
-from .utils import write_file
+from pathlib import Path
+
 import pytest
+
+import cluv.ssh as cluv_ssh
 
 
 @pytest.fixture(autouse=True)
-def patch_ssh_config_path(tmp_path, monkeypatch):
+def patch_ssh_config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(cluv_ssh, "SSH_CONFIG_PATH", tmp_path / "config")
 
 
@@ -14,14 +16,17 @@ class TestGetHostnames:
     def test_returns_empty_set_when_no_file(self):
         assert cluv_ssh.get_ssh_hostnames() == set()
 
-    def test_returns_default_wildcard_for_empty_file(self, tmp_path):
-        write_file(tmp_path / "config", "")
+    def test_returns_default_wildcard_for_empty_file(self, tmp_path: Path):
+        p = tmp_path / "config"
+        p.touch()
         assert cluv_ssh.get_ssh_hostnames() == set("*")
 
-    def test_get_all_hosts(self, tmp_path):
-        write_file(tmp_path / "config", "Host mila\nHost narval\nHost rorqual\n")
+    def test_get_all_hosts(self, tmp_path: Path):
+        p = tmp_path / "config"
+        p.write_text("Host mila\nHost narval\nHost rorqual\n")
         assert cluv_ssh.get_ssh_hostnames() == {"*", "mila", "narval", "rorqual"}
 
-    def test_returns_no_duplicates(self, tmp_path):
-        write_file(tmp_path / "config", "Host mila\nHost mila\n")
+    def test_returns_no_duplicates(self, tmp_path: Path):
+        p = tmp_path / "config"
+        p.write_text("Host mila\nHost mila\n")
         assert cluv_ssh.get_ssh_hostnames() == {"*", "mila"}

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -15,13 +15,13 @@ class TestGetHostnames:
         assert cluv_ssh.get_ssh_hostnames() == set()
 
     def test_returns_default_wildcard_for_empty_file(self, tmp_path):
-        write_file(tmp_path, "", "config")
+        write_file(tmp_path / "config", "")
         assert cluv_ssh.get_ssh_hostnames() == set("*")
 
     def test_get_all_hosts(self, tmp_path):
-        write_file(tmp_path, "Host mila\nHost narval\nHost rorqual\n", "config")
+        write_file(tmp_path / "config", "Host mila\nHost narval\nHost rorqual\n")
         assert cluv_ssh.get_ssh_hostnames() == {"*", "mila", "narval", "rorqual"}
 
     def test_returns_no_duplicates(self, tmp_path):
-        write_file(tmp_path, "Host mila\nHost mila\n", "config")
+        write_file(tmp_path / "config", "Host mila\nHost mila\n")
         assert cluv_ssh.get_ssh_hostnames() == {"*", "mila"}

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -1,0 +1,27 @@
+"""Unit tests for cluv/ssh.py — pure, no real SSH config touched."""
+
+import cluv.ssh as cluv_ssh
+from .utils import write_file
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def patch_ssh_config_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(cluv_ssh, "SSH_CONFIG_PATH", tmp_path / "config")
+
+
+class TestGetHostnames:
+    def test_returns_empty_set_when_no_file(self):
+        assert cluv_ssh.get_ssh_hostnames() == set()
+
+    def test_returns_empty_set_for_empty_file(self, tmp_path):
+        write_file(tmp_path, "", "config")
+        assert cluv_ssh.get_ssh_hostnames() == set("*")
+
+    def test_get_all_hosts(self, tmp_path):
+        write_file(tmp_path, "Host mila\nHost narval\nHost rorqual\n", "config")
+        assert cluv_ssh.get_ssh_hostnames() == {"*", "mila", "narval", "rorqual"}
+
+    def test_returns_no_duplicates(self, tmp_path):
+        write_file(tmp_path, "Host mila\nHost mila\n", "config")
+        assert cluv_ssh.get_ssh_hostnames() == {"*", "mila"}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-def write_pyproject(tmp_path, content: str):
-    p = tmp_path / "pyproject.toml"
+def write_file(tmp_path, content: str, filename: str):
+    p = tmp_path / filename
     p.write_text(content)
     return p

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,6 @@
-def write_file(tmp_path, content: str, filename: str):
-    p = tmp_path / filename
+from pathlib import Path
+
+def write_file(tmp_path: Path, content: str) -> Path:
+    p = tmp_path
     p.write_text(content)
     return p

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,0 @@
-from pathlib import Path
-
-def write_file(tmp_path: Path, content: str) -> Path:
-    p = tmp_path
-    p.write_text(content)
-    return p


### PR DESCRIPTION
## Summary
* Add a check in `cluv init` to compare the list of clusters to the list of SSH hostnames. If a cluster is missing a SSH config, suggests to run `mila init`.
* The cluv config in the `init` command  is now get directly with the function `load_cluv_config` instead of using the return path of `check_cluv_config`. 

## Issues
* Close #18 