### PR TITLE
Add `cluv submit first` command

### DIFF
--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -115,7 +115,11 @@ def add_submit_args(
     submit_parser.add_argument(
         "cluster",
         metavar="<cluster>",
-        help="The cluster to submit the job on.",
+        help=(
+            "The cluster to submit the job on. "
+            "Set at 'first' to submit a job on all clusters, and wait until one of them starts. "
+            "Once one starts, cancel the others."
+        ),
     )
     submit_parser.add_argument(
         "job_script",

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -70,7 +70,7 @@ async def submit(
     result = await sbatch(remote, job_script, sbatch_args, program_args, git_commit)
 
     if result.returncode != 0:
-        console.print(f"[red] Invalid sbatch : {result.stderr}[/red]")
+        console.print(f"[red] Error during sbatch : {result.stderr}[/red]")
         return None
 
     job_id = int(result.stdout.strip())

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -163,11 +163,11 @@ async def submit_first(
                 # Stop the wait if a job is running
                 if start_cluster is not None:
                     break
-                
+
                 # Remove clusters with failed jobs
                 for cluster in failed_clusters:
                     del cluster_to_jobid[cluster]
-                
+
                 # Stop the wait if all the jobs failed
                 if not cluster_to_jobid:
                     console.log("All submitted jobs have ended without starting. Exiting.")

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -37,8 +37,7 @@ async def submit(
 
 
     Parameters:
-        cluster: SSH hostname of the target cluster. Can be set to "first" to launch the job
-        on all clusters and keep only the first one to starts.
+        cluster: SSH hostname of the target cluster. Can be set to "first" to launch the job on all clusters and keep only the first one to starts.
         job_script: Path to the job script to submit, relative to the project root.
         sbatch_args: List of additional flags to pass to `sbatch`.
         program_args: List of arguments to pass to the job script, for example `["python", "main.py"]`.

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import os
 import shlex
 import subprocess
 import sys
@@ -7,17 +9,23 @@ from pathlib import Path
 
 from cluv.cli.sync import sync
 from cluv.config import ClusterConfig, find_pyproject, get_config
+from cluv.remote import Remote
 from cluv.utils import console
+
+
+RUNNING_JOB_STATES = ["PENDING", "RUNNING"]
+FAILED_JOB_STATES = ["FAILED", "CANCELLED", "TIMEOUT", "NODE_FAIL", "OUT_OF_MEMORY", "PREEMPTED"]
+
 
 __all__ = ["submit"]
 
 
 async def submit(
     cluster: str,
-    job_script: str,
+    job_script: Path,
     sbatch_args: list[str],
     program_args: list[str],
-) -> int:
+) -> int | None:
     """Submit a SLURM job on a remote cluster.
 
     Enforces a clean git state, syncs the project, sets `GIT_COMMIT` and any
@@ -29,13 +37,14 @@ async def submit(
 
 
     Parameters:
-        cluster: SSH hostname of the target cluster.
+        cluster: SSH hostname of the target cluster. Can be set to "first" to launch the job
+        on all clusters and keep only the first one to starts.
         job_script: Path to the job script to submit, relative to the project root.
         sbatch_args: List of additional flags to pass to `sbatch`.
         program_args: List of arguments to pass to the job script, for example `["python", "main.py"]`.
 
     Returns:
-        The job ID of the submitted job.
+        The job ID of the submitted job or None if the sbatch command fails.
 
     Examples:
 
@@ -48,49 +57,24 @@ async def submit(
     )
     ```
     """
-    # 1. Check git is clean locally (untracked files are fine?).
-    git_status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
-    dirty_lines = [line for line in git_status.stdout.splitlines() if not line.startswith("??")]
-    if dirty_lines:
-        console.print(
-            "[red]Working directory is dirty. Please commit your changes before submitting.[/red]",
-        )
-        sys.exit(1)
+    # Check git is clean locally (untracked files are fine) and capture current commit hash.
+    git_commit = ensure_clean_git_state()
 
-    # 2. Capture current commit hash.
-    git_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    if cluster == "first":
+        return await submit_first(job_script, sbatch_args, program_args, git_commit)
 
-    # 3. Sync.
+    # Sync.
     remotes = await sync(clusters=[cluster])
+
+    # Submit the sbatch command.
     remote = remotes[0]
+    result = await sbatch(remote, job_script, sbatch_args, program_args, git_commit)
 
-    config = get_config()
+    if result.returncode != 0:
+        console.print(f"[red] Invalid sbatch : {result.stderr}[/red]")
+        return None
 
-    # 4. Resolve remote job script path.
-    project_path = find_pyproject().parent.relative_to(Path.home())
-    remote_job_script = f"~/{project_path}/{job_script}"
-
-    # 5. Build env var dict: global SBATCH_* defaults merged with per-cluster overrides.
-    env_vars: dict[str, str] = {**config.env}
-    env_vars.update(config.cluster_configs.get(cluster, ClusterConfig()).env)
-    # Prefix the job name with "cluv-" so admins can identify cluv-submitted jobs in sacct.
-    base_name = env_vars.get("SBATCH_JOB_NAME") or Path(job_script).stem
-    env_vars["SBATCH_JOB_NAME"] = f"cluv-{base_name}"
-    env_vars["GIT_COMMIT"] = git_commit
-
-    env_prefix = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env_vars.items())
-    sbatch_args_str = " ".join(shlex.quote(f) for f in sbatch_args)
-    program_args_str = shlex.join(program_args)
-
-    # 6. Submit.
-    remote_cmd = f"bash -l -c '{env_prefix} sbatch --parsable --chdir={project_path} {sbatch_args_str} {remote_job_script} {program_args_str}'"
-    console.print(
-        f"Submitting job on [bold]{cluster}[/bold]: {job_script}"
-        + (f" {sbatch_args_str}" if sbatch_args_str else "")
-        + (f" -- {program_args_str}" if program_args_str else "")
-    )
-    output = await remote.get_output(remote_cmd)
-    job_id = int(output.strip())
+    job_id = int(result.stdout.strip())
 
     console.log(
         f"Successfully submitted job {job_id} on the {cluster} cluster.\n"
@@ -98,4 +82,205 @@ async def submit(
     )
 
     return job_id
-    # return the job id?
+
+
+async def submit_first(
+    job_script: Path,
+    sbatch_args: list[str],
+    program_args: list[str],
+    git_commit: str,
+) -> int | None:
+    """Submit the job on all clusters, and wait until one of them starts.
+    Once one starts, cancel the others.
+    """
+    # Sync with all clusters with an existing connections.
+    remotes = await sync()
+    clusters_to_remote = {remote.hostname: remote for remote in remotes}
+
+    # Submit the job on all the clusters
+    sbatch_results = await asyncio.gather(
+        *[
+            sbatch(
+                remote,
+                job_script,
+                sbatch_args,
+                program_args,
+                git_commit,
+            )
+            for remote in remotes
+        ],
+        return_exceptions=True,
+    )
+
+    # Get the results of the sbatch command. We expect an int (the job id) or the exception
+    # if the command failed on the remote cluster.
+    console.print("Jobs submitted on the clusters:")
+    cluster_to_jobid: dict[str, int] = {}
+    for cluster, result in zip(clusters_to_remote.keys(), sbatch_results):
+        if isinstance(result, BaseException):
+            continue
+        else:
+            if result.returncode == 0:
+                job_id = int(result.stdout.strip())
+                cluster_to_jobid[cluster] = job_id
+                console.print(f"    - [bold]{cluster}[/bold]: job {job_id}")
+            else:
+                console.print(
+                    f"    - [bold]{cluster}[/bold]: no job, [red]{result.stderr.strip()}[/red]"
+                )
+
+    if len(cluster_to_jobid) == 0:
+        console.print("No job submitted on clusters. See errors above.")
+        return None
+
+    # Wait for a job to start on a cluster.
+    # If the wait is interrupted, cancel all jobs.
+    start_cluster: str | None = None
+    start_job_id: int | None = None
+    wait_time = 2  # seconds; grows up to 20s
+    try:
+        with console.status("Waiting for a job to start..."):
+            while start_cluster is None:
+                failed_clusters: list[str] = []
+                for cluster, remote in clusters_to_remote.items():
+                    job_id = cluster_to_jobid.get(cluster)
+                    if job_id is None:
+                        continue
+                    job_status = await get_job_status(remote, job_id)
+
+                    if job_status in RUNNING_JOB_STATES:
+                        start_cluster = cluster
+                        start_job_id = job_id
+                        break
+                    elif job_status in FAILED_JOB_STATES:
+                        console.print(
+                            f"Job {job_id} on cluster {cluster} ended with status {job_status}."
+                        )
+                        failed_clusters.append(cluster)
+
+                # Stop the wait if a job is running
+                if start_cluster is not None:
+                    break
+                
+                # Remove clusters with failed jobs
+                for cluster in failed_clusters:
+                    del cluster_to_jobid[cluster]
+                
+                # Stop the wait if all the jobs failed
+                if not cluster_to_jobid:
+                    console.log("All submitted jobs have ended without starting. Exiting.")
+                    return None
+
+                await asyncio.sleep(wait_time)
+                wait_time = _update_waiting_time(wait_time)
+        console.log(
+            f"Job {start_job_id} on cluster {start_cluster} is running. Cancelling the other jobs...\n",
+            f"Use `ssh {start_cluster} sacct -j {start_job_id}` to view its status.",
+        )
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        console.log("Interrupted by user. Cancelling all jobs...")
+    finally:
+        await cancel_all_jobs(clusters_to_remote, cluster_to_jobid, start_cluster)
+
+    return start_job_id
+
+
+def ensure_clean_git_state() -> str:
+    """
+    Check git is clean locally and return the current commit hash.
+    """
+    git_status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
+    dirty_lines = [line for line in git_status.stdout.splitlines() if not line.startswith("??")]
+    if dirty_lines and not (os.environ.get("SKIP_CLEAN_GIT_CHECK", "0") == "1"):
+        console.print(
+            "[red]Working directory is dirty. Please commit your changes before submitting.[/red]",
+        )
+        sys.exit(1)
+
+    # Capture current commit hash.
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+
+
+def get_sbatch_command(
+    cluster: str,
+    job_script: Path,
+    sbatch_args: list[str],
+    program_args: list[str],
+    git_commit: str,
+) -> str:
+    """
+    Generate the command to submit the job via sbatch on the remote cluster, with the appropriate env vars set.
+    """
+    # Resolve remote job script path.
+    project_path = find_pyproject().parent.relative_to(Path.home())
+    remote_job_script = f"~/{project_path}/{job_script}"
+
+    # Build env var dict: global SBATCH_* defaults merged with per-cluster overrides.
+    config = get_config()
+    env_vars: dict[str, str] = {**config.env}
+    env_vars.update(config.cluster_configs.get(cluster, ClusterConfig()).env)
+
+    # Prefix the job name with "cluv-" so it is easy to identify cluv-submitted jobs in sacct.
+    base_name = env_vars.get("SBATCH_JOB_NAME") or Path(job_script).stem
+    env_vars["SBATCH_JOB_NAME"] = f"cluv-{base_name}"
+    env_vars["GIT_COMMIT"] = git_commit
+
+    env_vars_prefix = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env_vars.items())
+    sbatch_args_str = " ".join(shlex.quote(f) for f in sbatch_args)
+    program_args_str = shlex.join(program_args)
+
+    return (
+        f"bash --login -c '{env_vars_prefix} sbatch --parsable --chdir={project_path} "
+        f"{sbatch_args_str} {remote_job_script} {program_args_str}'"
+    )
+
+
+async def sbatch(
+    remote: Remote,
+    job_script: Path,
+    sbatch_args: list[str],
+    program_args: list[str],
+    git_commit: str,
+) -> subprocess.CompletedProcess[str]:
+    """Submit the job via sbatch on the remote cluster, and return the job id."""
+    cluster = remote.hostname
+
+    remote_cmd = get_sbatch_command(
+        cluster, Path(job_script), sbatch_args, program_args, git_commit
+    )
+    return await remote.run(remote_cmd, display=True, warn=True, hide=True)
+
+
+async def get_job_status(remote: Remote, job_id: int) -> str:
+    """Get the status of the job with the given id on the remote cluster."""
+    sacct_command = f"sacct -j {job_id} --format=State --noheader --parsable2 | head -1"
+    return await remote.get_output(sacct_command)
+
+
+async def cancel_job(remote: Remote, job_id: int) -> str:
+    """Cancel the job with the given id on the remote cluster."""
+    scancel_command = f"scancel {job_id}"
+    output = await remote.get_output(scancel_command)
+    console.print(f"Cancelled job {job_id} on cluster {remote.hostname}.")
+    return output
+
+
+async def cancel_all_jobs(
+    remotes: dict[str, Remote], cluster_to_jobid: dict[str, int], keep_cluster: str | None
+) -> None:
+    """Cancel all jobs in cluster_to_jobid on their respective remotes."""
+    await asyncio.gather(
+        *[
+            cancel_job(remotes[cluster], job_id)
+            for cluster, job_id in cluster_to_jobid.items()
+            if cluster != keep_cluster
+        ]
+    )
+
+
+def _update_waiting_time(
+    current_waiting_time: int, max_waiting_time: int = 20, factor: int = 2
+) -> int:
+    """Update the waiting time by multiplying it by a factor, up to a maximum."""
+    new_waiting_time = current_waiting_time * factor
+    return min(new_waiting_time, max_waiting_time)

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -118,7 +118,9 @@ async def submit_first(
     cluster_to_jobid: dict[str, int] = {}
     for cluster, result in zip(clusters_to_remote.keys(), sbatch_results):
         if isinstance(result, BaseException):
-            continue
+            console.print(
+                f"    - [bold]{cluster}[/bold]: error when trying to use remote, [red]{result}[/red]"
+            )
         else:
             if result.returncode == 0:
                 job_id = int(result.stdout.strip())

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -247,7 +247,7 @@ async def sbatch(
     cluster = remote.hostname
 
     remote_cmd = get_sbatch_command(
-        cluster, Path(job_script), sbatch_args, program_args, git_commit
+        cluster, job_script, sbatch_args, program_args, git_commit
     )
     return await remote.run(remote_cmd, display=True, warn=True, hide=True)
 

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -173,7 +173,7 @@ async def submit_first(
                     return None
 
                 await asyncio.sleep(wait_time)
-                wait_time = _update_waiting_time(wait_time)
+                wait_time = min(wait_time*2, 20)
         console.log(
             f"Job {start_job_id} on cluster {start_cluster} is running. Cancelling the other jobs...\n",
             f"Use `ssh {start_cluster} sacct -j {start_job_id}` to view its status.",
@@ -277,11 +277,3 @@ async def cancel_all_jobs(
             if cluster != keep_cluster
         ]
     )
-
-
-def _update_waiting_time(
-    current_waiting_time: int, max_waiting_time: int = 20, factor: int = 2
-) -> int:
-    """Update the waiting time by multiplying it by a factor, up to a maximum."""
-    new_waiting_time = current_waiting_time * factor
-    return min(new_waiting_time, max_waiting_time)

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -65,7 +65,7 @@ async def submit(
     # Sync.
     remotes = await sync(clusters=[cluster])
 
-    # Submit the sbatch command.
+    # Run the sbatch command over SSH.
     remote = remotes[0]
     result = await sbatch(remote, job_script, sbatch_args, program_args, git_commit)
 

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -254,7 +254,7 @@ async def sbatch(
 
 async def get_job_status(remote: Remote, job_id: int) -> str:
     """Get the status of the job with the given id on the remote cluster."""
-    sacct_command = f"sacct -j {job_id} --format=State --noheader --parsable2 | head -1"
+    sacct_command = f"sacct -j {job_id} --format=State --noheader --allocations"
     return await remote.get_output(sacct_command)
 
 

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -1,0 +1,80 @@
+import textwrap
+from pathlib import Path
+
+from cluv.cli.submit import get_sbatch_command, get_config
+
+import pytest
+
+
+@pytest.fixture
+def project_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    # To avoid that a test reads the cached config of an other, we need to clear the cache between each test.
+    get_config.cache_clear()
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)  # Set the home directory to tmp_path
+    project_dir = tmp_path / "my_project"
+    project_dir.mkdir()
+    monkeypatch.chdir(project_dir)  # Set current working dir
+    return project_dir
+
+
+class TestGetSbatchCommand:
+    def test_generate_command_for_selected_cluster_with_correct_args_and_vars(self, project_dir: Path) -> None:
+        p = project_dir / "pyproject.toml"
+        p.write_text(
+            textwrap.dedent(
+                """\
+            [tool.cluv]
+            results_path = "results"
+            [tool.cluv.slurm]
+            MY_VAR="1"
+            [tool.cluv.clusters.mila]
+            SPECIAL_MILA_VAR="xyz"
+            [tool.cluv.clusters.vulcan]
+            SPECIAL_VULCAN_VAR="kij"
+            """
+            )
+        )
+
+        sbatch_command = get_sbatch_command(
+            cluster="mila",
+            job_script=Path("scripts/my_script.sh"),
+            sbatch_args=["--account=my_account", "--mem=8G"],
+            program_args=["program_arg_1", "program_arg_2"],
+            git_commit="abecdef",
+        )
+
+        assert (
+            sbatch_command
+            == "bash --login -c 'MY_VAR=1 SPECIAL_MILA_VAR=xyz SBATCH_JOB_NAME=cluv-my_script GIT_COMMIT=abecdef sbatch --parsable --chdir=my_project --account=my_account --mem=8G ~/my_project/scripts/my_script.sh program_arg_1 program_arg_2'"
+        )
+
+    def test_only_override_slurm_vars_with_selected_cluster_vars(self, project_dir: Path) -> None:
+        p = project_dir / "pyproject.toml"
+        p.write_text(
+            textwrap.dedent(
+                """\
+            [tool.cluv]
+            results_path = "results"
+            [tool.cluv.slurm]
+            MY_VAR="1"
+            [tool.cluv.clusters.mila]
+            MY_VAR="2"
+            [tool.cluv.clusters.vulcan]
+            MY_VAR="3"
+            """
+            )
+        )
+
+        sbatch_command = get_sbatch_command(
+            cluster="mila",
+            job_script=Path("scripts/my_script.sh"),
+            sbatch_args=[],
+            program_args=[],
+            git_commit="abecdef",
+        )
+
+        assert (
+            sbatch_command
+            == "bash --login -c 'MY_VAR=2 SBATCH_JOB_NAME=cluv-my_script GIT_COMMIT=abecdef sbatch --parsable --chdir=my_project  ~/my_project/scripts/my_script.sh '"
+        )

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -26,11 +26,11 @@ class TestGetSbatchCommand:
                 """\
             [tool.cluv]
             results_path = "results"
-            [tool.cluv.slurm]
+            [tool.cluv.env]
             MY_VAR="1"
-            [tool.cluv.clusters.mila]
+            [tool.cluv.clusters.mila.env]
             SPECIAL_MILA_VAR="xyz"
-            [tool.cluv.clusters.vulcan]
+            [tool.cluv.clusters.vulcan.env]
             SPECIAL_VULCAN_VAR="kij"
             """
             )
@@ -56,11 +56,11 @@ class TestGetSbatchCommand:
                 """\
             [tool.cluv]
             results_path = "results"
-            [tool.cluv.slurm]
+            [tool.cluv.env]
             MY_VAR="1"
-            [tool.cluv.clusters.mila]
+            [tool.cluv.clusters.mila.env]
             MY_VAR="2"
-            [tool.cluv.clusters.vulcan]
+            [tool.cluv.clusters.vulcan.env]
             MY_VAR="3"
             """
             )


### PR DESCRIPTION
## Summary
* Add implementation for `cluv submit first` :
   * Sync the project on all clusters.
   * Submit the job script on all clusters with `sbatch`.
   * If the `sbatch` command was valid show the job id, else show the error.
   * Wait for a job to start by checking the job status on each cluster with `squeue`.
   * Once a job starts, cancels all other jobs.