### PR TITLE
Add an argument to only display one table of `cluv status`

### DIFF
--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -139,20 +139,15 @@ def add_submit_args(
 def add_status_args(subparsers: Subparsers) -> argparse.ArgumentParser:
     status_parser = subparsers.add_parser(
         "status",
-        help="Get the status of available clusters.",
+        help="Get the status of clusters and jobs.",
         formatter_class=rich_argparse.RichHelpFormatter,
     )
     status_parser.add_argument(
-        "clusters",
-        nargs="*",
-        default=None,
-        metavar="<cluster>",
-        help=("Cluster(s) to query. Leave empty to query all clusters with an active connection."),
-    )
-    status_parser.add_argument(
-        "--show",
+        "table",
+        nargs="?",
         choices=["clusters", "jobs", "all"],
         default="all",
+        metavar="<table>",
         help="Which table to display: cluster overview, jobs overview, or both (default: all).",
     )
     status_parser.set_defaults(func=status)

--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -149,8 +149,12 @@ def add_status_args(subparsers: Subparsers) -> argparse.ArgumentParser:
         metavar="<cluster>",
         help=("Cluster(s) to query. Leave empty to query all clusters with an active connection."),
     )
-    # TODO: Add sub-commands to query the status with respect to different things, GPUs, storage, jobs, etc?
-    # Or just display everything?
+    status_parser.add_argument(
+        "--show",
+        choices=["clusters", "jobs", "all"],
+        default="all",
+        help="Which table to display: cluster overview, jobs overview, or both (default: all).",
+    )
     status_parser.set_defaults(func=status)
     return status_parser
 

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -274,11 +274,11 @@ def _gpu_bar(idle: int, total: int, width: int = 10) -> Text:
 
 def _build_cluster_table(data: list[ClusterStatus]) -> Table:
     table = Table(
-        title="[bold cyan]Cluster Overview[/bold cyan]",
+        title="Cluster Overview",
         box=box.ROUNDED,
         show_lines=True,
         header_style="bold white on #1a1a2e",
-        title_style="bold",
+        title_style="bold cyan",
         expand=True,
     )
 
@@ -323,9 +323,10 @@ def _build_cluster_table(data: list[ClusterStatus]) -> Table:
 
 def _build_my_jobs_table(data: list[ClusterStatus]) -> Table:
     table = Table(
-        title="[bold cyan]Your Jobs Summary[/bold cyan]",
+        title="Jobs Overview",
         box=box.SIMPLE_HEAVY,
         header_style="bold white on #1a1a2e",
+        title_style="bold cyan",
         expand=True,
     )
     table.add_column("Cluster", style="bold magenta")

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -347,11 +347,11 @@ def _build_my_jobs_table(data: list[ClusterStatus]) -> Table:
 
 def _build_legend() -> Panel:
     legend = (
+        "[green]●[/green] connected  "
+        "[red]⚠[/red] disconnected  "
         "[green]▰[/green] free GPU  "
         "[red]▱[/red] busy GPU   "
         "[green]█[/green]/[yellow]█[/yellow]/[red]█[/red] disk usage (low/med/high)   "
-        "[green]●[/green] online  "
-        "[red]⚠[/red] offline"
     )
     return Panel(legend, title="Legend", border_style="dim", padding=(0, 1))
 

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -261,7 +261,7 @@ def _build_cluster_table(data: list[ClusterStatus]) -> Table:
     table.add_column("$SCRATCH", justify="left", ratio=2)
 
     for c in data:
-        status_cell = Text("● ", style="bold green") if c.online else Text("⚠ ", style="bold red")
+        status = Text("● ", style="bold green") if c.online else Text("⚠ ", style="bold red")
         my_jobs = Text(f"{c.jobs.my_running} / {c.jobs.my_pending}", style="cyan")
         all_jobs = Text(f"{c.jobs.running} / {c.jobs.pending}", style="white")
 
@@ -272,7 +272,7 @@ def _build_cluster_table(data: list[ClusterStatus]) -> Table:
         row_style = "dim" if not c.online else ""
 
         table.add_row(
-            status_cell + Text(c.name, style="bold magenta" if c.online else "bold bright_black"),
+            status + Text(c.name, style="bold magenta" if c.online else "bold bright_black"),
             Text(c.gpu_model, style="bright_blue"),
             _gpu_bar(c.gpu_idle, c.gpu_total),
             my_jobs,

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -267,9 +267,9 @@ def _build_cluster_table(data: list[ClusterStatus]) -> Table:
 
     for c in data:
         if not c.online:
-            status_cell = Text("⚠ disconnected", style="bold red")
+            status_cell = Text("⚠ offline", style="bold red")
         else:
-            status_cell = Text("● connected", style="bold green")
+            status_cell = Text("● online", style="bold green")
 
         my_jobs = Text(f"{c.jobs.my_running} / {c.jobs.my_pending}", style="cyan")
         all_jobs = Text(f"{c.jobs.running} / {c.jobs.pending}", style="white")
@@ -347,11 +347,11 @@ def _build_my_jobs_table(data: list[ClusterStatus]) -> Table:
 
 def _build_legend() -> Panel:
     legend = (
-        "[green]●[/green] connected  "
-        "[red]⚠[/red] disconnected  "
+        "[green]●[/green] online  "
+        "[red]⚠[/red] offline  "
         "[green]▰[/green] free GPU  "
         "[red]▱[/red] busy GPU   "
-        "[green]█[/green]/[yellow]█[/yellow]/[red]█[/red] disk usage (low/med/high)   "
+        "[green]█[/green]/[yellow]█[/yellow]/[red]█[/red] disk usage (low/med/high)"
     )
     return Panel(legend, title="Legend", border_style="dim", padding=(0, 1))
 

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -97,7 +97,7 @@ squeue -h -t PD -o "%i" 2>/dev/null | wc -l; echo {_SEP}
 _MILA_CLUSTERS = {"mila"}
 
 
-async def get_real_cluster_status(cluster: str) -> ClusterStatus:
+async def get_cluster_status(cluster: str) -> ClusterStatus:
     """Fetch live Slurm data from a remote cluster and return a ClusterStatus.
 
     Uses a single SSH round-trip. Falls back gracefully when commands are
@@ -357,7 +357,7 @@ async def status(table: str) -> None:
     # Query clusters in parallel
     with console.status("Fetching clusters status..."):
         data: list[ClusterStatus] = [
-            d for d in await asyncio.gather(*(get_real_cluster_status(c) for c in clusters))
+            d for d in await asyncio.gather(*(get_cluster_status(c) for c in clusters))
         ]
 
     # Show a tip message if all clusters are offline, which likely means the user hasn't logged in yet (no control sockets).

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -12,7 +12,6 @@ from rich.text import Text
 
 from cluv.cli.login import get_remote_without_2fa_prompt
 from cluv.config import get_config
-from cluv.remote import Remote
 from cluv.slurm import (
     StorageStats,
     parse_disk_quota,
@@ -47,6 +46,18 @@ class ClusterStatus:
     gpu_model: str
     jobs: JobStats
     storage: StorageStats
+
+
+def get_default_cluster_status(cluster: str) -> ClusterStatus:
+    return ClusterStatus(
+        name=cluster,
+        online=False,
+        gpu_idle=0,
+        gpu_total=0,
+        gpu_model="?",
+        jobs=JobStats(running=0, pending=0, my_running=0, my_pending=0),
+        storage=StorageStats(home_used=0, home_quota=0, scratch_used=0, scratch_quota=0),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -90,14 +101,20 @@ squeue -h -t PD -o "%i" 2>/dev/null | wc -l; echo {_SEP}
 _MILA_CLUSTERS = {"mila"}
 
 
-async def get_real_cluster_status(remote: Remote) -> ClusterStatus:
+async def get_real_cluster_status(cluster: str) -> ClusterStatus:
     """Fetch live Slurm data from a remote cluster and return a ClusterStatus.
 
     Uses a single SSH round-trip. Falls back gracefully when commands are
     unavailable (e.g. partition-stats is DRAC-only).
     """
 
-    cluster = remote.hostname
+    # Use get_remote_without_2fa_prompt directly so we never filter out the
+    # "current" cluster the way login() does. A working socket for mila is
+    # perfectly usable even when /home/mila is mounted locally.
+    remote = await get_remote_without_2fa_prompt(cluster)
+    if remote is None:
+        return get_default_cluster_status(cluster)
+
     script = _REMOTE_SCRIPT_MILA if cluster in _MILA_CLUSTERS else _REMOTE_SCRIPT_DRAC
 
     try:
@@ -109,15 +126,7 @@ async def get_real_cluster_status(remote: Remote) -> ClusterStatus:
         )
     except Exception as exc:
         logger.warning(f"[red]Could not reach {cluster}: {exc}[/red]")
-        return ClusterStatus(
-            name=cluster,
-            online=False,
-            gpu_idle=0,
-            gpu_total=0,
-            gpu_model="?",
-            jobs=JobStats(running=0, pending=0, my_running=0, my_pending=0),
-            storage=StorageStats(home_used=0, home_quota=0, scratch_used=0, scratch_quota=0),
-        )
+        return get_default_cluster_status(cluster)
 
     parts = raw.split(_SEP)
     # Pad in case some sections are missing
@@ -197,33 +206,6 @@ async def get_real_cluster_status(remote: Remote) -> ClusterStatus:
     )
 
 
-async def get_all_cluster_statuses(
-    remotes: list[Remote] | None = None,
-) -> tuple[list[ClusterStatus], bool]:
-    """Query clusters in parallel.
-
-    If *remotes* is provided, query exactly those connections.
-    Otherwise, query all clusters that already have an active SSH connection
-    (never blocks on 2FA).
-
-    Returns (statuses, any_live) where any_live is False when no cluster
-    was reachable.
-    """
-    if remotes is None:
-        clusters = get_config().clusters
-        remotes = [
-            r
-            for r in await asyncio.gather(*(get_remote_without_2fa_prompt(c) for c in clusters))
-            if r is not None
-        ]
-
-    if not remotes:
-        return [], False
-
-    statuses = list(await asyncio.gather(*(get_real_cluster_status(r) for r in remotes)))
-    return statuses, True
-
-
 # ---------------------------------------------------------------------------
 # UI helpers
 # ---------------------------------------------------------------------------
@@ -285,9 +267,9 @@ def _build_cluster_table(data: list[ClusterStatus]) -> Table:
 
     for c in data:
         if not c.online:
-            status_cell = Text("⚠ offline", style="bold red")
+            status_cell = Text("⚠ disconnected", style="bold red")
         else:
-            status_cell = Text("● online", style="bold green")
+            status_cell = Text("● connected", style="bold green")
 
         my_jobs = Text(f"{c.jobs.my_running} / {c.jobs.my_pending}", style="cyan")
         all_jobs = Text(f"{c.jobs.running} / {c.jobs.pending}", style="white")
@@ -381,24 +363,16 @@ async def status(table: str) -> None:
     """
     console = Console()
     clusters = get_config().clusters_names
-    clusters = list(clusters or [])
 
-    if clusters:
-        # Use get_remote_without_2fa_prompt directly so we never filter out the
-        # "current" cluster the way login() does. A working socket for mila is
-        # perfectly usable even when /home/mila is mounted locally.
-        remotes = [
-            r
-            for r in await asyncio.gather(*(get_remote_without_2fa_prompt(c) for c in clusters))
-            if r is not None
-        ]
-        data, is_live = await get_all_cluster_statuses(remotes=remotes)
-    else:
-        data, is_live = await get_all_cluster_statuses()
+    # Query clusters in parallel
+    data: list[ClusterStatus] = [
+        d for d in await asyncio.gather(*(get_real_cluster_status(c) for c in clusters))
+    ]
 
-    if not is_live:
+    # Show a tip message if all clusters are offline, which likely means the user hasn't logged in yet (no control sockets).
+    if all(not c.online for c in data):
         console.print(
-            "[yellow]No active cluster connections found. Run [bold]cluv login[/bold] first.[/yellow]"
+            "[yellow]No active connections to any clusters found. Run [bold]cluv login[/bold] first.[/yellow]"
         )
 
     console.print()

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -60,10 +60,6 @@ def get_default_cluster_status(cluster: str) -> ClusterStatus:
     )
 
 
-# ---------------------------------------------------------------------------
-# Real data layer
-# ---------------------------------------------------------------------------
-
 # All commands are separated by a sentinel so we can split a single SSH output.
 _SEP = "---CLUV-SEP---"
 
@@ -341,8 +337,8 @@ def _build_my_jobs_table(data: list[ClusterStatus]) -> Table:
 
 def _build_legend() -> Panel:
     legend = (
-        "[green]●[/green] online  "
-        "[red]⚠[/red] offline  "
+        "[green]●[/green] connected  "
+        "[red]⚠[/red] disconnected  "
         "[green]▰[/green] free GPU  "
         "[red]▱[/red] busy GPU   "
         "[green]█[/green]/[yellow]█[/yellow]/[red]█[/red] disk usage (low/med/high)"

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -381,7 +381,7 @@ def _build_legend() -> Panel:
     return Panel(legend, title="Legend", border_style="dim", padding=(0, 1))
 
 
-async def status(clusters: list[str] | None = None):
+async def status(clusters: list[str] | None = None, show: str = "all"):
     """Gets the status of available clusters.
     - Gives you an overview of the state of each cluster, and displays an overview of the state of your jobs across the clusters.
     - Displays the number of idle nodes, or the number of idle GPUs, or something similar, for each cluster
@@ -411,9 +411,10 @@ async def status(clusters: list[str] | None = None):
     console.rule("[bold cyan]cluv status[/bold cyan]")
     console.print()
 
-    console.print(_build_cluster_table(data))
-    console.print()
-    console.print(_build_my_jobs_table(data))
-    console.print()
-    console.print(_build_legend())
-    console.print()
+    if show in ("clusters", "all"):
+        console.print(_build_cluster_table(data))
+        console.print(_build_legend())
+        console.print()
+    if show in ("jobs", "all"):
+        console.print(_build_my_jobs_table(data))
+        console.print()

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -382,12 +382,13 @@ def _build_legend() -> Panel:
     return Panel(legend, title="Legend", border_style="dim", padding=(0, 1))
 
 
-async def status(clusters: list[str] | None = None, show: str = "all"):
+async def status(table: str) -> None:
     """Gets the status of available clusters.
     - Gives you an overview of the state of each cluster, and displays an overview of the state of your jobs across the clusters.
     - Displays the number of idle nodes, or the number of idle GPUs, or something similar, for each cluster
     """
     console = Console()
+    clusters = get_config().clusters_names
     clusters = list(clusters or [])
 
     if clusters:
@@ -412,10 +413,10 @@ async def status(clusters: list[str] | None = None, show: str = "all"):
     console.rule("[bold cyan]cluv status[/bold cyan]")
     console.print()
 
-    if show in ("clusters", "all"):
+    if table in ("clusters", "all"):
         console.print(_build_cluster_table(data))
         console.print(_build_legend())
         console.print()
-    if show in ("jobs", "all"):
+    if table in ("jobs", "all"):
         console.print(_build_my_jobs_table(data))
         console.print()

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -13,6 +13,14 @@ from rich.text import Text
 from cluv.cli.login import get_remote_without_2fa_prompt
 from cluv.config import get_config
 from cluv.remote import Remote
+from cluv.slurm import (
+    StorageStats,
+    parse_disk_quota,
+    parse_diskusage_report,
+    parse_partition_stats,
+    parse_savail,
+    parse_sinfo_nodes,
+)
 
 logger = logging.getLogger(__name__)
 __all__ = ["status"]
@@ -28,15 +36,6 @@ class JobStats:
     cancelled: int | None = None
     completed: int | None = None
     my_completed: int | None = None  # recently completed jobs for the current user
-
-
-@dataclass
-class StorageStats:
-    """Disk usage as (used_gib, quota_gib) for $HOME and $SCRATCH."""
-    home_used: float
-    home_quota: float
-    scratch_used: float
-    scratch_quota: float
 
 
 @dataclass
@@ -97,13 +96,6 @@ async def get_real_cluster_status(remote: Remote) -> ClusterStatus:
     Uses a single SSH round-trip. Falls back gracefully when commands are
     unavailable (e.g. partition-stats is DRAC-only).
     """
-    from cluv.slurm import (
-        parse_disk_quota,
-        parse_diskusage_report,
-        parse_partition_stats,
-        parse_savail,
-        parse_sinfo_nodes,
-    )
 
     cluster = remote.hostname
     script = _REMOTE_SCRIPT_MILA if cluster in _MILA_CLUSTERS else _REMOTE_SCRIPT_DRAC

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -365,9 +365,10 @@ async def status(table: str) -> None:
     clusters = get_config().clusters_names
 
     # Query clusters in parallel
-    data: list[ClusterStatus] = [
-        d for d in await asyncio.gather(*(get_real_cluster_status(c) for c in clusters))
-    ]
+    with console.status("Fetching cluster status...",):
+        data: list[ClusterStatus] = [
+            d for d in await asyncio.gather(*(get_real_cluster_status(c) for c in clusters))
+        ]
 
     # Show a tip message if all clusters are offline, which likely means the user hasn't logged in yet (no control sockets).
     if all(not c.online for c in data):

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -257,20 +257,15 @@ def _build_cluster_table(data: list[ClusterStatus]) -> Table:
     )
 
     table.add_column("Cluster", style="bold", ratio=1)
-    table.add_column("Status", justify="center", ratio=1)
-    table.add_column("GPU model", justify="center", ratio=1)
-    table.add_column("Free GPUs", justify="left", ratio=2)
+    table.add_column("GPU model", justify="center", ratio=2)
+    table.add_column("Free GPUs", justify="left", ratio=1)
     table.add_column("My jobs\nrun/pend", justify="center", ratio=1)
     table.add_column("All jobs\nrun/pend", justify="center", ratio=1)
     table.add_column("$HOME", justify="left", ratio=2)
     table.add_column("$SCRATCH", justify="left", ratio=2)
 
     for c in data:
-        if not c.online:
-            status_cell = Text("⚠ offline", style="bold red")
-        else:
-            status_cell = Text("● online", style="bold green")
-
+        status_cell = Text("● ", style="bold green") if c.online else Text("⚠ ", style="bold red")
         my_jobs = Text(f"{c.jobs.my_running} / {c.jobs.my_pending}", style="cyan")
         all_jobs = Text(f"{c.jobs.running} / {c.jobs.pending}", style="white")
 
@@ -281,8 +276,7 @@ def _build_cluster_table(data: list[ClusterStatus]) -> Table:
         row_style = "dim" if not c.online else ""
 
         table.add_row(
-            Text(c.name, style="bold magenta" if c.online else "dim"),
-            status_cell,
+            status_cell + Text(c.name, style="bold magenta" if c.online else "bold bright_black"),
             Text(c.gpu_model, style="bright_blue"),
             _gpu_bar(c.gpu_idle, c.gpu_total),
             my_jobs,
@@ -365,7 +359,7 @@ async def status(table: str) -> None:
     clusters = get_config().clusters_names
 
     # Query clusters in parallel
-    with console.status("Fetching cluster status...",):
+    with console.status("Fetching clusters status..."):
         data: list[ClusterStatus] = [
             d for d in await asyncio.gather(*(get_real_cluster_status(c) for c in clusters))
         ]

--- a/cluv/slurm.py
+++ b/cluv/slurm.py
@@ -6,8 +6,16 @@ All functions are free of I/O and can be unit-tested against fixture strings.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
-from cluv.cli.status import StorageStats
+
+@dataclass
+class StorageStats:
+    """Disk usage as (used_gib, quota_gib) for $HOME and $SCRATCH."""
+    home_used: float
+    home_quota: float
+    scratch_used: float
+    scratch_quota: float
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,12 +17,12 @@ import milatools.cli.init_command
 import pytest
 import pytest_asyncio
 
-from cluv.config import load_cluv_config
 from cluv.cli.init import DEFAULT_RESULTS_PATH, init
 from cluv.cli.login import get_remote_without_2fa_prompt, login
-from cluv.cli.status import ClusterStatus, get_real_cluster_status
+from cluv.cli.status import ClusterStatus, get_cluster_status
 from cluv.cli.submit import submit
 from cluv.cli.sync import sync
+from cluv.config import load_cluv_config
 from cluv.remote import Remote, control_socket_is_running
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -127,8 +127,8 @@ async def test_login(remote: Remote):
 
 
 @pytest_asyncio.fixture(scope="session")
-async def cluster_status(remote: Remote):
-    return await get_real_cluster_status(remote)
+async def cluster_status(cluster: str) -> ClusterStatus:
+    return await get_cluster_status(cluster)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Add the argument `table` to `cluv status` to only show the table that the user need. 3 possible options :
   * `cluster`, show only the cluster table with the legend.
   * `job`, show only the job table.
   * `all`, show the two tables.
* Remove the argument `clusters` of `cluv status`. The command will now automatically try to get the infos of the clusters specified in the config.
* Merge `Cluster` and `Status` columns.
* Rework title style of the cluster and job tables.

## Example
<img width="1694" height="587" alt="Capture d’écran, le 2026-05-29 à 15 00 17" src="https://github.com/user-attachments/assets/47dd8abb-ea2c-49f4-bf38-ff1dd1aa40d1" />

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
* Close #58 