### PR TITLE
Fix cluster table columns with ratio instead of width

### DIFF
--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -416,16 +416,16 @@ def _build_cluster_table(data: list[ClusterStatus]) -> Table:
         expand=True,
     )
 
-    table.add_column("Cluster", style="bold")
-    table.add_column("Status", justify="center")
-    table.add_column("GPU model", justify="center")
-    table.add_column("Free GPUs", justify="left")
-    table.add_column("My jobs\nrun/pend", justify="center")
-    table.add_column("All jobs\nrun/pend", justify="center")
-    table.add_column("Avg wait", justify="center")
-    table.add_column("GPU util", justify="center")
-    table.add_column("$HOME", justify="left")
-    table.add_column("$SCRATCH", justify="left")
+    table.add_column("Cluster", style="bold", ratio=1)
+    table.add_column("Status", justify="center", ratio=1)
+    table.add_column("GPU model", justify="center", ratio=1)
+    table.add_column("Free GPUs", justify="left", ratio=2)
+    table.add_column("My jobs\nrun/pend", justify="center", ratio=1)
+    table.add_column("All jobs\nrun/pend", justify="center", ratio=1)
+    table.add_column("Avg wait", justify="center", ratio=1)
+    table.add_column("GPU util", justify="center", ratio=1)
+    table.add_column("$HOME", justify="left", ratio=2)
+    table.add_column("$SCRATCH", justify="left", ratio=2)
 
     for c in data:
         if not c.online:

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -416,16 +416,16 @@ def _build_cluster_table(data: list[ClusterStatus]) -> Table:
         expand=True,
     )
 
-    table.add_column("Cluster", style="bold", min_width=10)
-    table.add_column("Status", justify="center", min_width=8)
-    table.add_column("GPU model", justify="center", min_width=9)
-    table.add_column("Free GPUs", justify="left", min_width=20)
-    table.add_column("My jobs\nrun/pend", justify="center", min_width=9)
-    table.add_column("All jobs\nrun/pend", justify="center", min_width=10)
-    table.add_column("Avg wait", justify="center", min_width=8)
-    table.add_column("GPU util", justify="center", min_width=8)
-    table.add_column("$HOME", justify="left", min_width=18)
-    table.add_column("$SCRATCH", justify="left", min_width=18)
+    table.add_column("Cluster", style="bold")
+    table.add_column("Status", justify="center")
+    table.add_column("GPU model", justify="center")
+    table.add_column("Free GPUs", justify="left")
+    table.add_column("My jobs\nrun/pend", justify="center")
+    table.add_column("All jobs\nrun/pend", justify="center")
+    table.add_column("Avg wait", justify="center")
+    table.add_column("GPU util", justify="center")
+    table.add_column("$HOME", justify="left")
+    table.add_column("$SCRATCH", justify="left")
 
     for c in data:
         if not c.online:


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Use `ratio` to make columns adapt to content but still use all available width, and justify where it makes sense.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
* Close #67