### PR TITLE
fix(ssh): resolve ssh config path lazily and tolerate match-only stanzas

### DIFF
--- a/cluv/ssh.py
+++ b/cluv/ssh.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import paramiko
 
 
-
 def get_ssh_hostnames() -> set[str]:
     # Resolve at call time so test fixtures can monkeypatch `Path.home`.
     ssh_config_path = Path.home() / ".ssh" / "config"

--- a/cluv/ssh.py
+++ b/cluv/ssh.py
@@ -1,12 +1,18 @@
 from pathlib import Path
 import paramiko
 
-SSH_CONFIG_PATH = Path.home() / ".ssh" / "config"
 
 
 def get_ssh_hostnames() -> set[str]:
-    if not SSH_CONFIG_PATH.exists():
+    # Resolve at call time so test fixtures can monkeypatch `Path.home`.
+    ssh_config_path = Path.home() / ".ssh" / "config"
+    if not ssh_config_path.exists():
         return set()
-    ssh_config = paramiko.SSHConfig.from_path(SSH_CONFIG_PATH)
-
-    return ssh_config.get_hostnames()
+    ssh_config = paramiko.SSHConfig.from_path(ssh_config_path)
+    try:
+        return ssh_config.get_hostnames()
+    except KeyError:
+        # paramiko<=4.0 raises KeyError on `Match host X exec ...` stanzas
+        # because the parsed entry has no `host` key. Fall back to a scan
+        # that simply skips those entries.
+        return {h for entry in ssh_config._config for h in entry.get("host", ())}

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -8,25 +8,24 @@ import cluv.ssh as cluv_ssh
 
 
 @pytest.fixture(autouse=True)
-def patch_ssh_config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(cluv_ssh, "SSH_CONFIG_PATH", tmp_path / "config")
+def ssh_config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".ssh").mkdir()
+    return tmp_path / ".ssh" / "config"
 
 
 class TestGetHostnames:
     def test_returns_empty_set_when_no_file(self):
         assert cluv_ssh.get_ssh_hostnames() == set()
 
-    def test_returns_default_wildcard_for_empty_file(self, tmp_path: Path):
-        p = tmp_path / "config"
-        p.touch()
+    def test_returns_default_wildcard_for_empty_file(self, ssh_config_path: Path):
+        ssh_config_path.touch()
         assert cluv_ssh.get_ssh_hostnames() == set("*")
 
-    def test_get_all_hosts(self, tmp_path: Path):
-        p = tmp_path / "config"
-        p.write_text("Host mila\nHost narval\nHost rorqual\n")
+    def test_get_all_hosts(self, ssh_config_path: Path):
+        ssh_config_path.write_text("Host mila\nHost narval\nHost rorqual\n")
         assert cluv_ssh.get_ssh_hostnames() == {"*", "mila", "narval", "rorqual"}
 
-    def test_returns_no_duplicates(self, tmp_path: Path):
-        p = tmp_path / "config"
-        p.write_text("Host mila\nHost mila\n")
+    def test_returns_no_duplicates(self, ssh_config_path: Path):
+        ssh_config_path.write_text("Host mila\nHost mila\n")
         assert cluv_ssh.get_ssh_hostnames() == {"*", "mila"}


### PR DESCRIPTION
If you run `pytest tests/test_integration.py` locally on cluv main and your `~/.ssh/config` happens to contain a `Match host X exec ...` block, six `test_init` parametrizations crash with `KeyError: 'host'` inside paramiko. CI passes because CI's ssh config has none, so the breakage only shows up on dev laptops.

Two small things combine to cause it. `cluv/ssh.py` evaluates `SSH_CONFIG_PATH` at module import, so by the time `tmp_path` monkeypatches `Path.home`, the constant already points at your real home directory. The tests end up reading whatever you have on disk. And paramiko 4.0.0's `SSHConfig.get_hostnames()` indexes `entry["host"]` unconditionally, which a pure `Match` block doesn't have, so it raises.

The fix resolves the path inside `get_ssh_hostnames` so the fixture's monkeypatch actually applies, and wraps the paramiko call in a try/except that falls back to scanning `_config` and skipping match-only entries.

---

*AI (Claude) supported my development of this PR.*