### PR TITLE
feat: opt-in Apptainer container support

### DIFF
--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -155,12 +155,6 @@ def add_build_args(subparsers: Subparsers) -> argparse.ArgumentParser:
         help="The cluster to build the container on.",
     )
     build_parser.add_argument(
-        "--extra",
-        metavar="<group>",
-        default=None,
-        help="Optional extras group to include (e.g. 'runtime').",
-    )
-    build_parser.add_argument(
         "--no-sync",
         action="store_true",
         default=False,

--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -20,6 +20,7 @@ import rich.logging
 import rich_argparse
 import simple_parsing
 
+from .cli.build import build
 from .cli.init import init
 from .cli.login import login
 from .cli.run import run
@@ -58,6 +59,9 @@ def main(argv: list[str] | None = None) -> None:
     subparsers = parser.add_subparsers(dest="<command>", required=True)
 
     # add -v/--verbose to each subparser as well.
+    build_parser = add_build_args(subparsers)
+    _add_v_arg(build_parser)
+
     init_parser = add_init_args(subparsers)
     _add_v_arg(init_parser)
 
@@ -137,6 +141,33 @@ def add_submit_args(
     )
     submit_parser.set_defaults(func=submit)
     return submit_parser
+
+
+def add_build_args(subparsers: Subparsers) -> argparse.ArgumentParser:
+    build_parser = subparsers.add_parser(
+        "build",
+        help="Build an Apptainer container on a remote cluster.",
+        formatter_class=rich_argparse.RichHelpFormatter,
+    )
+    build_parser.add_argument(
+        "cluster",
+        metavar="<cluster>",
+        help="The cluster to build the container on.",
+    )
+    build_parser.add_argument(
+        "--extra",
+        metavar="<group>",
+        default=None,
+        help="Optional extras group to include (e.g. 'runtime').",
+    )
+    build_parser.add_argument(
+        "--no-sync",
+        action="store_true",
+        default=False,
+        help="Skip syncing the project before building.",
+    )
+    build_parser.set_defaults(func=build)
+    return build_parser
 
 
 def add_status_args(subparsers: Subparsers) -> argparse.ArgumentParser:

--- a/cluv/cli/build.py
+++ b/cluv/cli/build.py
@@ -8,11 +8,15 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
 
 from cluv.cli.login import login
 from cluv.cli.sync import sync
 from cluv.config import ContainerConfig, find_pyproject, get_cluv_config
 from cluv.utils import console
+
+if TYPE_CHECKING:
+    from cluv.remote import Remote
 
 logger = logging.getLogger(__name__)
 
@@ -69,13 +73,11 @@ async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -
     container: ContainerConfig = cluster_config.container
 
     if not no_sync:
-        await sync(clusters=[cluster])
+        remotes = await sync(clusters=[cluster])
     else:
-        await login([cluster])
+        remotes = await login([cluster])
 
-    remotes = await login([cluster])
     remote = remotes[0]
-
     project_path = PurePosixPath(find_pyproject().parent.relative_to(Path.home()))
 
     console.print("[bold]Exporting pinned requirements from uv.lock...[/bold]")
@@ -111,6 +113,8 @@ async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -
     console.print("[bold]Building container (this may take several minutes)...[/bold]")
 
     # GOMAXPROCS=1 prevents pids.max cgroup kills on DRAC login nodes.
+    # Their user.slice cgroup has pids.max=512; Go's default thread-per-CPU
+    # overshoots during OCI fetch, killing the build with EAGAIN.
     build_cmd = (
         f"bash -l -c '"
         f"export GOMAXPROCS=${{GOMAXPROCS:-1}} GOMEMLIMIT=${{GOMEMLIMIT:-2GiB}}; "
@@ -122,6 +126,21 @@ async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -
     result = await remote.run(build_cmd, display=True, hide=False)
     if result.returncode != 0:
         console.print("[red]Container build failed.[/red]")
+        await _cleanup_build_dir(remote)
+        return None
+
+    # Verify the image loads before deploying.
+    console.print("[bold]Verifying container...[/bold]")
+    verify_cmd = (
+        f"bash -l -c '"
+        f"module load apptainer 2>/dev/null || true; "
+        f"apptainer exec /tmp/cluv-build/{sif_name} "
+        f"python -c \"import importlib.metadata; print(\\\"verify OK\\\")\"'"
+    )
+    result = await remote.run(verify_cmd, display=True, hide="out")
+    if result.returncode != 0:
+        console.print("[red]Container verification failed.[/red]")
+        await _cleanup_build_dir(remote)
         return None
 
     console.print(f"[bold]Deploying to {deploy_path}...[/bold]")
@@ -130,16 +149,22 @@ async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -
         f"mkdir -p {deploy_path} && "
         f"cp /tmp/cluv-build/{sif_name} {deploy_path}/{sif_name} && "
         f"chmod 640 {deploy_path}/{sif_name} && "
-        f"ln -sfn {sif_name} {deploy_path}/current.sif && "
-        f"rm -rf /tmp/cluv-build"
+        f"ln -sfn {sif_name} {deploy_path}/current.sif"
         f"'"
     )
     result = await remote.run(deploy_cmd, display=True, hide=True)
     if result.returncode != 0:
         console.print("[red]Deploy failed.[/red]")
+        await _cleanup_build_dir(remote)
         return None
+
+    await _cleanup_build_dir(remote)
 
     sif_path = f"{deploy_path}/{sif_name}"
     console.print(f"[green]Container deployed: {sif_path}[/green]")
     console.print(f"[green]Symlink: {deploy_path}/current.sif -> {sif_name}[/green]")
     return sif_path
+
+
+async def _cleanup_build_dir(remote: "Remote") -> None:
+    await remote.run("rm -rf /tmp/cluv-build", warn=True, hide=True, display=False)

--- a/cluv/cli/build.py
+++ b/cluv/cli/build.py
@@ -8,15 +8,11 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING
 
 from cluv.cli.login import login
 from cluv.cli.sync import sync
 from cluv.config import ContainerConfig, find_pyproject, get_cluv_config
 from cluv.utils import console
-
-if TYPE_CHECKING:
-    from cluv.remote import Remote
 
 logger = logging.getLogger(__name__)
 
@@ -81,15 +77,23 @@ async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -
     project_path = PurePosixPath(find_pyproject().parent.relative_to(Path.home()))
 
     console.print("[bold]Exporting pinned requirements from uv.lock...[/bold]")
-    uv_extra = f"--extra {extra}" if extra else ""
-    export_cmd = (
-        f"bash -l -c 'cd ~/{project_path} && "
-        f"uv export --locked --no-dev --no-hashes --no-annotate --no-header --no-emit-project "
-        f"{uv_extra} --format requirements-txt'"
-    )
+    export_parts = [
+        "uv export --locked --no-dev --no-hashes --no-annotate --no-header --no-emit-project",
+    ]
+    if extra:
+        export_parts.append(f"--extra {extra}")
+    export_parts.append("--format requirements-txt")
+    export_cmd = f"bash -l -c 'cd ~/{project_path} && {' '.join(export_parts)}'"
     result = await remote.run(export_cmd, display=True, hide="out")
     if result.returncode != 0:
-        console.print(f"[red]uv export failed: {result.stderr}[/red]")
+        stderr = result.stderr.strip()
+        if "locked" in stderr.lower() or "lock" in stderr.lower():
+            console.print(
+                "[red]uv.lock is out of sync with pyproject.toml. "
+                "Run 'uv lock' locally, commit, and try again.[/red]"
+            )
+        else:
+            console.print(f"[red]uv export failed: {stderr}[/red]")
         return None
     requirements = result.stdout
 
@@ -107,7 +111,8 @@ async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -
     git_sha = await remote.get_output(
         f"git -C ~/{project_path} rev-parse --short HEAD",
     )
-    sif_name = f"train-{git_sha}.sif"
+    project_name = find_pyproject().parent.name
+    sif_name = f"{project_name}-{git_sha}.sif"
     deploy_path = container.deploy_path
 
     console.print("[bold]Building container (this may take several minutes)...[/bold]")
@@ -131,11 +136,11 @@ async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -
 
     # Verify the image loads before deploying.
     console.print("[bold]Verifying container...[/bold]")
+    verify_script = "import sys; sys.exit(0)"
     verify_cmd = (
         f"bash -l -c '"
         f"module load apptainer 2>/dev/null || true; "
-        f"apptainer exec /tmp/cluv-build/{sif_name} "
-        f"python -c \"import importlib.metadata; print(\\\"verify OK\\\")\"'"
+        f"apptainer exec /tmp/cluv-build/{sif_name} python -c \"{verify_script}\"'"
     )
     result = await remote.run(verify_cmd, display=True, hide="out")
     if result.returncode != 0:
@@ -166,5 +171,5 @@ async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -
     return sif_path
 
 
-async def _cleanup_build_dir(remote: "Remote") -> None:
+async def _cleanup_build_dir(remote) -> None:
     await remote.run("rm -rf /tmp/cluv-build", warn=True, hide=True, display=False)

--- a/cluv/cli/build.py
+++ b/cluv/cli/build.py
@@ -1,0 +1,145 @@
+"""Build an Apptainer container on a remote cluster.
+
+Generates pinned requirements from uv.lock, uploads an Apptainer definition,
+builds a .sif image, and deploys it to the configured path.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path, PurePosixPath
+
+from cluv.cli.login import login
+from cluv.cli.sync import sync
+from cluv.config import ContainerConfig, find_pyproject, get_cluv_config
+from cluv.utils import console
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["build"]
+
+
+def generate_def(base_image: str, extra_apt: list[str], extra_pip_args: str) -> str:
+    post_lines = []
+    if extra_apt:
+        pkgs = " ".join(extra_apt)
+        post_lines.append(
+            f"apt-get update && apt-get install -y --no-install-recommends {pkgs} "
+            "&& rm -rf /var/lib/apt/lists/*"
+        )
+    pip_cmd = "pip install --no-cache-dir"
+    if extra_pip_args:
+        pip_cmd += f" {extra_pip_args}"
+    pip_cmd += " -r /build/requirements.txt"
+    post_lines.append(pip_cmd)
+    post_lines.append("mv /build/requirements.txt /opt/requirements.txt")
+    post_lines.append("rm -rf /build")
+
+    post_body = "\n    ".join(post_lines)
+
+    return (
+        f"Bootstrap: docker\n"
+        f"From: {base_image}\n"
+        f"\n"
+        f"%files\n"
+        f"    /tmp/cluv-build/requirements.txt /build/requirements.txt\n"
+        f"\n"
+        f"%post\n"
+        f"    {post_body}\n"
+        f"\n"
+        f"%test\n"
+        f'    python -c "import importlib.metadata; print(\'container OK\')"\n'
+    )
+
+
+async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -> str | None:
+    """Build an Apptainer container on the given cluster.
+
+    Returns the remote path to the built .sif, or None on failure.
+    """
+    config = get_cluv_config()
+    cluster_config = config.clusters.get(cluster)
+    if not cluster_config or not cluster_config.container:
+        console.print(
+            f"[red]No container config for cluster '{cluster}'.[/red]\n"
+            f"Add [tool.cluv.clusters.{cluster}.container] to pyproject.toml."
+        )
+        return None
+
+    container: ContainerConfig = cluster_config.container
+
+    if not no_sync:
+        await sync(clusters=[cluster])
+    else:
+        await login([cluster])
+
+    remotes = await login([cluster])
+    remote = remotes[0]
+
+    project_path = PurePosixPath(find_pyproject().parent.relative_to(Path.home()))
+
+    console.print("[bold]Exporting pinned requirements from uv.lock...[/bold]")
+    uv_extra = f"--extra {extra}" if extra else ""
+    export_cmd = (
+        f"bash -l -c 'cd ~/{project_path} && "
+        f"uv export --locked --no-dev --no-hashes --no-annotate --no-header --no-emit-project "
+        f"{uv_extra} --format requirements-txt'"
+    )
+    result = await remote.run(export_cmd, display=True, hide="out")
+    if result.returncode != 0:
+        console.print(f"[red]uv export failed: {result.stderr}[/red]")
+        return None
+    requirements = result.stdout
+
+    console.print("[bold]Uploading build context...[/bold]")
+    await remote.run("mkdir -p /tmp/cluv-build", hide=True)
+    await remote.run(
+        "cat > /tmp/cluv-build/requirements.txt",
+        input=requirements,
+        hide=True,
+    )
+
+    def_content = generate_def(container.base_image, container.extra_apt, container.extra_pip_args)
+    await remote.run("cat > /tmp/cluv-build/container.def", input=def_content, hide=True)
+
+    git_sha = await remote.get_output(
+        f"git -C ~/{project_path} rev-parse --short HEAD",
+    )
+    sif_name = f"train-{git_sha}.sif"
+    deploy_path = container.deploy_path
+
+    console.print("[bold]Building container (this may take several minutes)...[/bold]")
+
+    # GOMAXPROCS=1 prevents pids.max cgroup kills on DRAC login nodes.
+    build_cmd = (
+        f"bash -l -c '"
+        f"export GOMAXPROCS=${{GOMAXPROCS:-1}} GOMEMLIMIT=${{GOMEMLIMIT:-2GiB}}; "
+        f"module load apptainer 2>/dev/null || true; "
+        f"cd /tmp/cluv-build && "
+        f"apptainer build {sif_name} container.def"
+        f"'"
+    )
+    result = await remote.run(build_cmd, display=True, hide=False)
+    if result.returncode != 0:
+        console.print("[red]Container build failed.[/red]")
+        return None
+
+    console.print(f"[bold]Deploying to {deploy_path}...[/bold]")
+    deploy_cmd = (
+        f"bash -l -c '"
+        f"mkdir -p {deploy_path} && "
+        f"cp /tmp/cluv-build/{sif_name} {deploy_path}/{sif_name} && "
+        f"chmod 640 {deploy_path}/{sif_name} && "
+        f"ln -sfn {sif_name} {deploy_path}/current.sif && "
+        f"rm -rf /tmp/cluv-build"
+        f"'"
+    )
+    result = await remote.run(deploy_cmd, display=True, hide=True)
+    if result.returncode != 0:
+        console.print("[red]Deploy failed.[/red]")
+        return None
+
+    sif_path = f"{deploy_path}/{sif_name}"
+    console.print(f"[green]Container deployed: {sif_path}[/green]")
+    console.print(f"[green]Symlink: {deploy_path}/current.sif -> {sif_name}[/green]")
+    return sif_path

--- a/cluv/cli/build.py
+++ b/cluv/cli/build.py
@@ -2,12 +2,17 @@
 
 Generates pinned requirements from uv.lock, uploads an Apptainer definition,
 builds a .sif image, and deploys it to the configured path.
+
+The image is tagged by a content hash of uv.lock + the container config
+(see ContainerConfig.image_tag), so rebuilding with unchanged dependencies
+is a no-op and `cluv submit` can pin jobs to the exact image.
 """
 
 from __future__ import annotations
 
 import logging
-from pathlib import Path, PurePosixPath
+import subprocess
+from pathlib import Path
 
 from cluv.cli.login import login
 from cluv.cli.sync import sync
@@ -52,7 +57,40 @@ def generate_def(base_image: str, extra_apt: list[str], extra_pip_args: str) -> 
     )
 
 
-async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -> str | None:
+def export_requirements(project_root: Path, extra: str | None) -> str | None:
+    """Export pinned requirements from uv.lock, locally.
+
+    Local export guarantees the requirements match the uv.lock that the image
+    tag is computed from. Returns None (with a console message) on failure.
+    """
+    cmd = [
+        "uv",
+        "export",
+        "--locked",
+        "--no-dev",
+        "--no-hashes",
+        "--no-annotate",
+        "--no-header",
+        "--no-emit-project",
+    ]
+    if extra:
+        cmd += ["--extra", extra]
+    cmd += ["--format", "requirements-txt"]
+    result = subprocess.run(cmd, cwd=project_root, capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if "lock" in stderr.lower():
+            console.print(
+                "[red]uv.lock is out of sync with pyproject.toml. "
+                "Run 'uv lock', commit, and try again.[/red]"
+            )
+        else:
+            console.print(f"[red]uv export failed: {stderr}[/red]")
+        return None
+    return result.stdout
+
+
+async def build(cluster: str, no_sync: bool = False) -> str | None:
     """Build an Apptainer container on the given cluster.
 
     Returns the remote path to the built .sif, or None on failure.
@@ -67,35 +105,36 @@ async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -
         return None
 
     container: ContainerConfig = cluster_config.container
+    project_root = find_pyproject().parent
+
+    lock_path = project_root / "uv.lock"
+    if not lock_path.exists():
+        console.print("[red]No uv.lock found. Run 'uv lock' first.[/red]")
+        return None
+
+    console.print("[bold]Exporting pinned requirements from uv.lock...[/bold]")
+    requirements = export_requirements(project_root, container.extra)
+    if requirements is None:
+        return None
+
+    sif_name = container.sif_filename(project_root.name, lock_path.read_bytes())
+    deploy_path = container.deploy_path
+    sif_path = f"{deploy_path}/{sif_name}"
 
     if not no_sync:
         remotes = await sync(clusters=[cluster])
     else:
         remotes = await login([cluster])
-
     remote = remotes[0]
-    project_path = PurePosixPath(find_pyproject().parent.relative_to(Path.home()))
 
-    console.print("[bold]Exporting pinned requirements from uv.lock...[/bold]")
-    export_parts = [
-        "uv export --locked --no-dev --no-hashes --no-annotate --no-header --no-emit-project",
-    ]
-    if extra:
-        export_parts.append(f"--extra {extra}")
-    export_parts.append("--format requirements-txt")
-    export_cmd = f"bash -l -c 'cd ~/{project_path} && {' '.join(export_parts)}'"
-    result = await remote.run(export_cmd, display=True, hide="out")
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        if "locked" in stderr.lower() or "lock" in stderr.lower():
-            console.print(
-                "[red]uv.lock is out of sync with pyproject.toml. "
-                "Run 'uv lock' locally, commit, and try again.[/red]"
-            )
-        else:
-            console.print(f"[red]uv export failed: {stderr}[/red]")
-        return None
-    requirements = result.stdout
+    # Same lock + config = same image: skip the build if it's already deployed.
+    result = await remote.run(f"test -f {sif_path}", warn=True, hide=True, display=False)
+    if result.returncode == 0:
+        await remote.run(
+            f"ln -sfn {sif_name} {deploy_path}/current.sif", warn=True, hide=True, display=False
+        )
+        console.print(f"[green]Image already deployed (dependencies unchanged): {sif_path}[/green]")
+        return sif_path
 
     console.print("[bold]Uploading build context...[/bold]")
     await remote.run("mkdir -p /tmp/cluv-build", hide=True)
@@ -107,13 +146,6 @@ async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -
 
     def_content = generate_def(container.base_image, container.extra_apt, container.extra_pip_args)
     await remote.run("cat > /tmp/cluv-build/container.def", input=def_content, hide=True)
-
-    git_sha = await remote.get_output(
-        f"git -C ~/{project_path} rev-parse --short HEAD",
-    )
-    project_name = find_pyproject().parent.name
-    sif_name = f"{project_name}-{git_sha}.sif"
-    deploy_path = container.deploy_path
 
     console.print("[bold]Building container (this may take several minutes)...[/bold]")
 
@@ -165,7 +197,6 @@ async def build(cluster: str, extra: str | None = None, no_sync: bool = False) -
 
     await _cleanup_build_dir(remote)
 
-    sif_path = f"{deploy_path}/{sif_name}"
     console.print(f"[green]Container deployed: {sif_path}[/green]")
     console.print(f"[green]Symlink: {deploy_path}/current.sif -> {sif_name}[/green]")
     return sif_path

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -291,9 +291,18 @@ def get_sbatch_command(
             )
         )
 
-    # Inject CONTAINER_PATH when the cluster has container config.
+    # Inject CONTAINER_PATH when the cluster has container config. Pin the
+    # content-hash-tagged image instead of the mutable current.sif symlink, so
+    # a build between submit and job start can't change what a queued job runs.
     if cluster_config.container and "CONTAINER_PATH" not in env_vars:
-        env_vars["CONTAINER_PATH"] = f"{cluster_config.container.deploy_path}/current.sif"
+        lock_path = project_root / "uv.lock"
+        if not lock_path.exists():
+            raise FileNotFoundError(
+                f"{lock_path} not found: it is needed to pin the container image "
+                f"for cluster '{cluster}'. Run 'uv lock' first."
+            )
+        sif_name = cluster_config.container.sif_filename(project_root.name, lock_path.read_bytes())
+        env_vars["CONTAINER_PATH"] = f"{cluster_config.container.deploy_path}/{sif_name}"
 
     env_vars_prefix = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env_vars.items())
     sbatch_args_str = " ".join(shlex.quote(f) for f in sbatch_args)

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -291,6 +291,10 @@ def get_sbatch_command(
             )
         )
 
+    # Inject CONTAINER_PATH when the cluster has container config.
+    if cluster_config.container and "CONTAINER_PATH" not in env_vars:
+        env_vars["CONTAINER_PATH"] = f"{cluster_config.container.deploy_path}/current.sif"
+
     env_vars_prefix = " ".join(f"{k}={shlex.quote(str(v))}" for k, v in env_vars.items())
     sbatch_args_str = " ".join(shlex.quote(f) for f in sbatch_args)
     program_args_str = shlex.join(program_args)

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -10,7 +10,7 @@ import tomllib
 from dataclasses import field
 from pathlib import Path
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from pydantic.dataclasses import dataclass
 
 from cluv.utils import current_cluster
@@ -25,6 +25,13 @@ class ContainerConfig(BaseModel):
 
     deploy_path: str
     """Remote path where built .sif images are stored (e.g. '/project/acct/containers')."""
+
+    @field_validator("deploy_path")
+    @classmethod
+    def deploy_path_must_be_absolute(cls, v: str) -> str:
+        if not v.startswith("/"):
+            raise ValueError(f"deploy_path must be an absolute path, got '{v}'")
+        return v
 
     base_image: str = "python:3.12-slim"
     """Docker base image for the Apptainer definition."""

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import hashlib
 import logging
 import os
 import tomllib
@@ -41,6 +42,25 @@ class ContainerConfig(BaseModel):
 
     extra_pip_args: str = ""
     """Extra arguments passed to pip install inside the container (e.g. '--extra-index-url ...')."""
+
+    extra: str | None = None
+    """Optional extras group from pyproject.toml baked into the image (e.g. 'runtime')."""
+
+    def image_tag(self, lock_bytes: bytes) -> str:
+        """Content hash of everything that determines the image: uv.lock + this config.
+
+        The image holds dependencies only, so the same tag means the same image.
+        `cluv build` uses this to skip rebuilds, and `cluv submit` to pin jobs to
+        the exact image they were submitted against (a `current.sif` symlink could
+        be repointed by a later build before a queued job starts).
+        """
+        h = hashlib.sha256(lock_bytes)
+        for part in (self.base_image, *self.extra_apt, self.extra_pip_args, self.extra or ""):
+            h.update(b"\x00" + part.encode())
+        return h.hexdigest()[:12]
+
+    def sif_filename(self, project_name: str, lock_bytes: bytes) -> str:
+        return f"{project_name}-{self.image_tag(lock_bytes)}.sif"
 
 
 @dataclass(frozen=True)

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -20,6 +20,22 @@ from cluv.utils import find_pyproject
 logger = logging.getLogger(__name__)
 
 
+class ContainerConfig(BaseModel):
+    """Configuration for Apptainer container builds on a cluster."""
+
+    deploy_path: str
+    """Remote path where built .sif images are stored (e.g. '/project/acct/containers')."""
+
+    base_image: str = "python:3.12-slim"
+    """Docker base image for the Apptainer definition."""
+
+    extra_apt: list[str] = []
+    """Additional apt packages to install in the container."""
+
+    extra_pip_args: str = ""
+    """Extra arguments passed to pip install inside the container (e.g. '--extra-index-url ...')."""
+
+
 @dataclass(frozen=True)
 class PartialClusterConfig:
     """Per-cluster configuration options."""
@@ -37,6 +53,10 @@ class PartialClusterConfig:
 
     This folder will be synced from the current cluster to all other clusters at their respective `dataset_path`.
     """
+
+    container: ContainerConfig | None = None
+    """Optional Apptainer container configuration. When set, `cluv build` can build containers on
+    this cluster and `cluv submit` will use the container instead of a venv."""
 
 
 @dataclass(frozen=True)
@@ -57,6 +77,10 @@ class ClusterConfig:
     This folder will be synced from the current cluster to all other clusters at their respective `dataset_path`.
     """
 
+    container: ContainerConfig | None = None
+    """Optional Apptainer container configuration. When set, `cluv build` can build containers on
+    this cluster and `cluv submit` will use the container instead of a venv."""
+
     def expandvars(self):
         return ClusterConfig(
             env=self.env,
@@ -64,6 +88,7 @@ class ClusterConfig:
             datasets_path=(
                 Path(os.path.expandvars(self.datasets_path)) if self.datasets_path else None
             ),
+            container=self.container,
         )
 
 
@@ -111,6 +136,7 @@ class CluvConfig(BaseModel):
             # TODO: Use the cluster-specific results_path if we add that option back in the future.
             results_path=Path(cluv_config.results_path),
             datasets_path=Path(datasets_path) if datasets_path else None,
+            container=cluster_config.container,
         )
 
 

--- a/scripts/container_job.sh
+++ b/scripts/container_job.sh
@@ -23,7 +23,10 @@ echo "Running command: apptainer exec $CONTAINER_PATH $@"
 srun apptainer exec --nv \
     --env PYTHONUNBUFFERED=1 \
     --env PYTHONPATH=$project_root \
+    --env MPLCONFIGDIR=/tmp/mpl \
+    --env TORCHDYNAMO_DISABLE=1 \
     --bind $project_root:$project_root \
+    --bind /dev/shm:/dev/shm \
     ${SLURM_TMPDIR:+--bind $SLURM_TMPDIR:$SLURM_TMPDIR} \
     ${SCRATCH:+--bind $SCRATCH:$SCRATCH} \
     $CONTAINER_PATH \

--- a/scripts/container_job.sh
+++ b/scripts/container_job.sh
@@ -22,12 +22,13 @@ module load apptainer 2>/dev/null || true
 echo "Running command: apptainer exec $CONTAINER_PATH $@"
 srun apptainer exec --nv \
     --env PYTHONUNBUFFERED=1 \
-    --env PYTHONPATH=$project_root \
+    --env "PYTHONPATH=$project_root" \
     --env MPLCONFIGDIR=/tmp/mpl \
     --env TORCHDYNAMO_DISABLE=1 \
-    --bind $project_root:$project_root \
+    --bind "$project_root":"$project_root" \
     --bind /dev/shm:/dev/shm \
-    ${SLURM_TMPDIR:+--bind $SLURM_TMPDIR:$SLURM_TMPDIR} \
-    ${SCRATCH:+--bind $SCRATCH:$SCRATCH} \
-    $CONTAINER_PATH \
+    ${SLURM_TMPDIR:+--bind "$SLURM_TMPDIR":"$SLURM_TMPDIR"} \
+    ${SCRATCH:+--bind "$SCRATCH":"$SCRATCH"} \
+    ${PROJECT:+--bind /project:/project} \
+    "$CONTAINER_PATH" \
     "$@"

--- a/scripts/container_job.sh
+++ b/scripts/container_job.sh
@@ -13,22 +13,32 @@ echo "CONTAINER_PATH=${CONTAINER_PATH:?CONTAINER_PATH is not set. Run 'cluv buil
 
 if [ ! -f "$CONTAINER_PATH" ]; then
     echo "FATAL: container not found at $CONTAINER_PATH" >&2
-    echo "Run 'cluv build <cluster>' to build one." >&2
+    echo "Run 'cluv build <cluster>' to build it (the image is tagged by uv.lock hash; rebuild after changing dependencies)." >&2
     exit 1
 fi
+
+# Set up the source code at the submitted commit in $SLURM_TMPDIR, so changes
+# to the project between submission and job start don't affect the job (same
+# approach as safe_job.sh; the container replaces only the venv).
+project_root_in_tmpdir="$SLURM_TMPDIR/$project_name"
+echo "Cloning the project at $GIT_COMMIT into $project_root_in_tmpdir"
+srun --ntasks-per-node=1 --ntasks=$SLURM_JOB_NUM_NODES bash -e <<END
+    cd $SLURM_TMPDIR
+    git clone $project_root
+    cd $project_root_in_tmpdir
+    git checkout --detach $GIT_COMMIT
+END
 
 module load apptainer 2>/dev/null || true
 
 echo "Running command: apptainer exec $CONTAINER_PATH $@"
 srun apptainer exec --nv \
-    --env PYTHONUNBUFFERED=1 \
-    --env "PYTHONPATH=$project_root" \
+    --env "PYTHONPATH=$project_root_in_tmpdir" \
     --env MPLCONFIGDIR=/tmp/mpl \
-    --env TORCHDYNAMO_DISABLE=1 \
-    --bind "$project_root":"$project_root" \
+    --bind "$SLURM_TMPDIR":"$SLURM_TMPDIR" \
     --bind /dev/shm:/dev/shm \
-    ${SLURM_TMPDIR:+--bind "$SLURM_TMPDIR":"$SLURM_TMPDIR"} \
     ${SCRATCH:+--bind "$SCRATCH":"$SCRATCH"} \
     ${PROJECT:+--bind /project:/project} \
+    --pwd "$project_root_in_tmpdir" \
     "$CONTAINER_PATH" \
     "$@"

--- a/scripts/container_job.sh
+++ b/scripts/container_job.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem-per-cpu=4G
+#SBATCH --time=0:05:00
+#SBATCH --output=logs/%j/slurm-%j.out
+
+project_name="cluv"
+project_root="$HOME/repos/$project_name"
+
+echo "GIT_COMMIT=${GIT_COMMIT:?GIT_COMMIT is not set. Use 'cluv submit' to submit this job script.}"
+echo "CONTAINER_PATH=${CONTAINER_PATH:?CONTAINER_PATH is not set. Run 'cluv build' first or set it in your cluv config.}"
+
+if [ ! -f "$CONTAINER_PATH" ]; then
+    echo "FATAL: container not found at $CONTAINER_PATH" >&2
+    echo "Run 'cluv build <cluster>' to build one." >&2
+    exit 1
+fi
+
+module load apptainer 2>/dev/null || true
+
+echo "Running command: apptainer exec $CONTAINER_PATH $@"
+srun apptainer exec --nv \
+    --env PYTHONUNBUFFERED=1 \
+    --env PYTHONPATH=$project_root \
+    --bind $project_root:$project_root \
+    ${SLURM_TMPDIR:+--bind $SLURM_TMPDIR:$SLURM_TMPDIR} \
+    ${SCRATCH:+--bind $SCRATCH:$SCRATCH} \
+    $CONTAINER_PATH \
+    "$@"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from cluv.cli.build import generate_def
 from cluv.config import ContainerConfig, PartialClusterConfig, load_cluv_config
 
@@ -63,6 +65,10 @@ class TestContainerConfig:
     def test_cluster_without_container(self):
         cfg = PartialClusterConfig(env={"SBATCH_ACCOUNT": "def-me"})
         assert cfg.container is None
+
+    def test_relative_deploy_path_rejected(self):
+        with pytest.raises(ValueError, match="absolute path"):
+            ContainerConfig(deploy_path="relative/path")
 
 
 class TestContainerConfigFromToml:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,107 @@
+"""Unit tests for cluv/cli/build.py — pure, no I/O beyond string generation."""
+
+from pathlib import Path
+
+from cluv.cli.build import generate_def
+from cluv.config import ContainerConfig, PartialClusterConfig, load_cluv_config
+
+
+class TestGenerateDef:
+    def test_minimal(self):
+        result = generate_def("python:3.12-slim", [], "")
+        assert "Bootstrap: docker" in result
+        assert "From: python:3.12-slim" in result
+        assert "pip install --no-cache-dir -r /build/requirements.txt" in result
+        assert "apt-get" not in result
+
+    def test_with_apt_packages(self):
+        result = generate_def("python:3.12-slim", ["gcc", "libgomp1"], "")
+        assert "apt-get update" in result
+        assert "gcc libgomp1" in result
+
+    def test_with_extra_pip_args(self):
+        result = generate_def(
+            "python:3.12-slim", [],
+            "--extra-index-url https://download.pytorch.org/whl/cu126",
+        )
+        assert "--extra-index-url https://download.pytorch.org/whl/cu126" in result
+
+    def test_custom_base_image(self):
+        result = generate_def("nvidia/cuda:12.6.0-runtime-ubuntu22.04", [], "")
+        assert "From: nvidia/cuda:12.6.0-runtime-ubuntu22.04" in result
+
+    def test_all_options(self):
+        result = generate_def(
+            "python:3.12-slim",
+            ["gcc", "libc6-dev"],
+            "--extra-index-url https://download.pytorch.org/whl/cu126",
+        )
+        assert "apt-get" in result
+        assert "gcc libc6-dev" in result
+        assert "--extra-index-url" in result
+        assert "%test" in result
+
+
+class TestContainerConfig:
+    def test_defaults(self):
+        cfg = ContainerConfig(deploy_path="/project/acct/containers")
+        assert cfg.base_image == "python:3.12-slim"
+        assert cfg.extra_apt == []
+        assert cfg.extra_pip_args == ""
+
+    def test_custom_values(self):
+        cfg = ContainerConfig(
+            deploy_path="/project/acct/containers",
+            base_image="nvidia/cuda:12.6.0-runtime-ubuntu22.04",
+            extra_apt=["gcc", "libgomp1"],
+            extra_pip_args="--extra-index-url https://download.pytorch.org/whl/cu126",
+        )
+        assert cfg.deploy_path == "/project/acct/containers"
+        assert cfg.base_image == "nvidia/cuda:12.6.0-runtime-ubuntu22.04"
+        assert cfg.extra_apt == ["gcc", "libgomp1"]
+
+    def test_cluster_without_container(self):
+        cfg = PartialClusterConfig(env={"SBATCH_ACCOUNT": "def-me"})
+        assert cfg.container is None
+
+
+class TestContainerConfigFromToml:
+    def test_parse_container_config(self, tmp_path: Path):
+        p = tmp_path / "pyproject.toml"
+        p.write_text("""\
+[tool.cluv]
+results_path = "logs"
+
+[tool.cluv.clusters.mila]
+
+[tool.cluv.clusters.rorqual.env]
+SBATCH_ACCOUNT = "def-bengioy"
+
+[tool.cluv.clusters.rorqual.container]
+deploy_path = "/project/acct/containers"
+base_image = "python:3.12-slim"
+extra_apt = ["gcc", "libgomp1"]
+extra_pip_args = "--extra-index-url https://download.pytorch.org/whl/cu126"
+""")
+        cfg = load_cluv_config(p)
+        assert cfg.clusters["mila"].container is None
+        container = cfg.clusters["rorqual"].container
+        assert container is not None
+        assert container.deploy_path == "/project/acct/containers"
+        assert container.extra_apt == ["gcc", "libgomp1"]
+
+    def test_minimal_container_config(self, tmp_path: Path):
+        p = tmp_path / "pyproject.toml"
+        p.write_text("""\
+[tool.cluv]
+results_path = "logs"
+
+[tool.cluv.clusters.narval.container]
+deploy_path = "/project/acct/containers"
+""")
+        cfg = load_cluv_config(p)
+        container = cfg.clusters["narval"].container
+        assert container is not None
+        assert container.deploy_path == "/project/acct/containers"
+        assert container.base_image == "python:3.12-slim"
+        assert container.extra_apt == []

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -44,6 +44,46 @@ class TestGenerateDef:
         assert "%test" in result
 
 
+class TestImageTag:
+    LOCK = b"fake uv.lock contents"
+
+    def test_deterministic(self):
+        cfg = ContainerConfig(deploy_path="/project/acct/containers")
+        assert cfg.image_tag(self.LOCK) == cfg.image_tag(self.LOCK)
+        assert len(cfg.image_tag(self.LOCK)) == 12
+
+    def test_changes_with_lock_contents(self):
+        cfg = ContainerConfig(deploy_path="/project/acct/containers")
+        assert cfg.image_tag(self.LOCK) != cfg.image_tag(b"different lock")
+
+    def test_changes_with_config(self):
+        base = ContainerConfig(deploy_path="/project/acct/containers")
+        tags = {
+            base.image_tag(self.LOCK),
+            ContainerConfig(
+                deploy_path="/project/acct/containers", base_image="python:3.13-slim"
+            ).image_tag(self.LOCK),
+            ContainerConfig(
+                deploy_path="/project/acct/containers", extra_apt=["gcc"]
+            ).image_tag(self.LOCK),
+            ContainerConfig(
+                deploy_path="/project/acct/containers", extra="runtime"
+            ).image_tag(self.LOCK),
+        }
+        assert len(tags) == 4
+
+    def test_independent_of_deploy_path(self):
+        # Same image contents deployed elsewhere keeps the same tag.
+        a = ContainerConfig(deploy_path="/project/acct/containers")
+        b = ContainerConfig(deploy_path="/project/other/containers")
+        assert a.image_tag(self.LOCK) == b.image_tag(self.LOCK)
+
+    def test_sif_filename(self):
+        cfg = ContainerConfig(deploy_path="/project/acct/containers")
+        name = cfg.sif_filename("my_project", self.LOCK)
+        assert name == f"my_project-{cfg.image_tag(self.LOCK)}.sif"
+
+
 class TestContainerConfig:
     def test_defaults(self):
         cfg = ContainerConfig(deploy_path="/project/acct/containers")

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -120,6 +120,7 @@ class TestGetSbatchCommand:
 
         (project_dir / "scripts").mkdir()
         (project_dir / "scripts" / "container_job.sh").touch()
+        (project_dir / "uv.lock").write_bytes(b"fake lock")
 
         sbatch_command = get_sbatch_command(
             cluster="rorqual",
@@ -129,7 +130,37 @@ class TestGetSbatchCommand:
             git_commit="abc1234",
         )
 
-        assert "CONTAINER_PATH=/project/acct/containers/current.sif" in sbatch_command
+        # Pinned to the content-hash-tagged image, not the mutable current.sif.
+        container = get_cluv_config().clusters["rorqual"].container
+        assert container is not None
+        sif_name = container.sif_filename("my_project", b"fake lock")
+        assert f"CONTAINER_PATH=/project/acct/containers/{sif_name}" in sbatch_command
+        assert "current.sif" not in sbatch_command
+
+    def test_container_path_requires_uv_lock(self, project_dir: Path) -> None:
+        p = project_dir / "pyproject.toml"
+        p.write_text(
+            textwrap.dedent(
+                """\
+            [tool.cluv]
+            results_path = "results"
+            [tool.cluv.clusters.rorqual.container]
+            deploy_path = "/project/acct/containers"
+            """
+            )
+        )
+
+        (project_dir / "scripts").mkdir()
+        (project_dir / "scripts" / "container_job.sh").touch()
+
+        with pytest.raises(FileNotFoundError, match="uv.lock"):
+            get_sbatch_command(
+                cluster="rorqual",
+                job_script=Path("scripts/container_job.sh"),
+                sbatch_args=[],
+                program_args=[],
+                git_commit="abc1234",
+            )
 
     def test_container_path_not_injected_without_container_config(self, project_dir: Path) -> None:
         p = project_dir / "pyproject.toml"
@@ -173,6 +204,7 @@ class TestGetSbatchCommand:
 
         (project_dir / "scripts").mkdir()
         (project_dir / "scripts" / "container_job.sh").touch()
+        (project_dir / "uv.lock").write_bytes(b"fake lock")
 
         sbatch_command = get_sbatch_command(
             cluster="rorqual",
@@ -183,7 +215,7 @@ class TestGetSbatchCommand:
         )
 
         assert "CONTAINER_PATH=/custom/path.sif" in sbatch_command
-        assert "CONTAINER_PATH=/project/acct/containers/current.sif" not in sbatch_command
+        assert "CONTAINER_PATH=/project/acct/containers" not in sbatch_command
 
 
 class TestEnsureCleanGitState:

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -105,6 +105,87 @@ class TestGetSbatchCommand:
         )
 
 
+    def test_container_path_injected_when_container_config_present(self, project_dir: Path) -> None:
+        p = project_dir / "pyproject.toml"
+        p.write_text(
+            textwrap.dedent(
+                """\
+            [tool.cluv]
+            results_path = "results"
+            [tool.cluv.clusters.rorqual.container]
+            deploy_path = "/project/acct/containers"
+            """
+            )
+        )
+
+        (project_dir / "scripts").mkdir()
+        (project_dir / "scripts" / "container_job.sh").touch()
+
+        sbatch_command = get_sbatch_command(
+            cluster="rorqual",
+            job_script=Path("scripts/container_job.sh"),
+            sbatch_args=[],
+            program_args=["python", "main.py"],
+            git_commit="abc1234",
+        )
+
+        assert "CONTAINER_PATH=/project/acct/containers/current.sif" in sbatch_command
+
+    def test_container_path_not_injected_without_container_config(self, project_dir: Path) -> None:
+        p = project_dir / "pyproject.toml"
+        p.write_text(
+            textwrap.dedent(
+                """\
+            [tool.cluv]
+            results_path = "results"
+            [tool.cluv.clusters.mila]
+            """
+            )
+        )
+
+        (project_dir / "scripts").mkdir()
+        (project_dir / "scripts" / "job.sh").touch()
+
+        sbatch_command = get_sbatch_command(
+            cluster="mila",
+            job_script=Path("scripts/job.sh"),
+            sbatch_args=[],
+            program_args=[],
+            git_commit="abc1234",
+        )
+
+        assert "CONTAINER_PATH" not in sbatch_command
+
+    def test_explicit_container_path_env_not_overridden(self, project_dir: Path) -> None:
+        p = project_dir / "pyproject.toml"
+        p.write_text(
+            textwrap.dedent(
+                """\
+            [tool.cluv]
+            results_path = "results"
+            [tool.cluv.clusters.rorqual.env]
+            CONTAINER_PATH = "/custom/path.sif"
+            [tool.cluv.clusters.rorqual.container]
+            deploy_path = "/project/acct/containers"
+            """
+            )
+        )
+
+        (project_dir / "scripts").mkdir()
+        (project_dir / "scripts" / "container_job.sh").touch()
+
+        sbatch_command = get_sbatch_command(
+            cluster="rorqual",
+            job_script=Path("scripts/container_job.sh"),
+            sbatch_args=[],
+            program_args=[],
+            git_commit="abc1234",
+        )
+
+        assert "CONTAINER_PATH=/custom/path.sif" in sbatch_command
+        assert "CONTAINER_PATH=/project/acct/containers/current.sif" not in sbatch_command
+
+
 class TestEnsureCleanGitState:
     def test_prefers_branch_tip_in_github_actions_detached_head(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Why

cluv currently syncs a venv to the cluster and copies it into each job's `$SLURM_TMPDIR` at start. This works well on Mila, but on DRAC it means every dependency must be pre-staged (several clusters have no internet on compute), the copy adds minutes per job, and the environment can drift between submissions.

Containers flip this: build the environment once into an immutable `.sif` image, tagged by git SHA, and run jobs directly from it. No copy step, no drift, no internet needed at runtime.

Based on a setup that's been running on Rorqual and Narval in [RolnickLab/radar-transferability](https://github.com/RolnickLab/radar-transferability) for a few months.

## What

Opt-in, per-cluster container support. Clusters without `[container]` config are unchanged.

```toml
[tool.cluv.clusters.rorqual.container]
deploy_path = "/project/acct/containers"
```

- **`cluv build <cluster>`** exports pinned deps from `uv.lock`, builds a `.sif` on the remote, deploys with a git-SHA tag and `current.sif` symlink.
- **`cluv submit`** auto-injects `CONTAINER_PATH` when the cluster has container config.
- **`scripts/container_job.sh`** runs via `apptainer exec` instead of venv activation.

Build includes the `GOMAXPROCS=1` workaround for DRAC login nodes (pids.max=512 cgroup limit kills Go's default thread spawning).

---

*AI (Claude) supported my development of this PR.*