### PR TITLE
Remove outdated checks for an undefined `results_path` in `cluv init`

### DIFF
--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -156,17 +156,11 @@ def check_git() -> None:
         raise RuntimeError("Error when checking git remote: ", git_remote.stderr)
 
 
-def check_symlink_to_scratch(project_root: Path, results_path: str | None) -> None:
+def check_symlink_to_scratch(project_root: Path, results_path: str) -> None:
     """
     Check if a symlink from the results_path in the project in $HOME to the corresponding path in $SCRATCH already exists. If not, create it.
     The symlink should be like : $HOME/<project>/<results_path> -> $SCRATCH/<results_path>/<project_name>
     """
-    if results_path is None:
-        console.print(
-            "[yellow]⚠️  Warning: Results path is not configured. Skipping symlink creation.[/yellow]"
-        )
-        return
-
     if "SCRATCH" not in os.environ:
         console.print(
             "[yellow]⚠️  Warning: $SCRATCH variable not set. Skipping symlink creation.[/yellow]"

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -203,18 +203,11 @@ def check_ssh_hostnames(clusters: list[str]) -> None:
         console.print("[green]✅ All clusters in the cluv config are present in your SSH config.[/green]")
 
 
-def check_job_script(project_root: Path, results_path: str | None) -> None:
+def check_job_script(project_root: Path, results_path: str) -> None:
     """
     Check if job script templates exist. If not, create them.
     The scripts are templates for users to submit jobs to Slurm with cluv.
     """
-    if results_path is None:
-        console.print(
-            "[yellow]⚠️  Warning: Results path is not configured. Skipping job template script generation.[/yellow]"
-        )
-        return
-
-    project_name = project_root.name
     try:
         project_root_relative_to_home = project_root.relative_to(Path.home())
         project_root_for_script = f"$HOME/{project_root_relative_to_home}"
@@ -243,7 +236,7 @@ def check_job_script(project_root: Path, results_path: str | None) -> None:
         )
         script_content = re.sub(
             r"^project_name=.*$",
-            f'project_name="{project_name}"',
+            f'project_name="{project_root.name}"',
             script_content,
             flags=re.MULTILINE,
         )

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -195,11 +195,15 @@ def check_ssh_hostnames(clusters: list[str]) -> None:
     missing_clusters = set(clusters).difference(ssh_hostnames)
 
     if len(missing_clusters) > 0:
-        console.print(f"[yellow]⚠️  Warning: Missing SSH config for {len(missing_clusters)} clusters. Try to run [bold]mila init[/bold] to add all available clusters.[/yellow]")
+        console.print(
+            f"[yellow]⚠️  Warning: Missing SSH config for {len(missing_clusters)} clusters. Try to run [bold]mila init[/bold] to add all available clusters.[/yellow]"
+        )
         for cluster in missing_clusters:
             console.print(f"[yellow]    - {cluster}[/yellow]")
     else:
-        console.print("[green]✅ All clusters in the cluv config are present in your SSH config.[/green]")
+        console.print(
+            "[green]✅ All clusters in the cluv config are present in your SSH config.[/green]"
+        )
 
 
 def check_job_script(project_root: Path, results_path: str) -> None:
@@ -224,7 +228,9 @@ def check_job_script(project_root: Path, results_path: str) -> None:
     for script_template in script_templates:
         script_path = scripts_dir / script_template.name
         if script_path.exists():
-            console.print(f"[green]✅ Job template script already exists at '{script_path}'.[/green]")
+            console.print(
+                f"[green]✅ Job template script already exists at '{script_path}'.[/green]"
+            )
             continue
         script_content = script_template.read_text()
         script_content = re.sub(
@@ -286,7 +292,9 @@ def _get_script_templates_path() -> Path:
         if script_templates_path.exists():
             return script_templates_path
     checked_paths_text = ", ".join(str(path) for path in checked_paths)
-    raise RuntimeError(f"Couldn't find the script templates folder. Checked: {checked_paths_text}.")
+    raise RuntimeError(
+        f"Couldn't find the script templates folder. Checked: {checked_paths_text}."
+    )
 
 
 def _get_pyproject_template_path() -> Path:

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -10,7 +10,6 @@ from cluv.utils import console
 __all__ = ["init"]
 
 SCRIPTS_DIR_PATH = "scripts"
-JOB_SCRIPT_PATH = f"{SCRIPTS_DIR_PATH}/job.sh"
 DEFAULT_RESULTS_PATH = "logs"
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 # Repository root when running cluv from a source checkout.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -79,14 +79,7 @@ class TestCheckCluvConfig:
         assert config.results_path == "results"
 
 
-# TODO : fixture to set environment variables ?
 class TestSymlinkCheck:
-    def test_no_symlink_if_results_path_is_none(self, tmp_path) -> None:
-        """check_symlink_to_scratch() should not create a symlink if the results_path is None"""
-        check_symlink_to_scratch(tmp_path, None)
-
-        assert not (tmp_path / DEFAULT_RESULTS_PATH).exists()
-
     def test_no_symlink_if_scratch_not_set(self, tmp_path, monkeypatch) -> None:
         """check_symlink_to_scratch() should not create a symlink if the $SCRATCH env var is not set"""
         monkeypatch.delenv("SCRATCH", raising=False)
@@ -129,13 +122,6 @@ class TestSymlinkCheck:
 
 
 class TestJobScriptCheck:
-    def test_no_job_script_if_results_path_is_none(self, tmp_path: Path) -> None:
-        """check_job_script() should not create a job script if the results_path is None"""
-
-        check_job_script(tmp_path, None)
-
-        assert not (tmp_path / JOB_SCRIPT_PATH).exists()
-
     def test_keep_existing_job_script(self, tmp_path: Path) -> None:
         """check_job_script() should not overwrite an existing job script"""
         job_script_path = tmp_path / JOB_SCRIPT_PATH

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,13 +65,15 @@ class TestCheckCluvConfig:
     def test_keep_existing_cluv_config(self, tmp_path: Path) -> None:
         """check_cluv_config() should not overwrite an existing cluv config"""
         p = tmp_path / "pyproject.toml"
-        p.write_text(textwrap.dedent(
-            """\
+        p.write_text(
+            textwrap.dedent(
+                """\
             [tool.cluv]
             clusters = {"mila" = {}}
             results_path = "results"
             """
-        ))
+            )
+        )
 
         check_cluv_config(p)
         config = load_cluv_config(p)
@@ -193,7 +195,7 @@ class TestJobScriptCheck:
         generated_legacy_script = project_root / "scripts" / "legacy_job.sh"
         assert generated_legacy_script.exists()
         generated_legacy_script_content = generated_legacy_script.read_text()
-        assert '#SBATCH --output=outputs/%j/slurm-%j.out' in generated_legacy_script_content
+        assert "#SBATCH --output=outputs/%j/slurm-%j.out" in generated_legacy_script_content
         assert 'results_path="outputs"' in generated_legacy_script_content
         assert "Using $results_path" in generated_legacy_script_content
         assert "results_dir" not in generated_legacy_script_content

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,7 +8,7 @@ import pytest
 
 from cluv.cli.init import (
     DEFAULT_RESULTS_PATH,
-    JOB_SCRIPT_PATH,
+    SCRIPTS_DIR_PATH,
     check_cluv_config,
     check_git,
     check_home_dir,
@@ -19,6 +19,7 @@ from cluv.config import load_cluv_config
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CLUV_INIT_MODULE = importlib.import_module("cluv.cli.init")
+JOB_SCRIPT_PATH = f"{SCRIPTS_DIR_PATH}/job.sh"
 
 
 class TestCheckHomeDir:
@@ -101,7 +102,6 @@ class TestSymlinkCheck:
         assert expected_results_path.is_symlink()
         assert expected_results_scratch_path.exists()
         assert expected_results_path.resolve() == expected_results_scratch_path.resolve()
-
 
     def test_keep_existing_symlink(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """check_symlink_to_scratch() should not overwrite an existing symlink not pointing to scratch"""


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
Since the `results_path` of a config can't be `None` anymore, some checks in `cluv init` aren't needed when :
- Trying to create the symlink to `$SCRATCH`.
- Adding the job script templates.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/