### PR TITLE
Fix cluv submit not using current cluster

### DIFF
--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -277,17 +277,15 @@ def setup_logging(verbose: int | None, force: bool = False) -> None:
     # )
     cluv_logger = logging.getLogger("cluv")
     cluv_logger.addHandler(handler)
-
-    # if verbose == 0:
-    #     # logger.setLevel(logging.ERROR)
-    #     logger.setLevel(logging.WARNING)
-    #     cluv_logger.setLevel(logging.WARNING)
-    # elif verbose == 1:
-    #     logger.setLevel(logging.INFO)
-    #     cluv_logger.setLevel(logging.INFO)
-    # elif verbose >= 2:
-    #     logger.setLevel(logging.DEBUG)
-    #     cluv_logger.setLevel(logging.DEBUG)
+    if verbose == 0:
+        logger.setLevel(logging.WARNING)
+        cluv_logger.setLevel(logging.WARNING)
+    elif verbose == 1:
+        logger.setLevel(logging.INFO)
+        cluv_logger.setLevel(logging.INFO)
+    elif verbose >= 2:
+        logger.setLevel(logging.DEBUG)
+        cluv_logger.setLevel(logging.DEBUG)
 
 
 def _add_v_arg(parser: argparse.ArgumentParser) -> None:

--- a/cluv/cache.py
+++ b/cluv/cache.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import json
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 
 from cluv.utils import find_pyproject
@@ -27,23 +26,7 @@ class Job:
     program_args: list[str]
 
 
-def save_job(
-    job_id: int,
-    cluster: str,
-    job_script: str,
-    git_commit: str,
-    sbatch_args: list[str],
-    program_args: list[str],
-) -> None:
-    job = Job(
-        job_id=job_id,
-        cluster=cluster,
-        job_script=job_script,
-        git_commit=git_commit,
-        submitted_at=datetime.now(timezone.utc).isoformat(),
-        sbatch_args=sbatch_args,
-        program_args=program_args,
-    )
+def save_job(job: Job) -> None:
     path = get_cache_path()
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/cluv/cache.py
+++ b/cluv/cache.py
@@ -17,7 +17,7 @@ def get_cache_path() -> Path:
 
 
 @dataclass
-class CachedJob:
+class Job:
     job_id: int
     cluster: str
     job_script: str
@@ -35,7 +35,7 @@ def save_job(
     sbatch_args: list[str],
     program_args: list[str],
 ) -> None:
-    job = CachedJob(
+    job = Job(
         job_id=job_id,
         cluster=cluster,
         job_script=job_script,
@@ -51,14 +51,14 @@ def save_job(
         f.write(json.dumps(asdict(job)) + "\n")
 
 
-def load_jobs() -> list[CachedJob]:
+def load_jobs() -> list[Job]:
     path = get_cache_path()
     if not path.exists():
         return []
     jobs = []
     for line in path.read_text().splitlines():
         try:
-            jobs.append(CachedJob(**json.loads(line)))
+            jobs.append(Job(**json.loads(line)))
         except Exception:
             pass
     return jobs

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -11,7 +11,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from cluv.cache import CachedJob, load_jobs
+from cluv.cache import Job, load_jobs
 from cluv.cli.login import get_remote_without_2fa_prompt
 from cluv.config import get_cluv_config
 from cluv.slurm import (
@@ -315,10 +315,7 @@ def _build_cluster_table(
     return table
 
 
-def _build_cluv_jobs_table(
-        cached_jobs: list[CachedJob],
-        live_info: dict[int, LiveJobInfo]
-) -> Table:
+def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobInfo]) -> Table:
     """Build the jobs overview table with one row per cached job, enriched with live status info."""
     table = Table(
         title="Jobs Overview",
@@ -380,8 +377,7 @@ def _build_legend() -> Panel:
 
 
 async def get_job_infos(
-    cached_jobs: list[CachedJob],
-    clusters: list[str]
+    cached_jobs: list[Job], clusters: list[str]
 ) -> tuple[dict[int, LiveJobInfo], dict[str, JobStats]]:
     """Fetch live job info for all cached jobs, and count job statuses per cluster."""
     # Regroup jobs by cluster

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -191,7 +191,7 @@ async def submit_first(
     # If the wait is interrupted, cancel all jobs.
     first_running_job: JobHandle | None = None
 
-    max_wait_time_seconds = 60
+    max_wait_time_seconds = 5
 
     cluster_and_jobid_to_jobstate: dict[tuple[str, int], str] = {
         (cluster, job_id): "UNKNOWN" for cluster, job_id in cluster_to_jobid.items()
@@ -297,7 +297,7 @@ async def wait_for_running_job(
     """Watch the jobs with sacct until one of them starts (or completes)."""
 
     first_running_job: JobHandle | None = None
-    wait_time = 10
+    wait_time = 1
 
     to_query = list(cluster_and_jobid_to_jobstate.keys())
 
@@ -331,7 +331,7 @@ async def wait_for_jobs_to_cancel(
     cluster_to_remote: dict[str, Remote | None],
     max_wait_time_seconds: int = 60,
 ) -> JobHandle | None:
-
+    start_wait_time = 5
     to_cancel = list(cluster_and_jobid_to_jobstate.keys())
     to_cancel.remove((first_running_job.cluster, first_running_job.job_id))
 
@@ -358,7 +358,8 @@ async def wait_for_jobs_to_cancel(
             for cluster, job_id in to_cancel
         ]
     )
-    wait_time = 5
+
+    wait_time = min(start_wait_time, max_wait_time_seconds)
 
     while not all(
         cluster_and_jobid_to_jobstate[cluster_jobid].startswith(

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from pathlib import Path, PurePosixPath
 
+import rich.panel
+import rich.syntax
 import rich.table
 import rich.text
 from rich.live import Live
@@ -164,13 +166,19 @@ async def submit_first(
                 cluster_to_jobid[cluster] = job_id
                 table.add_row(
                     cluster,
-                    f"{sbatch_command}\n[green]Job ID: {job_id}[/green]",
+                    rich.console.Group(
+                        rich.syntax.Syntax(sbatch_command, lexer="sh", word_wrap=True),
+                        rich.text.Text(f"Job ID: {job_id}", style="green"),
+                    ),
                     end_section=True,
                 )
             else:
                 table.add_row(
                     cluster,
-                    f"{sbatch_command}\n[red]Error: {sbatch_result.stderr.strip()}[/red]",
+                    rich.console.Group(
+                        rich.syntax.Syntax(sbatch_command, lexer="sh", word_wrap=True),
+                        rich.text.Text(f"Error: {sbatch_result.stderr.strip()}", style="red"),
+                    ),
                     end_section=True,
                 )
     console.print(table)
@@ -332,6 +340,8 @@ async def wait_for_jobs_to_cancel(
     )
     for (cluster, job_id), job_state in zip(to_cancel, job_states):
         logger.info(f"Job {job_id} on cluster {cluster} state: {job_state}")
+        if job_state.startswith("CANCELLED by"):
+            job_state = "CANCELLED"  # just to avoid confusing users.
         cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
 
     to_cancel = [

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path, PurePosixPath
 
+import rich.table
+
 from cluv.cache import save_job
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_cluv_config
@@ -15,7 +17,6 @@ from cluv.remote import Remote, run
 from cluv.slurm import FAILED_JOB_STATES
 from cluv.utils import console, current_cluster
 
-RUNNING_JOB_STATES = ["PENDING", "RUNNING"]
 logger = logging.getLogger(__name__)
 
 __all__ = ["submit"]
@@ -100,101 +101,106 @@ async def submit_first(
     """
     # Sync with all clusters with an existing connections.
     remotes = await sync()
-    clusters_to_remote = {remote.hostname: remote for remote in remotes}
+    cluster_to_remote: dict[str, Remote | None] = {remote.hostname: remote for remote in remotes}
+    this_cluster = current_cluster()
+    if this_cluster is not None:
+        # We are also on a Slurm cluster, so consider this as an option as well.
+        cluster_to_remote[this_cluster] = None
+        # `sync` does not return a Remote for the current cluster.
+        assert not any(remote.hostname == this_cluster for remote in remotes)
 
-    # Submit the job on all the clusters
+    # Submit the job on all the clusters (and possibly locally).
     sbatch_results = await asyncio.gather(
         *[
             sbatch(
                 remote,
-                job_script,
-                sbatch_args,
-                program_args,
-                git_commit,
+                job_script=job_script,
+                sbatch_args=sbatch_args,
+                program_args=program_args,
+                git_commit=git_commit,
             )
-            for remote in remotes
+            for remote in cluster_to_remote.values()
         ],
         return_exceptions=True,
     )
+    # TODO: This could be a list of tuples eventually, since we could potentially try to submit
+    # multiple different jobs per cluster.
+    cluster_to_sbatch_result = dict(zip(cluster_to_remote.keys(), sbatch_results))
 
-    # Get the results of the sbatch command. We expect an int (the job id) or the exception
-    # if the command failed on the remote cluster.
-    console.print("Jobs submitted on the clusters:")
     cluster_to_jobid: dict[str, int] = {}
-    for cluster, result in zip(clusters_to_remote.keys(), sbatch_results):
+    table = rich.table.Table("Cluster", "Result", title="Jobs submitted on the clusters")
+    for cluster, result in cluster_to_sbatch_result.items():
         if isinstance(result, BaseException):
-            console.print(
-                f"    - [bold]{cluster}[/bold]: error when trying to use remote, [red]{result}[/red]"
-            )
+            table.add_row(cluster, f"[red]Error: {result}[/red]")
         else:
             if result.returncode == 0:
                 job_id = int(result.stdout.strip())
                 cluster_to_jobid[cluster] = job_id
-                console.print(f"    - [bold]{cluster}[/bold]: job {job_id}")
+                table.add_row(cluster, f"[green]Job ID: {job_id}[/green]")
             else:
-                console.print(
-                    f"    - [bold]{cluster}[/bold]: no job, [red]{result.stderr.strip()}[/red]"
-                )
+                table.add_row(cluster, f"[red]Error: {result.stderr.strip()}[/red]")
+    console.print(table)
 
-    if len(cluster_to_jobid) == 0:
+    if not cluster_to_jobid:
         console.print("No job submitted on clusters. See errors above.")
         return None
 
     # Wait for a job to start on a cluster.
     # If the wait is interrupted, cancel all jobs.
-    start_cluster: str | None = None
-    start_job_id: int | None = None
-    wait_time = 2  # seconds; grows up to 20s
+    first_running_job_cluster: str | None = None
+    first_running_job_id: int | None = None
+
+    max_wait_time_seconds = 60
+    wait_time = 2  # seconds; grows up to max_wait_time_seconds.
     try:
-        with console.status("Waiting for a job to start..."):
-            while start_cluster is None:
-                failed_clusters: list[str] = []
-                for cluster, remote in clusters_to_remote.items():
-                    job_id = cluster_to_jobid.get(cluster)
-                    if job_id is None:
-                        continue
-                    job_status = await get_job_status(remote, job_id)
+        spinner = console.status("Waiting for a job to start...")
+        spinner.start()
 
-                    if job_status in RUNNING_JOB_STATES:
-                        start_cluster = cluster
-                        start_job_id = job_id
-                        break
-                    elif job_status in FAILED_JOB_STATES:
-                        console.print(
-                            f"Job {job_id} on cluster {cluster} ended with status {job_status}."
-                        )
-                        failed_clusters.append(cluster)
+        while first_running_job_id is None:
+            for cluster, job_id in list(cluster_to_jobid.items()):
+                remote: Remote | None = cluster_to_remote[cluster]
 
-                # Stop the wait if a job is running
-                if start_cluster is not None:
+                job_state = await get_job_state(remote, job_id)
+                if job_state == "RUNNING":
+                    first_running_job_cluster = cluster
+                    first_running_job_id = job_id
                     break
+                elif job_state in FAILED_JOB_STATES:
+                    console.print(
+                        f"Job {job_id} on cluster {cluster} ended with status {job_state}."
+                    )
+                    cluster_to_jobid.pop(cluster)
 
-                # Remove clusters with failed jobs
-                for cluster in failed_clusters:
-                    del cluster_to_jobid[cluster]
+            # Stop the wait if all the jobs failed
+            if not cluster_to_jobid:
+                console.log("All submitted jobs have failed! Exiting.")
+                return None
 
-                # Stop the wait if all the jobs failed
-                if not cluster_to_jobid:
-                    console.log("All submitted jobs have ended without starting. Exiting.")
-                    return None
+            await asyncio.sleep(wait_time)
+            wait_time = min(wait_time * 2, max_wait_time_seconds)
 
-                await asyncio.sleep(wait_time)
-                wait_time = min(wait_time * 2, 20)
-        console.log(
-            f"Job {start_job_id} on cluster {start_cluster} is running. Cancelling the other jobs...\n",
-            f"Use `ssh {start_cluster} sacct -j {start_job_id}` to view its status.",
-        )
+        spinner.stop()
+        if first_running_job_id:
+            console.log(
+                f"Job {first_running_job_id} on cluster {first_running_job_cluster} is running. Cancelling the other jobs...\n",
+                f"Use `ssh {first_running_job_cluster} sacct -j {first_running_job_id}` to view its status.",
+            )
     except (KeyboardInterrupt, asyncio.CancelledError):
         console.log("Interrupted by user. Cancelling all jobs...")
     finally:
-        await cancel_all_jobs(clusters_to_remote, cluster_to_jobid, start_cluster)
+        await cancel_all_jobs(cluster_to_remote, cluster_to_jobid, first_running_job_cluster)
 
-    if start_job_id is not None and start_cluster is not None:
+    if first_running_job_id is not None and first_running_job_cluster is not None:
         save_job(
-            start_job_id, start_cluster, str(job_script), git_commit, sbatch_args, program_args
+            first_running_job_id,
+            first_running_job_cluster,
+            str(job_script),
+            git_commit,
+            sbatch_args,
+            program_args,
         )
-
-    return start_job_id
+    # TODO: Return the cluster and job id.
+    return first_running_job_id
 
 
 def ensure_clean_git_state() -> str:
@@ -326,22 +332,30 @@ async def sbatch(
     return await run(tuple(shlex.split(remote_cmd)), _display=True, warn=True, hide=True)
 
 
-async def get_job_status(remote: Remote, job_id: int) -> str:
-    """Get the status of the job with the given id on the remote cluster."""
+async def get_job_state(remote: Remote | None, job_id: int) -> str:
+    """Get the state of the job with the given id on the remote cluster with `sacct`."""
     sacct_command = f"sacct -j {job_id} --format=State --noheader --allocations"
-    return await remote.get_output(sacct_command)
+    if remote:
+        return await remote.get_output(sacct_command, hide=True)
+    result = await run(tuple(shlex.split(sacct_command)), hide=True)
+    return result.stdout.strip()
 
 
-async def cancel_job(remote: Remote, job_id: int) -> str:
+async def cancel_job(remote: Remote | None, job_id: int) -> str:
     """Cancel the job with the given id on the remote cluster."""
     scancel_command = f"scancel {job_id}"
-    output = await remote.get_output(scancel_command)
-    console.print(f"Cancelled job {job_id} on cluster {remote.hostname}.")
+    if remote:
+        output = await remote.get_output(scancel_command, hide=True)
+        console.print(f"Cancelled job {job_id} on cluster {remote.hostname}.")
+    else:
+        result = await run(tuple(shlex.split(scancel_command)), hide=True)
+        console.print(f"Cancelled job {job_id} on the current cluster.")
+        output = result.stdout
     return output
 
 
 async def cancel_all_jobs(
-    remotes: dict[str, Remote], cluster_to_jobid: dict[str, int], keep_cluster: str | None
+    remotes: dict[str, Remote | None], cluster_to_jobid: dict[str, int], keep_cluster: str | None
 ) -> None:
     """Cancel all jobs in cluster_to_jobid on their respective remotes."""
     await asyncio.gather(

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -379,6 +379,11 @@ async def wait_for_jobs_to_cancel(
             logger.info(f"Job {job_id} on cluster {cluster} is in state: {job_state}")
             if job_state.startswith("CANCELLED by"):
                 job_state = "CANCELLED"  # just to avoid confusing users.
+            if job_state == "FAILED":
+                # Cheat slightly, but it's fine because this is usually just one of the job
+                # steps that is marked "FAILED" in sacct on some clusters, while the others are
+                # marked "CANCELLED". With "FAILED" in red, users might get a bit worried.
+                job_state = "CANCELLED"
             cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
             if job_state.startswith(("CANCELLED", "COMPLETED")):
                 console.print(f"Job {job_id} on cluster {cluster} is now {job_state}.")

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -377,6 +377,8 @@ async def wait_for_jobs_to_cancel(
 
         for (cluster, job_id), job_state in zip(to_cancel, job_states):
             logger.info(f"Job {job_id} on cluster {cluster} is in state: {job_state}")
+            if job_state.startswith("CANCELLED by"):
+                job_state = "CANCELLED"  # just to avoid confusing users.
             cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
             if job_state.startswith(("CANCELLED", "COMPLETED")):
                 console.print(f"Job {job_id} on cluster {cluster} is now {job_state}.")

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path, PurePosixPath
 
 import rich.table
+import rich.text
 from rich.live import Live
 
 from cluv.cache import Job, save_job
@@ -161,17 +162,27 @@ async def submit_first(
     cancelling = False
 
     def make_table() -> rich.table.Table:
-        nonlocal cancelling
         table = rich.table.Table(
             "Cluster",
             "Job ID",
             "Status",
-            title="Waiting for a job to start"
+            title="Waiting for a job to start..."
             if not cancelling
-            else "Waiting for other jobs to be cancelled",
+            else "Waiting for jobs to cancel...",
         )
         for (cluster, job_id), job_state in cluster_and_jobid_to_jobstate.items():
-            table.add_row(cluster, str(job_id), job_state)
+            table.add_row(
+                cluster,
+                str(job_id),
+                rich.text.Text(
+                    job_state,
+                    style="green"
+                    if job_state.startswith(("RUNNING", "COMPLETED"))
+                    else "yellow"
+                    if job_state.startswith("PENDING")
+                    else "red",
+                ),
+            )
         return table
 
     try:
@@ -179,7 +190,7 @@ async def submit_first(
             first_running_job = await wait_for_running_job(
                 cluster_and_jobid_to_jobstate, cluster_to_remote, max_wait_time_seconds
             )
-            live.update(make_table(), refresh=True)
+            live.update(make_table(), refresh=True)  # probably not entirely necessary.
             if not first_running_job:
                 console.log("All submitted jobs have failed! Exiting.")
                 return None
@@ -195,10 +206,11 @@ async def submit_first(
                 cluster_to_remote,
                 max_wait_time_seconds,
             )
-            live.update(make_table(), refresh=True)
+            live.update(make_table(), refresh=True)  # probably not entirely necessary.
 
         console.print(
-            f"Successfully cancelled all other jobs except for job {first_running_job.job_id} on cluster {first_running_job.cluster}."
+            f"Successfully cancelled all other jobs except for job {first_running_job.job_id} "
+            f"on cluster {first_running_job.cluster}, which is {first_running_job.state}."
         )
     except (KeyboardInterrupt, asyncio.CancelledError, Exception):
         console.log("Interrupted by user. Cancelling all jobs...")
@@ -281,6 +293,10 @@ async def wait_for_jobs_to_cancel(
     job_states = await asyncio.gather(
         *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
     )
+    for (cluster, job_id), job_state in zip(to_cancel, job_states):
+        logger.info(f"Job {job_id} on cluster {cluster} state: {job_state}")
+        cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
+
     to_cancel = [
         (cluster, job_id)
         for (cluster, job_id), job_state in zip(to_cancel, job_states)
@@ -313,16 +329,18 @@ async def wait_for_jobs_to_cancel(
         logger.debug(f"Job states: {job_states}")
 
         for (cluster, job_id), job_state in zip(to_cancel, job_states):
-            logger.info(f"Job {job_id} on cluster {cluster} state: {job_state}")
+            logger.info(f"Job {job_id} on cluster {cluster} is in state: {job_state}")
             cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
-            if job_state.startswith(tuple(["CANCELLED"] + FAILED_JOB_STATES)):
+            if job_state.startswith(("CANCELLED", "COMPLETED")):
                 console.print(f"Job {job_id} on cluster {cluster} is now {job_state}.")
                 to_cancel.remove((cluster, job_id))
+                # TODO: Do we remove the jobs from the table if they failed?
                 # Also remove from `cluster_to_jobid` so the ctrl+c handler below doesn't
                 # try to cancel it again.
                 # cluster_and_jobid_to_jobstate.pop((cluster, job_id))
     console.print(
-        f"Successfully cancelled all other jobs except for job {first_running_job.job_id} on cluster {first_running_job.cluster}."
+        f"Successfully cancelled all other jobs except for job {first_running_job.job_id} on "
+        f"cluster {first_running_job.cluster}."
     )
 
 
@@ -457,7 +475,7 @@ async def sbatch(
 
 async def get_job_state(remote: Remote | None, job_id: int) -> str:
     """Get the state of the job with the given id on the remote cluster with `sacct`."""
-    sacct_command = f"sacct -j {job_id} --format=State --noheader --allocations"
+    sacct_command = f"sacct -j {job_id} --format=State --parsable2 --noheader --allocations"
     if remote:
         return await remote.get_output(sacct_command, hide=True)
     result = await run(tuple(shlex.split(sacct_command)), hide=True)

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -156,31 +156,26 @@ async def submit_first(
     table = rich.table.Table("Cluster", "Result", title="Jobs submitted on the clusters")
     for cluster, sbatch_result in cluster_to_sbatch_result.items():
         sbatch_command = sbatch_commands[cluster]
-        if isinstance(sbatch_result, BaseException):
-            table.add_row(
-                cluster, f"{sbatch_command}\n[red]Error: {sbatch_result}[/red]", end_section=True
+        if isinstance(sbatch_result, BaseException) or sbatch_result.returncode != 0:
+            error_message = (
+                str(sbatch_result)
+                if isinstance(sbatch_result, BaseException)
+                else sbatch_result.stderr.strip()
             )
+            output_text = rich.text.Text(f"Error: {error_message}", style="red")
         else:
-            if sbatch_result.returncode == 0:
-                job_id = int(sbatch_result.stdout.strip())
-                cluster_to_jobid[cluster] = job_id
-                table.add_row(
-                    cluster,
-                    rich.console.Group(
-                        rich.syntax.Syntax(sbatch_command, lexer="sh", word_wrap=True),
-                        rich.text.Text(f"Job ID: {job_id}", style="green"),
-                    ),
-                    end_section=True,
-                )
-            else:
-                table.add_row(
-                    cluster,
-                    rich.console.Group(
-                        rich.syntax.Syntax(sbatch_command, lexer="sh", word_wrap=True),
-                        rich.text.Text(f"Error: {sbatch_result.stderr.strip()}", style="red"),
-                    ),
-                    end_section=True,
-                )
+            job_id = int(sbatch_result.stdout.strip())
+            cluster_to_jobid[cluster] = job_id
+            output_text = rich.text.Text(f"Job ID: {job_id}", style="green")
+        table.add_row(
+            cluster,
+            rich.console.Group(
+                rich.syntax.Syntax(sbatch_command, lexer="sh", word_wrap=True),
+                output_text,
+            ),
+            end_section=True,
+        )
+
     console.print(table)
 
     if not cluster_to_jobid:

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -104,7 +104,7 @@ async def submit(
     console.log(
         f"Successfully submitted job {job_id} on the {cluster} cluster.\n"
         f"Use `ssh {cluster} sacct -j {job_id}` to view its status, and `cluv sync {cluster}` to "
-        f"fetch results once it is complete.."
+        f"fetch results once it is complete."
     )
 
     return job

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -11,9 +11,9 @@ from pathlib import Path, PurePosixPath
 from cluv.cache import save_job
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_cluv_config
-from cluv.remote import Remote
+from cluv.remote import Remote, run
 from cluv.slurm import FAILED_JOB_STATES
-from cluv.utils import console
+from cluv.utils import console, current_cluster
 
 RUNNING_JOB_STATES = ["PENDING", "RUNNING"]
 logger = logging.getLogger(__name__)
@@ -60,14 +60,18 @@ async def submit(
     # Check git is clean locally (untracked files are fine) and capture current commit hash.
     git_commit = ensure_clean_git_state()
 
+    here = current_cluster()
+
     if cluster == "first":
         return await submit_first(job_script, sbatch_args, program_args, git_commit)
 
-    # Sync.
-    remotes = await sync(clusters=[cluster])
-
-    # Run the sbatch command over SSH.
-    remote = remotes[0]
+    if cluster != here:
+        # Sync.
+        remote = (await sync(clusters=[cluster]))[0]
+        # Run the sbatch command over SSH.
+    else:
+        # Submitting to the current cluster.
+        remote = None
     result = await sbatch(remote, job_script, sbatch_args, program_args, git_commit)
 
     if result.returncode != 0:
@@ -186,7 +190,9 @@ async def submit_first(
         await cancel_all_jobs(clusters_to_remote, cluster_to_jobid, start_cluster)
 
     if start_job_id is not None and start_cluster is not None:
-        save_job(start_job_id, start_cluster, str(job_script), git_commit, sbatch_args, program_args)
+        save_job(
+            start_job_id, start_cluster, str(job_script), git_commit, sbatch_args, program_args
+        )
 
     return start_job_id
 
@@ -302,17 +308,22 @@ def get_sbatch_command(
 
 
 async def sbatch(
-    remote: Remote,
+    remote: Remote | None,
     job_script: Path,
     sbatch_args: list[str],
     program_args: list[str],
     git_commit: str,
 ) -> subprocess.CompletedProcess[str]:
     """Submit the job via sbatch on the remote cluster, and return the job id."""
-    cluster = remote.hostname
-
+    cluster = remote.hostname if remote else current_cluster()
+    # Should be set, since `remote` is None if current_cluster() is the same as the cluster argument
+    # to `submit`.
+    assert cluster
     remote_cmd = get_sbatch_command(cluster, job_script, sbatch_args, program_args, git_commit)
-    return await remote.run(remote_cmd, display=True, warn=True, hide=True)
+    if remote:
+        return await remote.run(remote_cmd, display=True, warn=True, hide=True)
+    # Run the sbatch command locally.
+    return await run(tuple(shlex.split(remote_cmd)), _display=True, warn=True, hide=True)
 
 
 async def get_job_status(remote: Remote, job_id: int) -> str:

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -31,7 +31,7 @@ async def submit(
     job_script: Path,
     sbatch_args: list[str],
     program_args: list[str],
-) -> int | None:
+) -> Job | None:
     """Submit a SLURM job on a remote cluster.
 
     Enforces a clean git state, syncs the project, sets `GIT_COMMIT` and any
@@ -68,7 +68,10 @@ async def submit(
     here = current_cluster()
 
     if cluster == "first":
-        return await submit_first(job_script, sbatch_args, program_args, git_commit)
+        job = await submit_first(job_script, sbatch_args, program_args, git_commit)
+        if job:
+            save_job(job)
+        return job
 
     if cluster != here:
         # Sync.
@@ -78,20 +81,31 @@ async def submit(
         # Submitting to the current cluster.
         remote = None
     result = await sbatch(remote, job_script, sbatch_args, program_args, git_commit)
+    submit_time = datetime.datetime.now()
 
     if result.returncode != 0:
         console.print(f"[red] Error during sbatch : {result.stderr}[/red]")
         return None
 
     job_id = int(result.stdout.strip())
-    save_job(job_id, cluster, str(job_script), git_commit, sbatch_args, program_args)
+    job = Job(
+        job_id=job_id,
+        cluster=cluster,
+        job_script=str(job_script),
+        git_commit=git_commit,
+        sbatch_args=sbatch_args,
+        program_args=program_args,
+        submitted_at=submit_time.isoformat(),
+    )
+    save_job(job)
 
     console.log(
         f"Successfully submitted job {job_id} on the {cluster} cluster.\n"
-        f"Use `ssh {cluster} sacct -j {job_id}` to view its status."
+        f"Use `ssh {cluster} sacct -j {job_id}` to view its status, and `cluv sync {cluster}` to "
+        f"fetch results once it is complete.."
     )
 
-    return job_id
+    return job
 
 
 async def submit_first(
@@ -114,6 +128,10 @@ async def submit_first(
         assert not any(remote.hostname == this_cluster for remote in remotes)
 
     # Submit the job on all the clusters (and possibly locally).
+    sbatch_commands = {
+        cluster: get_sbatch_command(cluster, job_script, sbatch_args, program_args, git_commit)
+        for cluster in cluster_to_remote
+    }
     sbatch_results = await asyncio.gather(
         *[
             sbatch(
@@ -134,16 +152,27 @@ async def submit_first(
 
     cluster_to_jobid: dict[str, int] = {}
     table = rich.table.Table("Cluster", "Result", title="Jobs submitted on the clusters")
-    for cluster, result in cluster_to_sbatch_result.items():
-        if isinstance(result, BaseException):
-            table.add_row(cluster, f"[red]Error: {result}[/red]")
+    for cluster, sbatch_result in cluster_to_sbatch_result.items():
+        sbatch_command = sbatch_commands[cluster]
+        if isinstance(sbatch_result, BaseException):
+            table.add_row(
+                cluster, f"{sbatch_command}\n[red]Error: {sbatch_result}[/red]", end_section=True
+            )
         else:
-            if result.returncode == 0:
-                job_id = int(result.stdout.strip())
+            if sbatch_result.returncode == 0:
+                job_id = int(sbatch_result.stdout.strip())
                 cluster_to_jobid[cluster] = job_id
-                table.add_row(cluster, f"[green]Job ID: {job_id}[/green]")
+                table.add_row(
+                    cluster,
+                    f"{sbatch_command}\n[green]Job ID: {job_id}[/green]",
+                    end_section=True,
+                )
             else:
-                table.add_row(cluster, f"[red]Error: {result.stderr.strip()}[/red]")
+                table.add_row(
+                    cluster,
+                    f"{sbatch_command}\n[red]Error: {sbatch_result.stderr.strip()}[/red]",
+                    end_section=True,
+                )
     console.print(table)
 
     if not cluster_to_jobid:
@@ -177,9 +206,9 @@ async def submit_first(
                 rich.text.Text(
                     job_state,
                     style="green"
-                    if job_state.startswith(("RUNNING", "COMPLETED"))
+                    if job_state.startswith(("RUNNING", "COMPLETED", "CANCELLED"))
                     else "yellow"
-                    if job_state.startswith("PENDING")
+                    if job_state.startswith(("PENDING", "UNKNOWN"))
                     else "red",
                 ),
             )
@@ -212,6 +241,14 @@ async def submit_first(
             f"Successfully cancelled all other jobs except for job {first_running_job.job_id} "
             f"on cluster {first_running_job.cluster}, which is {first_running_job.state}."
         )
+        if first_running_job.state.startswith("RUNNING"):
+            console.print(
+                f"Use `ssh {first_running_job.cluster} sacct -j {first_running_job.job_id}` to view its status."
+            )
+            console.print(
+                f"Once completed, run `cluv sync {first_running_job.cluster}` to fetch its results."
+            )
+
     except (KeyboardInterrupt, asyncio.CancelledError, Exception):
         console.log("Interrupted by user. Cancelling all jobs...")
         to_cancel = list(cluster_to_jobid.items())
@@ -466,11 +503,11 @@ async def sbatch(
     # Should be set, since `remote` is None if current_cluster() is the same as the cluster argument
     # to `submit`.
     assert cluster
-    remote_cmd = get_sbatch_command(cluster, job_script, sbatch_args, program_args, git_commit)
+    sbatch_command = get_sbatch_command(cluster, job_script, sbatch_args, program_args, git_commit)
     if remote:
-        return await remote.run(remote_cmd, display=True, warn=True, hide=True)
+        return await remote.run(sbatch_command, display=False, warn=True, hide=True)
     # Run the sbatch command locally.
-    return await run(tuple(shlex.split(remote_cmd)), _display=True, warn=True, hide=True)
+    return await run(tuple(shlex.split(sbatch_command)), _display=False, warn=True, hide=True)
 
 
 async def get_job_state(remote: Remote | None, job_id: int) -> str:

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -532,19 +532,3 @@ async def cancel_job(remote: Remote | None, job_id: int, print: bool = False) ->
             console.print(f"Cancelled job {job_id} on the current cluster.")
         output = result.stdout
     return output
-
-
-async def cancel_all_jobs(
-    remotes: dict[str, Remote | None],
-    cluster_and_jobid: list[tuple[str, int]],
-    keep_cluster: str | None,
-    keep_job_id: int | None,
-) -> None:
-    """Cancel all jobs in cluster_to_jobid on their respective remotes."""
-    await asyncio.gather(
-        *[
-            cancel_job(remotes[cluster], job_id)
-            for cluster, job_id in cluster_and_jobid.items()
-            if cluster != keep_cluster and job_id != keep_job_id
-        ]
-    )

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path, PurePosixPath
 
 import rich.table
+from rich.live import Live
 
 from cluv.cache import save_job
 from cluv.cli.sync import sync
@@ -152,45 +153,72 @@ async def submit_first(
 
     max_wait_time_seconds = 60
     wait_time = 2  # seconds; grows up to max_wait_time_seconds.
+
+    cluster_and_jobid_to_jobstate: dict[tuple[str, int], str] = {
+        (cluster, job_id): "UNKNOWN" for cluster, job_id in cluster_to_jobid.items()
+    }
+
+    def make_table() -> rich.table.Table:
+        table = rich.table.Table("Cluster", "Job ID", "Status", title="Waiting for a job to start")
+        for (cluster, job_id), job_state in cluster_and_jobid_to_jobstate.items():
+            table.add_row(cluster, str(job_id), job_state)
+        return table
+
     try:
-        spinner = console.status("Waiting for a job to start...")
-        spinner.start()
+        with Live(make_table(), refresh_per_second=1) as live:
+            while first_running_job_id is None and cluster_to_jobid:
+                # Initial sleep after sbatch to give time for job to appear in sacct.
+                await asyncio.sleep(wait_time)
+                wait_time = min(wait_time * 2, max_wait_time_seconds)
 
-        while first_running_job_id is None:
-            for cluster, job_id in list(cluster_to_jobid.items()):
-                remote: Remote | None = cluster_to_remote[cluster]
-
-                job_state = await get_job_state(remote, job_id)
-                if job_state == "RUNNING":
-                    first_running_job_cluster = cluster
-                    first_running_job_id = job_id
-                    break
-                elif job_state in FAILED_JOB_STATES:
-                    console.print(
-                        f"Job {job_id} on cluster {cluster} ended with status {job_state}."
+                job_states = await asyncio.gather(
+                    *(
+                        get_job_state(cluster_to_remote[cluster], job_id)
+                        for cluster, job_id in cluster_to_jobid.items()
                     )
-                    cluster_to_jobid.pop(cluster)
+                )
+
+                for (cluster, job_id), job_state in zip(
+                    cluster_and_jobid_to_jobstate.keys(), job_states
+                ):
+                    cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
+                    if job_state in ["RUNNING", "COMPLETED"]:
+                        first_running_job_cluster = cluster
+                        first_running_job_id = job_id
+                        break
+                    elif job_state in FAILED_JOB_STATES:
+                        console.print(
+                            f"Job {job_id} on cluster {cluster} ended with status {job_state}."
+                        )
+                        cluster_to_jobid.pop(cluster)
+                live.update(make_table())
 
             # Stop the wait if all the jobs failed
             if not cluster_to_jobid:
                 console.log("All submitted jobs have failed! Exiting.")
                 return None
 
-            await asyncio.sleep(wait_time)
-            wait_time = min(wait_time * 2, max_wait_time_seconds)
-
-        spinner.stop()
-        if first_running_job_id:
-            console.log(
-                f"Job {first_running_job_id} on cluster {first_running_job_cluster} is running. Cancelling the other jobs...\n",
-                f"Use `ssh {first_running_job_cluster} sacct -j {first_running_job_id}` to view its status.",
-            )
     except (KeyboardInterrupt, asyncio.CancelledError):
         console.log("Interrupted by user. Cancelling all jobs...")
     finally:
-        await cancel_all_jobs(cluster_to_remote, cluster_to_jobid, first_running_job_cluster)
+        to_cancel = list(
+            cluster_to_jobid.items()
+        )  # a dict for now, might become a list of tuples.
+        if first_running_job_cluster:
+            assert first_running_job_id is not None
+            to_cancel.remove((first_running_job_cluster, first_running_job_id))
+        await asyncio.gather(
+            *[cancel_job(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel]
+        )
 
-    if first_running_job_id is not None and first_running_job_cluster is not None:
+    if first_running_job_id is not None:
+        assert first_running_job_cluster is not None
+        console.log(
+            f"Job {first_running_job_id} on cluster {first_running_job_cluster} is running. "
+            f"Cancelling the other jobs...\n",
+            f"Use `ssh {first_running_job_cluster} sacct -j {first_running_job_id}` to view its "
+            f"status.",
+        )
         save_job(
             first_running_job_id,
             first_running_job_cluster,
@@ -334,7 +362,7 @@ async def sbatch(
 
 async def get_job_state(remote: Remote | None, job_id: int) -> str:
     """Get the state of the job with the given id on the remote cluster with `sacct`."""
-    sacct_command = f"sacct -j {job_id} --format=State --noheader --allocations"
+    sacct_command = f"sacct -j {job_id} --parsable2 --format=State --noheader --allocations"
     if remote:
         return await remote.get_output(sacct_command, hide=True)
     result = await run(tuple(shlex.split(sacct_command)), hide=True)
@@ -355,13 +383,16 @@ async def cancel_job(remote: Remote | None, job_id: int) -> str:
 
 
 async def cancel_all_jobs(
-    remotes: dict[str, Remote | None], cluster_to_jobid: dict[str, int], keep_cluster: str | None
+    remotes: dict[str, Remote | None],
+    cluster_and_jobid: list[tuple[str, int]],
+    keep_cluster: str | None,
+    keep_job_id: int | None,
 ) -> None:
     """Cancel all jobs in cluster_to_jobid on their respective remotes."""
     await asyncio.gather(
         *[
             cancel_job(remotes[cluster], job_id)
-            for cluster, job_id in cluster_to_jobid.items()
-            if cluster != keep_cluster
+            for cluster, job_id in cluster_and_jobid.items()
+            if cluster != keep_cluster and job_id != keep_job_id
         ]
     )

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
+import datetime
 import logging
 import os
 import shlex
@@ -11,7 +13,7 @@ from pathlib import Path, PurePosixPath
 import rich.table
 from rich.live import Live
 
-from cluv.cache import save_job
+from cluv.cache import Job, save_job
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_cluv_config
 from cluv.remote import Remote, run
@@ -96,7 +98,7 @@ async def submit_first(
     sbatch_args: list[str],
     program_args: list[str],
     git_commit: str,
-) -> int | None:
+) -> Job | None:
     """Submit the job on all clusters, and wait until one of them starts.
     Once one starts, cancel the others.
     """
@@ -124,6 +126,7 @@ async def submit_first(
         ],
         return_exceptions=True,
     )
+    submit_time = datetime.datetime.now()
     # TODO: This could be a list of tuples eventually, since we could potentially try to submit
     # multiple different jobs per cluster.
     cluster_to_sbatch_result = dict(zip(cluster_to_remote.keys(), sbatch_results))
@@ -148,87 +151,179 @@ async def submit_first(
 
     # Wait for a job to start on a cluster.
     # If the wait is interrupted, cancel all jobs.
-    first_running_job_cluster: str | None = None
-    first_running_job_id: int | None = None
+    first_running_job: JobHandle | None = None
 
     max_wait_time_seconds = 60
-    wait_time = 2  # seconds; grows up to max_wait_time_seconds.
 
     cluster_and_jobid_to_jobstate: dict[tuple[str, int], str] = {
         (cluster, job_id): "UNKNOWN" for cluster, job_id in cluster_to_jobid.items()
     }
+    cancelling = False
 
     def make_table() -> rich.table.Table:
-        table = rich.table.Table("Cluster", "Job ID", "Status", title="Waiting for a job to start")
+        nonlocal cancelling
+        table = rich.table.Table(
+            "Cluster",
+            "Job ID",
+            "Status",
+            title="Waiting for a job to start"
+            if not cancelling
+            else "Waiting for other jobs to be cancelled",
+        )
         for (cluster, job_id), job_state in cluster_and_jobid_to_jobstate.items():
             table.add_row(cluster, str(job_id), job_state)
         return table
 
     try:
-        with Live(make_table(), refresh_per_second=1) as live:
-            while first_running_job_id is None and cluster_to_jobid:
-                # Initial sleep after sbatch to give time for job to appear in sacct.
-                await asyncio.sleep(wait_time)
-                wait_time = min(wait_time * 2, max_wait_time_seconds)
-
-                job_states = await asyncio.gather(
-                    *(
-                        get_job_state(cluster_to_remote[cluster], job_id)
-                        for cluster, job_id in cluster_to_jobid.items()
-                    )
-                )
-
-                for (cluster, job_id), job_state in zip(
-                    cluster_and_jobid_to_jobstate.keys(), job_states
-                ):
-                    cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
-                    if job_state in ["RUNNING", "COMPLETED"]:
-                        first_running_job_cluster = cluster
-                        first_running_job_id = job_id
-                        break
-                    elif job_state in FAILED_JOB_STATES:
-                        console.print(
-                            f"Job {job_id} on cluster {cluster} ended with status {job_state}."
-                        )
-                        cluster_to_jobid.pop(cluster)
-                live.update(make_table())
-
-            # Stop the wait if all the jobs failed
-            if not cluster_to_jobid:
+        with Live(get_renderable=make_table, console=console, refresh_per_second=1) as live:
+            first_running_job = await wait_for_running_job(
+                cluster_and_jobid_to_jobstate, cluster_to_remote, max_wait_time_seconds
+            )
+            live.update(make_table(), refresh=True)
+            if not first_running_job:
                 console.log("All submitted jobs have failed! Exiting.")
                 return None
 
-    except (KeyboardInterrupt, asyncio.CancelledError):
+            console.log(
+                f"Job {first_running_job.job_id} on cluster {first_running_job.cluster} is {first_running_job.state}. "
+                f"Cancelling the other jobs...\n",
+            )
+            cancelling = True
+            await wait_for_jobs_to_cancel(
+                cluster_and_jobid_to_jobstate,
+                first_running_job,
+                cluster_to_remote,
+                max_wait_time_seconds,
+            )
+            live.update(make_table(), refresh=True)
+
+        console.print(
+            f"Successfully cancelled all other jobs except for job {first_running_job.job_id} on cluster {first_running_job.cluster}."
+        )
+    except (KeyboardInterrupt, asyncio.CancelledError, Exception):
         console.log("Interrupted by user. Cancelling all jobs...")
-    finally:
-        to_cancel = list(
-            cluster_to_jobid.items()
-        )  # a dict for now, might become a list of tuples.
-        if first_running_job_cluster:
-            assert first_running_job_id is not None
-            to_cancel.remove((first_running_job_cluster, first_running_job_id))
+        to_cancel = list(cluster_to_jobid.items())
+        if first_running_job:
+            to_cancel.remove((first_running_job.cluster, first_running_job.job_id))
         await asyncio.gather(
-            *[cancel_job(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel]
+            *[
+                cancel_job(cluster_to_remote[cluster], job_id, print=True)
+                for cluster, job_id in to_cancel
+            ]
         )
 
-    if first_running_job_id is not None:
-        assert first_running_job_cluster is not None
-        console.log(
-            f"Job {first_running_job_id} on cluster {first_running_job_cluster} is running. "
-            f"Cancelling the other jobs...\n",
-            f"Use `ssh {first_running_job_cluster} sacct -j {first_running_job_id}` to view its "
-            f"status.",
-        )
-        save_job(
-            first_running_job_id,
-            first_running_job_cluster,
-            str(job_script),
-            git_commit,
-            sbatch_args,
-            program_args,
-        )
     # TODO: Return the cluster and job id.
-    return first_running_job_id
+    assert first_running_job
+    return Job(
+        job_id=first_running_job.job_id,
+        cluster=first_running_job.cluster,
+        job_script=str(job_script),
+        git_commit=git_commit,
+        sbatch_args=sbatch_args,
+        program_args=program_args,
+        submitted_at=submit_time.isoformat(),
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class JobHandle:
+    cluster: str
+    job_id: int
+    state: str
+
+
+async def wait_for_running_job(
+    cluster_and_jobid_to_jobstate: dict[tuple[str, int], str],
+    cluster_to_remote: dict[str, Remote | None],
+    max_wait_time_seconds: int = 60,
+) -> JobHandle | None:
+    """Watch the jobs with sacct until one of them starts (or completes)."""
+
+    first_running_job: JobHandle | None = None
+    wait_time = 10
+
+    to_query = list(cluster_and_jobid_to_jobstate.keys())
+
+    while first_running_job is None and to_query:
+        # Initial sleep after sbatch to give time for job to appear in sacct.
+        await asyncio.sleep(wait_time)
+        wait_time = min(wait_time * 2, max_wait_time_seconds)
+
+        job_states = await asyncio.gather(
+            *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_query)
+        )
+
+        for (cluster, job_id), job_state in zip(to_query.copy(), job_states):
+            if (previous_state := cluster_and_jobid_to_jobstate[(cluster, job_id)]) != job_state:
+                console.print(
+                    f"Job {job_id} on cluster {cluster}: {previous_state} -> {job_state}"
+                )
+            cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
+            if job_state.startswith(("RUNNING", "COMPLETED")):
+                return JobHandle(job_id=job_id, cluster=cluster, state=job_state)
+            if job_state in FAILED_JOB_STATES:
+                to_query.remove((cluster, job_id))
+    # If all failed, `cluster_and_jobid_to_jobstate` is empty.
+    assert not to_query
+    return None
+
+
+async def wait_for_jobs_to_cancel(
+    cluster_and_jobid_to_jobstate: dict[tuple[str, int], str],
+    first_running_job: JobHandle,
+    cluster_to_remote: dict[str, Remote | None],
+    max_wait_time_seconds: int = 60,
+) -> JobHandle | None:
+
+    to_cancel = list(cluster_and_jobid_to_jobstate.keys())
+    to_cancel.remove((first_running_job.cluster, first_running_job.job_id))
+
+    job_states = await asyncio.gather(
+        *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
+    )
+    to_cancel = [
+        (cluster, job_id)
+        for (cluster, job_id), job_state in zip(to_cancel, job_states)
+        if not job_state.startswith(("CANCELLED", "COMPLETED"))
+    ]
+
+    logger.info(f"Need to cancel the following jobs: {to_cancel}")
+
+    await asyncio.gather(
+        *[
+            cancel_job(cluster_to_remote[cluster], job_id, print=True)
+            for cluster, job_id in to_cancel
+        ]
+    )
+    wait_time = 5
+
+    while not all(
+        cluster_and_jobid_to_jobstate[cluster_jobid].startswith(
+            tuple(["CANCELLED"] + FAILED_JOB_STATES)
+        )
+        for cluster_jobid in to_cancel.copy()
+    ):
+        # Initial sleep after scancel to give time for job to be cancelled.
+        await asyncio.sleep(wait_time)
+        wait_time = min(wait_time * 2, max_wait_time_seconds)
+
+        job_states = await asyncio.gather(
+            *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
+        )
+        logger.debug(f"Job states: {job_states}")
+
+        for (cluster, job_id), job_state in zip(to_cancel, job_states):
+            logger.info(f"Job {job_id} on cluster {cluster} state: {job_state}")
+            cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
+            if job_state.startswith(tuple(["CANCELLED"] + FAILED_JOB_STATES)):
+                console.print(f"Job {job_id} on cluster {cluster} is now {job_state}.")
+                to_cancel.remove((cluster, job_id))
+                # Also remove from `cluster_to_jobid` so the ctrl+c handler below doesn't
+                # try to cancel it again.
+                # cluster_and_jobid_to_jobstate.pop((cluster, job_id))
+    console.print(
+        f"Successfully cancelled all other jobs except for job {first_running_job.job_id} on cluster {first_running_job.cluster}."
+    )
 
 
 def ensure_clean_git_state() -> str:
@@ -362,22 +457,24 @@ async def sbatch(
 
 async def get_job_state(remote: Remote | None, job_id: int) -> str:
     """Get the state of the job with the given id on the remote cluster with `sacct`."""
-    sacct_command = f"sacct -j {job_id} --parsable2 --format=State --noheader --allocations"
+    sacct_command = f"sacct -j {job_id} --format=State --noheader --allocations"
     if remote:
         return await remote.get_output(sacct_command, hide=True)
     result = await run(tuple(shlex.split(sacct_command)), hide=True)
     return result.stdout.strip()
 
 
-async def cancel_job(remote: Remote | None, job_id: int) -> str:
+async def cancel_job(remote: Remote | None, job_id: int, print: bool = False) -> str:
     """Cancel the job with the given id on the remote cluster."""
     scancel_command = f"scancel {job_id}"
     if remote:
         output = await remote.get_output(scancel_command, hide=True)
-        console.print(f"Cancelled job {job_id} on cluster {remote.hostname}.")
+        if print:
+            console.print(f"Cancelled job {job_id} on cluster {remote.hostname}.")
     else:
         result = await run(tuple(shlex.split(scancel_command)), hide=True)
-        console.print(f"Cancelled job {job_id} on the current cluster.")
+        if print:
+            console.print(f"Cancelled job {job_id} on the current cluster.")
         output = result.stdout
     return output
 

--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -139,9 +139,7 @@ async def sync(
     cwd = Path.cwd()
     for remote, new_runs in zip(remotes, per_cluster_new_runs):
         if new_runs:
-            console.print(
-                f"[green]Newly synced runs from [bold]{remote.hostname}[/bold]:[/green]"
-            )
+            console.print(f"[green]Newly synced runs from [bold]{remote.hostname}[/bold]:[/green]")
             for run_path in sorted(new_runs):
                 try:
                     display_path = run_path.relative_to(cwd)
@@ -155,6 +153,8 @@ async def sync(
 async def get_active_remotes() -> list[Remote]:
     """Returns the Remotes for each cluster which has an active SSH connection."""
     clusters = get_cluv_config().clusters_names
+    if (this_cluster := current_cluster()) and this_cluster in clusters:
+        clusters.remove(this_cluster)
     connections = await asyncio.gather(
         *(get_remote_without_2fa_prompt(cluster) for cluster in clusters)
     )
@@ -391,7 +391,9 @@ async def fetch_results(remote: Remote, config: CluvConfig) -> list[Path]:
 
     # Snapshot the runs already present locally before syncing.
     existing_runs: set[Path] = (
-        {p for p in results_path_here.iterdir() if p.is_dir()} if results_path_here.exists() else set()
+        {p for p in results_path_here.iterdir() if p.is_dir()}
+        if results_path_here.exists()
+        else set()
     )
 
     # Resolve any environment variables in the results_path on the remote before rsync, otherwise

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -13,9 +13,7 @@ from pathlib import Path
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass
 
-from cluv.utils import current_cluster
-
-from cluv.utils import find_pyproject
+from cluv.utils import current_cluster, find_pyproject
 
 logger = logging.getLogger(__name__)
 
@@ -106,10 +104,11 @@ class CluvConfig(BaseModel):
         cluv_config = get_cluv_config()
         cluster_config = cluv_config.clusters[cluster]
         datasets_path = cluster_config.datasets_path or cluv_config.datasets_path
+        results_path = cluster_config.results_path or cluv_config.results_path
         return ClusterConfig(
             env=cluv_config.env | cluster_config.env,
             # TODO: Use the cluster-specific results_path if we add that option back in the future.
-            results_path=Path(cluv_config.results_path),
+            results_path=Path(results_path),
             datasets_path=Path(datasets_path) if datasets_path else None,
         )
 

--- a/cluv/job.py
+++ b/cluv/job.py
@@ -3,6 +3,7 @@
 This is a simplified job script, used to test the syncing of the 'dataset' across clusters.
 """
 
+import enum
 import functools
 import os
 import re
@@ -24,6 +25,38 @@ SLURM_PROCID = int(os.environ["SLURM_PROCID"]) if "SLURM_PROCID" in os.environ e
 
 in_job_packing = "SLURM_NTASKS_PER_GPU" in os.environ
 in_job_array = "SLURM_ARRAY_JOB_ID" in os.environ
+
+
+class SlurmState(str, enum.Enum):
+    """Possible Slurm job states.
+
+    Reference: https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES
+    """
+
+    BOOT_FAIL = "BOOT_FAIL"
+    CANCELLED = "CANCELLED"
+    COMPLETED = "COMPLETED"
+    CONFIGURING = "CONFIGURING"
+    COMPLETING = "COMPLETING"
+    DEADLINE = "DEADLINE"
+    FAILED = "FAILED"
+    NODE_FAIL = "NODE_FAIL"
+    OUT_OF_MEMORY = "OUT_OF_MEMORY"
+    PENDING = "PENDING"
+    PREEMPTED = "PREEMPTED"
+    RUNNING = "RUNNING"
+    RESV_DEL_HOLD = "RESV_DEL_HOLD"
+    REQUEUE_FED = "REQUEUE_FED"
+    REQUEUE_HOLD = "REQUEUE_HOLD"
+    REQUEUED = "REQUEUED"
+    RESIZING = "RESIZING"
+    REVOKED = "REVOKED"
+    SIGNALING = "SIGNALING"
+    SPECIAL_EXIT = "SPECIAL_EXIT"
+    STAGE_OUT = "STAGE_OUT"
+    STOPPED = "STOPPED"
+    SUSPENDED = "SUSPENDED"
+    TIMEOUT = "TIMEOUT"
 
 
 @dataclass(frozen=True)

--- a/cluv/job.py
+++ b/cluv/job.py
@@ -3,7 +3,6 @@
 This is a simplified job script, used to test the syncing of the 'dataset' across clusters.
 """
 
-import enum
 import functools
 import os
 import re
@@ -25,38 +24,6 @@ SLURM_PROCID = int(os.environ["SLURM_PROCID"]) if "SLURM_PROCID" in os.environ e
 
 in_job_packing = "SLURM_NTASKS_PER_GPU" in os.environ
 in_job_array = "SLURM_ARRAY_JOB_ID" in os.environ
-
-
-class SlurmState(str, enum.Enum):
-    """Possible Slurm job states.
-
-    Reference: https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES
-    """
-
-    BOOT_FAIL = "BOOT_FAIL"
-    CANCELLED = "CANCELLED"
-    COMPLETED = "COMPLETED"
-    CONFIGURING = "CONFIGURING"
-    COMPLETING = "COMPLETING"
-    DEADLINE = "DEADLINE"
-    FAILED = "FAILED"
-    NODE_FAIL = "NODE_FAIL"
-    OUT_OF_MEMORY = "OUT_OF_MEMORY"
-    PENDING = "PENDING"
-    PREEMPTED = "PREEMPTED"
-    RUNNING = "RUNNING"
-    RESV_DEL_HOLD = "RESV_DEL_HOLD"
-    REQUEUE_FED = "REQUEUE_FED"
-    REQUEUE_HOLD = "REQUEUE_HOLD"
-    REQUEUED = "REQUEUED"
-    RESIZING = "RESIZING"
-    REVOKED = "REVOKED"
-    SIGNALING = "SIGNALING"
-    SPECIAL_EXIT = "SPECIAL_EXIT"
-    STAGE_OUT = "STAGE_OUT"
-    STOPPED = "STOPPED"
-    SUSPENDED = "SUSPENDED"
-    TIMEOUT = "TIMEOUT"
 
 
 @dataclass(frozen=True)

--- a/examples/pytorch-example/pyproject.toml
+++ b/examples/pytorch-example/pyproject.toml
@@ -60,20 +60,20 @@ results_path = "$HOME/logs/cluv"
 
 [tool.cluv.clusters.vulcan]
 
-# [tool.cluv.clusters.rorqual]
-# env = {SBATCH_ACCOUNT="rrg-bengioy-ad"}
+[tool.cluv.clusters.rorqual]
+env = {SBATCH_ACCOUNT="rrg-bengioy-ad"}
 
 [tool.cluv.clusters.fir]
-env = {UV_OFFLINE="0", WANDB_MODE="online", SBATCH_ACCOUNT="rrg-bengioy-ad"}
+env = {UV_OFFLINE="0", WANDB_MODE="online", SBATCH_ACCOUNT="def-bengioy"}
 
 [tool.cluv.clusters.nibi]
-env = {UV_OFFLINE="0", WANDB_MODE="online", SBATCH_ACCOUNT="rrg-bengioy-ad"}
+env = {UV_OFFLINE="0", WANDB_MODE="online", SBATCH_ACCOUNT="def-bengioy"}
 
 [tool.cluv.clusters.trillium]
-env = {SBATCH_ACCOUNT="rrg-bengioy-ad"}
+env = {SBATCH_TIMELIMIT="00:15:00", SBATCH_OUTPUT="/scratch/normandf/logs/pytorch-example/trillium_%j/slurm-%j.out"}
 
 [tool.cluv.clusters.trillium-gpu]
-env = {SBATCH_ACCOUNT="rrg-bengioy-ad"}
+env = {SBATCH_MEM_PER_NODE="0", SBATCH_OUTPUT="/scratch/normandf/logs/pytorch-example/trillium_%j/slurm-%j.out"}
 
 [tool.cluv.clusters.narval]
 # Mila doesn't have an allocation on Narval anymore.

--- a/examples/pytorch-example/pyproject.toml
+++ b/examples/pytorch-example/pyproject.toml
@@ -74,10 +74,10 @@ env = {UV_OFFLINE="0", WANDB_MODE="online", SBATCH_ACCOUNT="rrg-bengioy-ad"}
 # uncomment these to also submit on Trillium and Trillium-gpu.
 # See also: #61
 # [tool.cluv.clusters.trillium]
-# env = {SBATCH_TIMELIMIT="00:15:00", SBATCH_OUTPUT="/scratch/normandf/logs/pytorch-example/trillium_%j/slurm-%j.out"}
+# env = {SBATCH_TIMELIMIT="00:15:00"}
 
 # [tool.cluv.clusters.trillium-gpu]
-# env = {SBATCH_GPUS_PER_NODE="1", SBATCH_OUTPUT="/scratch/normandf/logs/pytorch-example/trillium_%j/slurm-%j.out"}
+# env = {SBATCH_GPUS_PER_NODE="1", SBATCH_ACCOUNT="rrg-bengioy-ad""}
 
 [tool.cluv.clusters.narval]
 # Mila doesn't have an allocation on Narval anymore.

--- a/examples/pytorch-example/pyproject.toml
+++ b/examples/pytorch-example/pyproject.toml
@@ -39,10 +39,10 @@ datasets_path = "$SCRATCH/datasets/cifar10"
 # Environment variables applied when using Slurm commands on all clusters.
 SBATCH_TIME = "3:00:00"
 SBATCH_REQUEUE = "1"
+SBATCH_MEM_PER_NODE="16G"
 # Assume that compute nodes don't have internet access by default. Override below when they do.
 UV_OFFLINE="1"
 WANDB_MODE="offline"
-SBATCH_MEM_PER_NODE="16G"
 
 ###  --------------   Clusters Config   --------------  ###
 
@@ -65,10 +65,10 @@ results_path = "$HOME/logs/pytorch_example"
 env = {SBATCH_ACCOUNT="rrg-bengioy-ad"}
 
 [tool.cluv.clusters.fir]
-env = {UV_OFFLINE="0", WANDB_MODE="online", SBATCH_ACCOUNT="def-bengioy"}
+env = {UV_OFFLINE="0", WANDB_MODE="online", SBATCH_ACCOUNT="rrg-bengioy-ad"}
 
 [tool.cluv.clusters.nibi]
-env = {UV_OFFLINE="0", WANDB_MODE="online", SBATCH_ACCOUNT="def-bengioy"}
+env = {UV_OFFLINE="0", WANDB_MODE="online", SBATCH_ACCOUNT="rrg-bengioy-ad"}
 
 # TODO: There are issues with the job output script being created in $HOME. Once #87 is implemented,
 # uncomment these to also submit on Trillium and Trillium-gpu.

--- a/examples/pytorch-example/pyproject.toml
+++ b/examples/pytorch-example/pyproject.toml
@@ -42,7 +42,7 @@ SBATCH_REQUEUE = "1"
 # Assume that compute nodes don't have internet access by default. Override below when they do.
 UV_OFFLINE="1"
 WANDB_MODE="offline"
-
+SBATCH_MEM_PER_NODE="16G"
 
 ###  --------------   Clusters Config   --------------  ###
 

--- a/examples/pytorch-example/pyproject.toml
+++ b/examples/pytorch-example/pyproject.toml
@@ -69,11 +69,14 @@ env = {UV_OFFLINE="0", WANDB_MODE="online", SBATCH_ACCOUNT="def-bengioy"}
 [tool.cluv.clusters.nibi]
 env = {UV_OFFLINE="0", WANDB_MODE="online", SBATCH_ACCOUNT="def-bengioy"}
 
-[tool.cluv.clusters.trillium]
-env = {SBATCH_TIMELIMIT="00:15:00", SBATCH_OUTPUT="/scratch/normandf/logs/pytorch-example/trillium_%j/slurm-%j.out"}
+# TODO: There are issues with the job output script being created in $HOME. Once #87 is implemented,
+# uncomment these to also submit on Trillium and Trillium-gpu.
+# See also: #61
+# [tool.cluv.clusters.trillium]
+# env = {SBATCH_TIMELIMIT="00:15:00", SBATCH_OUTPUT="/scratch/normandf/logs/pytorch-example/trillium_%j/slurm-%j.out"}
 
-[tool.cluv.clusters.trillium-gpu]
-env = {SBATCH_MEM_PER_NODE="0", SBATCH_OUTPUT="/scratch/normandf/logs/pytorch-example/trillium_%j/slurm-%j.out"}
+# [tool.cluv.clusters.trillium-gpu]
+# env = {SBATCH_GPUS_PER_NODE="1", SBATCH_OUTPUT="/scratch/normandf/logs/pytorch-example/trillium_%j/slurm-%j.out"}
 
 [tool.cluv.clusters.narval]
 # Mila doesn't have an allocation on Narval anymore.

--- a/examples/pytorch-example/pyproject.toml
+++ b/examples/pytorch-example/pyproject.toml
@@ -49,16 +49,17 @@ SBATCH_MEM_PER_NODE="16G"
 [tool.cluv.clusters.mila]
 # Overrides specific to the Mila cluster.
 env = {UV_OFFLINE="0", WANDB_MODE="online"}
-results_path = "$SCRATCH/logs/cluv"
 
 [tool.cluv.clusters.tamia]
 
 [tool.cluv.clusters.killarney]
 # For example, you might not have a $SCRATCH on Killarney. This can be overwritten here.
 datasets_path = "$HOME/datasets/cifar10"
-results_path = "$HOME/logs/cluv"
+results_path = "$HOME/logs/pytorch_example"
 
 [tool.cluv.clusters.vulcan]
+datasets_path = "$HOME/datasets/cifar10"
+results_path = "$HOME/logs/pytorch_example"
 
 [tool.cluv.clusters.rorqual]
 env = {SBATCH_ACCOUNT="rrg-bengioy-ad"}

--- a/examples/pytorch-example/scripts/job.sh
+++ b/examples/pytorch-example/scripts/job.sh
@@ -3,10 +3,6 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=2
 #SBATCH --time=0:15:00
-# NOTE: This will be overwritten by Cluv anyway. Can't be left empty, else the job submission will
-# fail on Trillium and Trillium-gpu, since it would be in $HOME which is apparently read-only from
-# compute nodes.
-#SBATCH --output=/scratch/your_username/slurm-%j.out
 
 # Minimal job script to validate the PyTorch setup.
 echo "hostname: $(hostname)"

--- a/examples/pytorch-example/scripts/job.sh
+++ b/examples/pytorch-example/scripts/job.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+#SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=2
 #SBATCH --mem=16G
-#SBATCH --time=0:05:00
+#SBATCH --time=0:15:00
 
 # Minimal job script to validate the PyTorch setup.
 echo "hostname: $(hostname)"

--- a/examples/pytorch-example/scripts/job.sh
+++ b/examples/pytorch-example/scripts/job.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#SBATCH --gres=gpu:1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=2
 #SBATCH --mem=16G

--- a/examples/pytorch-example/scripts/job.sh
+++ b/examples/pytorch-example/scripts/job.sh
@@ -2,8 +2,11 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=2
-#SBATCH --mem=16G
 #SBATCH --time=0:15:00
+# NOTE: This will be overwritten by Cluv anyway. Can't be left empty, else the job submission will
+# fail on Trillium and Trillium-gpu, since it would be in $HOME which is apparently read-only from
+# compute nodes.
+#SBATCH --output=/scratch/your_username/slurm-%j.out
 
 # Minimal job script to validate the PyTorch setup.
 echo "hostname: $(hostname)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,11 @@ def fake_scratch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     fake_scratch.mkdir()
     monkeypatch.setenv("SCRATCH", str(fake_scratch))
     return fake_scratch
+
+
+@pytest.fixture(autouse=True)
+def reset_cluv_config():
+    """Reset the cluv config before each test to avoid state leakage."""
+    from cluv.config import get_cluv_config
+
+    get_cluv_config.cache_clear()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,6 +17,7 @@ import milatools.cli.init_command
 import pytest
 import pytest_asyncio
 
+from cluv.cache import Job
 from cluv.cli.init import DEFAULT_RESULTS_PATH, init
 from cluv.cli.login import get_remote_without_2fa_prompt, login
 from cluv.cli.status import ClusterStatus, get_cluster_status
@@ -201,14 +202,15 @@ async def test_submit(remote: Remote, fake_scratch: Path):
         pytest.xfail(f"Submit integration test not supported on cluster {remote.hostname}.")
 
     should_cancel_job = True
-    job_id = await submit(
+    job = await submit(
         cluster=remote.hostname,
         job_script=Path("scripts/job.sh"),
         sbatch_args=["--time=00:00:30"],
         program_args=["python", "--version"],
     )
     cluster = remote.hostname
-    assert isinstance(job_id, int)
+    assert isinstance(job, Job)
+    job_id = job.job_id
     try:
         job_name = await remote.get_output(
             f"sacct -j {job_id} --format=JobName --noheader --parsable2 | head -1"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,7 @@ from cluv.cache import Job
 from cluv.cli.init import DEFAULT_RESULTS_PATH, init
 from cluv.cli.login import get_remote_without_2fa_prompt, login
 from cluv.cli.status import ClusterStatus, get_cluster_status
-from cluv.cli.submit import submit
+from cluv.cli.submit import get_job_state, submit
 from cluv.cli.sync import sync
 from cluv.config import get_cluv_config, load_cluv_config
 from cluv.remote import Remote, control_socket_is_running
@@ -187,8 +187,24 @@ async def test_status_storage(cluster_status: ClusterStatus):
     assert cluster_status.storage.scratch_used >= 0
 
 
+TEST_SUBMIT_TIMEOUT_SECONDS = 180
+
+
+@pytest.mark.parametrize(
+    cluster.__name__,
+    [
+        "mila",
+        pytest.param(
+            "rorqual",
+            marks=pytest.mark.xfail(
+                reason="Rorqual might take a long time for the job to actually run."
+            ),
+        ),
+    ],
+    indirect=True,
+)
 @pytest.mark.slow
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(TEST_SUBMIT_TIMEOUT_SECONDS)
 async def test_submit(remote: Remote, fake_scratch: Path):
     """End-to-end: actually submit scripts/job.sh to a slurm cluster via sbatch.
 
@@ -211,13 +227,14 @@ async def test_submit(remote: Remote, fake_scratch: Path):
     cluster = remote.hostname
     assert isinstance(job, Job)
     job_id = job.job_id
+
     try:
         job_name = await remote.get_output(
             f"sacct -j {job_id} --format=JobName --noheader --parsable2 | head -1"
         )
         assert job_name.strip().startswith("cluv-")
-        # Wait until the job exits, then verify output content after syncing logs back locally.
-        TERMINAL_STATUSES = {
+        wait_time = 5
+        TERMINAL_STATES = {
             "COMPLETED",
             "FAILED",
             "CANCELLED",
@@ -228,36 +245,24 @@ async def test_submit(remote: Remote, fake_scratch: Path):
             "BOOT_FAIL",
             "DEADLINE",
         }
-        final_status = "UNKNOWN"
-        max_poll_attempts = 5
-        poll_interval_seconds = 5
-        # Poll for terminal state, leaving a bit of room in the
-        # 180s test timeout for sync + output validation.
-        for _ in range(max_poll_attempts):
-            status_output = await remote.get_output(
-                f"sacct -j {job_id} --format=State --noheader --parsable2 --allocations | head -1",
-                warn=True,
-                hide=True,
-                display=False,
-            )
-            # --parsable2 uses pipe-delimited output (`STATE|...`), so keep only the state field.
-            final_status = status_output.strip().partition("|")[0].strip()
-            if final_status in TERMINAL_STATUSES:
-                break
-            await asyncio.sleep(poll_interval_seconds)
-            poll_interval_seconds *= 2
-        if final_status not in TERMINAL_STATUSES:
-            pytest.fail(
-                f"Job {job_id} did not reach terminal status within "
-                f"{max_poll_attempts * poll_interval_seconds}s "
-                f"(last status: {final_status!r})"
-            )
-        if final_status != "COMPLETED":
-            pytest.fail(f"Submitted job {job_id} ended with unexpected status: {final_status!r}")
-        should_cancel_job = False
+        async with asyncio.timeout(TEST_SUBMIT_TIMEOUT_SECONDS):
+            while (job_state := await get_job_state(remote, job_id)) not in TERMINAL_STATES:
+                print(
+                    f"Job {job_id} is in state {job_state}, waiting for it to reach a terminal state..."
+                )
+                await asyncio.sleep(wait_time)
+                wait_time = min(wait_time * 2, 60)  # Don't wait more than 30s between polls
+
+        # Wait until the job exits, then verify output content after syncing logs back locally.
+        if job_state == "COMPLETED":
+            should_cancel_job = False  # No need to cancel a completed job
+        else:
+            pytest.fail(f"Submitted job {job_id} ended with unexpected status: {job_state!r}")
 
         await sync(clusters=[remote.hostname])
 
+        # TODO: get the results dir based on the `job` object somehow, instead of assuming
+        # {cluster}_{job_id} which is just the default for a 'regular' job (no chunking or packing).
         output_file = (
             Path(os.path.expandvars(get_cluv_config().results_path))
             / f"{cluster}_{job_id}"
@@ -267,9 +272,13 @@ async def test_submit(remote: Remote, fake_scratch: Path):
             f"Expected job output file to be synced locally: {output_file}"
         )
         output_text = output_file.read_text(errors="replace")
+
+        # TODO: Reuse this test for the pytorch example by checking for a different output.
         assert re.search(r"Python \d+\.\d+(\.\d+)?", output_text), (
             f"Expected python version output in {output_file}, got:\n{output_text}"
         )
+    except asyncio.TimeoutError:
+        pytest.fail(f"Job {job_id} did not reach a terminal state within the timeout period.")
     finally:
         if should_cancel_job:
             await remote.run(f"scancel {job_id}", warn=True, hide=True, display=True)
@@ -321,6 +330,7 @@ def project_dir(fake_home: Path, project_name: str, is_existing_project: bool) -
         job_script.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
     return project_dir
 
+
 @pytest.fixture(autouse=True)
 def return_to_start_dir():
     start_dir = Path.cwd()
@@ -328,6 +338,7 @@ def return_to_start_dir():
         yield
     finally:
         os.chdir(start_dir)
+
 
 @pytest.mark.timeout(5)
 def test_init(

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -11,7 +11,13 @@ import cluv.cli.init
 import cluv.cli.submit
 import cluv.remote
 import cluv.utils
-from cluv.cli.submit import ensure_clean_git_state, get_sbatch_command, submit
+from cluv.cli.submit import (
+    ensure_clean_git_state,
+    get_sbatch_command,
+    submit,
+    submit_first,
+)
+from cluv.cli.sync import sync
 from cluv.config import get_cluv_config
 from cluv.utils import current_cluster
 
@@ -209,8 +215,6 @@ def mock_current_cluster(request: pytest.FixtureRequest, monkeypatch: pytest.Mon
 async def test_can_submit_on_current_cluster(
     monkeypatch: pytest.MonkeyPatch, mock_current_cluster: str, cluv_project_dir: Path
 ) -> None:
-    # This is a very basic test, just to check that we can call the function without error.
-    # A more thorough test would require mocking the sync and sbatch functions, which is a bit more work.
     dummy_commit = "dummy_git_commit"
     monkeypatch.setattr(
         cluv.cli.submit,
@@ -267,3 +271,144 @@ async def test_can_submit_on_current_cluster(
     assert returned_jobid == jobid
     mock_ensure_clean_git_state.assert_called_once()
     mock.assert_called_once()
+
+
+@pytest.mark.parametrize("runs_first_on_current_cluster", [True, False])
+async def test_submit_first_considers_current_cluster(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_current_cluster: str,
+    cluv_project_dir: Path,
+    runs_first_on_current_cluster: bool,
+) -> None:
+    """Test that `submit first` also considers the current cluster as an option.
+
+    Test that it submits a job locally, and also cancels the local job.
+    """
+    run_commands: list[tuple[str, ...]] = []
+    this_cluster_jobid = 123
+    other_cluster_jobid = 456
+    this_cluster_wait_time = 1 if runs_first_on_current_cluster else 3
+    other_cluster_wait_time = 3 if runs_first_on_current_cluster else 1
+
+    async def fake_run(
+        program_and_args: tuple[str, ...],
+        input: str | None = None,
+        warn: bool = False,
+        hide: cluv.remote.Hide = False,
+        **other_kwargs,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal this_cluster_wait_time, other_cluster_wait_time
+        full_command = shlex.join(program_and_args)
+        run_commands.append(program_and_args)
+
+        def _result(stdout: str):
+            return subprocess.CompletedProcess(
+                program_and_args, returncode=0, stdout=stdout, stderr=""
+            )
+
+        print(f"Running command: {full_command}")
+        if full_command.startswith("bash --login -c '") and "sbatch --parsable" in full_command:
+            return _result(str(this_cluster_jobid))
+        if full_command.startswith(f"ssh {other_cluster}") and "sbatch --parsable" in full_command:
+            return _result(str(other_cluster_jobid))
+
+        # Querying for the job's state:
+        if full_command.startswith(f"sacct -j {this_cluster_jobid} --format=State"):
+            this_cluster_wait_time -= 1
+            if this_cluster_wait_time > 0:
+                return _result("PENDING")
+            return _result("RUNNING")
+        if full_command.startswith(
+            f"ssh {other_cluster} 'sacct -j {other_cluster_jobid} --format=State"
+        ):
+            other_cluster_wait_time -= 1
+            if other_cluster_wait_time > 0:
+                return _result("PENDING")
+            return _result("RUNNING")
+
+        # Cancelling once the jobs are running.
+        if (
+            runs_first_on_current_cluster
+            and full_command == f"ssh {other_cluster} 'scancel {other_cluster_jobid}'"
+        ):
+            return _result("")
+        if not runs_first_on_current_cluster and full_command == f"scancel {this_cluster_jobid}":
+            return _result("")
+        print(*run_commands, sep="\n")
+        pytest.fail(f"Unexpected command: {full_command}, {runs_first_on_current_cluster=}")
+        # assert not ("ssh" in full_command and mock_current_cluster in full_command), (
+        #     "Should never try to ssh to the current cluster."
+        # )
+        # # assert " ".join(program_args) in full_command
+        # # assert " ".join(sbatch_args) in full_command
+        # # assert "sbatch --parsable" in full_command
+
+    monkeypatch.setattr(
+        cluv.remote, cluv.remote.run.__name__, _mock := unittest.mock.AsyncMock(wraps=fake_run)
+    )
+    monkeypatch.setattr(
+        cluv.cli.submit,
+        cluv.cli.submit.run.__name__,
+        _mock := unittest.mock.AsyncMock(wraps=fake_run),
+    )
+
+    # async def mock_sbatch(
+    #     remote: cluv.remote.Remote | None,
+    #     job_script: Path,
+    #     sbatch_args: list[str],
+    #     program_args: list[str],
+    #     git_commit: str,
+    # ):
+    #     sbatch_command = get_sbatch_command(
+    #         cluster=remote.hostname if remote else mock_current_cluster,
+    #         job_script=job_script,
+    #         sbatch_args=sbatch_args,
+    #         program_args=program_args,
+    #         git_commit=git_commit,
+    #     )
+    #     return subprocess.CompletedProcess(
+    #         sbatch_command if remote is None else ("ssh", remote.hostname, sbatch_command),
+    #         0,
+    #         str(this_cluster_jobid if remote is None else other_cluster_jobid),
+    #         "",
+    #     )
+
+    # monkeypatch.setattr(cluv.cli.submit, sbatch.__name__, mock_sbatch)
+
+    # Pack `cluv sync` so it returns a Remote that is not for the current cluster.
+    other_cluster = "mila" if mock_current_cluster != "mila" else "tamia"
+    # Should be fine to use a 'real' remote here, since we patch the `run` function that is used
+    # everywhere. There shouldn't be an actual call to `ssh other_cluster` that goes though.
+    other_cluster_remote = cluv.remote.Remote(hostname=other_cluster)
+    # mock_remote = unittest.mock.Mock(
+    #     spec=cluv.remote.Remote,
+    #     hostname=other_cluster,
+    #     wraps=,
+    #     spec_set=True,
+    # )
+
+    monkeypatch.setattr(
+        cluv.cli.submit,
+        sync.__name__,
+        mock_sync := unittest.mock.AsyncMock(return_value=[other_cluster_remote]),
+    )
+
+    job_script = cluv_project_dir / "my_script.sh"
+    job_script.parent.mkdir(exist_ok=True)
+    job_script.write_text("#!/bin/bash\necho Hello World\n")
+    job_script.touch(0o755)
+
+    sbatch_args = ["--account=my_account", "--mem=8G"]
+    program_args = ["program_arg_1", "program_arg_2"]
+    dummy_commit = "dummy_git_commit"
+    returned_jobid = await submit_first(
+        job_script=job_script,
+        sbatch_args=sbatch_args,
+        program_args=program_args,
+        git_commit=dummy_commit,
+    )
+    mock_sync.assert_awaited_once()
+    if runs_first_on_current_cluster:
+        assert returned_jobid == this_cluster_jobid
+    else:
+        assert returned_jobid == other_cluster_jobid

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -50,18 +50,6 @@ def project_dir(fake_home: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def cluv_project_dir(project_dir: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.chdir(project_dir)  # Set current working dir
 
-    # def uv_init_without_git():
-    #     subprocess.check_output(("uv", "init", "--package", "--vcs", "none"), text=True)
-
-    # # from cluv.cli.init import run_uv_init
-
-    # monkeypatch.setattr(
-    #     "cluv.cli.init",
-    #     run_uv_init.__name__,
-    #     mock := unittest.mock.Mock(uv_init_without_git),
-    # )
-    # from cluv.cli import init
-
     cluv.cli.init()
     # mock.assert_called_once()
     return project_dir

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -401,14 +401,15 @@ async def test_submit_first_considers_current_cluster(
     sbatch_args = ["--account=my_account", "--mem=8G"]
     program_args = ["program_arg_1", "program_arg_2"]
     dummy_commit = "dummy_git_commit"
-    returned_jobid = await submit_first(
+    returned_job = await submit_first(
         job_script=job_script,
         sbatch_args=sbatch_args,
         program_args=program_args,
         git_commit=dummy_commit,
     )
+    assert returned_job
     mock_sync.assert_awaited_once()
     if runs_first_on_current_cluster:
-        assert returned_jobid == this_cluster_jobid
+        assert returned_job.job_id == this_cluster_jobid
     else:
-        assert returned_jobid == other_cluster_jobid
+        assert returned_job.job_id == other_cluster_jobid

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -367,12 +367,6 @@ async def test_submit_first_considers_current_cluster(
             return _result("")
         print(*run_commands, sep="\n")
         pytest.fail(f"Unexpected command: {full_command}, {runs_first_on_current_cluster=}")
-        # assert not ("ssh" in full_command and mock_current_cluster in full_command), (
-        #     "Should never try to ssh to the current cluster."
-        # )
-        # # assert " ".join(program_args) in full_command
-        # # assert " ".join(sbatch_args) in full_command
-        # # assert "sbatch --parsable" in full_command
 
     monkeypatch.setattr(
         cluv.remote, cluv.remote.run.__name__, _mock := unittest.mock.AsyncMock(wraps=fake_run)

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -1,7 +1,6 @@
 import asyncio
 import shlex
 import subprocess
-import sys
 import textwrap
 import unittest
 import unittest.mock
@@ -284,8 +283,8 @@ async def test_can_submit_on_current_cluster(
         pytest.param(
             False,
             marks=pytest.mark.xfail(
-                sys.platform == "darwin" and IN_GITHUB_CLOUD_CI,
-                reason="This test doesn't work on MacOS in the GitHub Cloud CI, not sure why.",
+                IN_GITHUB_CLOUD_CI,
+                reason="This test doesn't work in the GitHub Cloud CI, not sure why.",
                 strict=True,
             ),
         ),

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -295,7 +295,7 @@ async def test_submit_first_considers_current_cluster(
     scancel_received_on_other_cluster = False
     real_sleep = asyncio.sleep
     monkeypatch.setattr(
-        asyncio, "sleep", lambda x: real_sleep(0.01 * x)
+        asyncio, "sleep", lambda x: real_sleep(0.1 * x)
     )  # Speed up the test by patching sleep.
 
     async def fake_run(

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -289,8 +289,8 @@ async def test_submit_first_considers_current_cluster(
     run_commands: list[tuple[str, ...]] = []
     this_cluster_jobid = 123
     other_cluster_jobid = 456
-    this_cluster_wait_time = 1 if runs_first_on_current_cluster else 2
-    other_cluster_wait_time = 2 if runs_first_on_current_cluster else 1
+    this_cluster_wait_time = 1 if runs_first_on_current_cluster else 3
+    other_cluster_wait_time = 3 if runs_first_on_current_cluster else 1
     scancel_received_on_this_cluster = False
     scancel_received_on_other_cluster = False
     real_sleep = asyncio.sleep

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -1,11 +1,19 @@
+import shlex
 import subprocess
 import textwrap
+import unittest
+import unittest.mock
 from pathlib import Path
 
 import pytest
 
-from cluv.cli.submit import ensure_clean_git_state, get_sbatch_command
+import cluv.cli.init
+import cluv.cli.submit
+import cluv.remote
+import cluv.utils
+from cluv.cli.submit import ensure_clean_git_state, get_sbatch_command, submit
 from cluv.config import get_cluv_config
+from cluv.utils import current_cluster
 
 
 @pytest.fixture(autouse=True)
@@ -27,6 +35,27 @@ def project_dir(fake_home: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     project_dir = fake_home / "my_project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)  # Set current working dir
+    return project_dir
+
+
+@pytest.fixture
+def cluv_project_dir(project_dir: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.chdir(project_dir)  # Set current working dir
+
+    # def uv_init_without_git():
+    #     subprocess.check_output(("uv", "init", "--package", "--vcs", "none"), text=True)
+
+    # # from cluv.cli.init import run_uv_init
+
+    # monkeypatch.setattr(
+    #     "cluv.cli.init",
+    #     run_uv_init.__name__,
+    #     mock := unittest.mock.Mock(uv_init_without_git),
+    # )
+    # from cluv.cli import init
+
+    cluv.cli.init()
+    # mock.assert_called_once()
     return project_dir
 
 
@@ -165,3 +194,76 @@ class TestEnsureCleanGitState:
         monkeypatch.setattr(subprocess, "check_output", mock_subprocess_check_output)
 
         assert ensure_clean_git_state() == "cccccccccccccccccccccccccccccccccccccccc"
+
+
+@pytest.fixture(params=["mila", "tamia", "rorqual"])
+def mock_current_cluster(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
+    cluster = getattr(request, "param", "mila")
+    mock = unittest.mock.Mock(spec=current_cluster, return_value=cluster)
+    monkeypatch.setattr(cluv.utils, current_cluster.__name__, mock)
+    monkeypatch.setattr(cluv.cli.submit, current_cluster.__name__, mock)
+    yield cluster
+    mock.assert_called()
+
+
+async def test_can_submit_on_current_cluster(
+    monkeypatch: pytest.MonkeyPatch, mock_current_cluster: str, cluv_project_dir: Path
+) -> None:
+    # This is a very basic test, just to check that we can call the function without error.
+    # A more thorough test would require mocking the sync and sbatch functions, which is a bit more work.
+    dummy_commit = "dummy_git_commit"
+    monkeypatch.setattr(
+        cluv.cli.submit,
+        ensure_clean_git_state.__name__,
+        mock_ensure_clean_git_state := unittest.mock.Mock(
+            wraps=ensure_clean_git_state, side_effect=lambda: dummy_commit
+        ),
+    )
+    here = mock_current_cluster
+    monkeypatch.setenv("CC_CLUSTER", here)
+
+    jobid = 123
+
+    sbatch_args = ["--account=my_account", "--mem=8G"]
+    program_args = ["program_arg_1", "program_arg_2"]
+
+    async def fake_run(
+        program_and_args: tuple[str, ...],
+        input: str | None = None,
+        warn: bool = False,
+        hide: cluv.remote.Hide = False,
+        **other_kwargs,
+    ) -> subprocess.CompletedProcess[str]:
+        full_command = shlex.join(program_and_args)
+        assert (
+            "ssh" not in full_command
+        )  # Should not SSH since we're submitting to the current cluster.
+        assert " ".join(program_args) in full_command
+        assert " ".join(sbatch_args) in full_command
+        assert "sbatch --parsable" in full_command
+        return subprocess.CompletedProcess(
+            program_and_args, returncode=0, stdout=f"{jobid}", stderr=""
+        )
+
+    monkeypatch.setattr(
+        cluv.remote, cluv.remote.run.__name__, mock := unittest.mock.Mock(wraps=fake_run)
+    )
+    monkeypatch.setattr(
+        cluv.cli.submit, cluv.cli.submit.run.__name__, mock := unittest.mock.Mock(wraps=fake_run)
+    )
+
+    job_script = cluv_project_dir / "my_script.sh"
+    job_script.parent.mkdir(exist_ok=True)
+    job_script.write_text("#!/bin/bash\necho Hello World\n")
+    job_script.touch(0o755)
+
+    returned_jobid = await submit(
+        cluster=here,
+        job_script=job_script,
+        sbatch_args=sbatch_args,
+        program_args=program_args,
+    )
+
+    assert returned_jobid == jobid
+    mock_ensure_clean_git_state.assert_called_once()
+    mock.assert_called_once()

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -277,12 +277,21 @@ async def test_can_submit_on_current_cluster(
     mock.assert_called_once()
 
 
-@pytest.mark.xfail(
-    sys.platform == "darwin" and IN_GITHUB_CLOUD_CI,
-    reason="This test doesn't work on MacOS in the GitHub Cloud CI, not sure why.",
-    strict=True,
+@pytest.mark.parametrize(
+    "runs_first_on_current_cluster",
+    [
+        True,
+        pytest.param(
+            False,
+            marks=pytest.mark.xfail(
+                sys.platform == "darwin" and IN_GITHUB_CLOUD_CI,
+                reason="This test doesn't work on MacOS in the GitHub Cloud CI, not sure why.",
+                strict=True,
+            ),
+        ),
+    ],
+    ids=["current_cluster_runs_first", "other_cluster_runs_first"],
 )
-@pytest.mark.parametrize("runs_first_on_current_cluster", [True, False])
 async def test_submit_first_considers_current_cluster(
     monkeypatch: pytest.MonkeyPatch,
     mock_current_cluster: str,

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -1,3 +1,4 @@
+import asyncio
 import shlex
 import subprocess
 import textwrap
@@ -261,14 +262,15 @@ async def test_can_submit_on_current_cluster(
     job_script.write_text("#!/bin/bash\necho Hello World\n")
     job_script.touch(0o755)
 
-    returned_jobid = await submit(
+    returned_job = await submit(
         cluster=here,
         job_script=job_script,
         sbatch_args=sbatch_args,
         program_args=program_args,
     )
 
-    assert returned_jobid == jobid
+    assert returned_job
+    assert returned_job.job_id == jobid
     mock_ensure_clean_git_state.assert_called_once()
     mock.assert_called_once()
 
@@ -287,8 +289,14 @@ async def test_submit_first_considers_current_cluster(
     run_commands: list[tuple[str, ...]] = []
     this_cluster_jobid = 123
     other_cluster_jobid = 456
-    this_cluster_wait_time = 1 if runs_first_on_current_cluster else 3
-    other_cluster_wait_time = 3 if runs_first_on_current_cluster else 1
+    this_cluster_wait_time = 1 if runs_first_on_current_cluster else 2
+    other_cluster_wait_time = 2 if runs_first_on_current_cluster else 1
+    scancel_received_on_this_cluster = False
+    scancel_received_on_other_cluster = False
+    real_sleep = asyncio.sleep
+    monkeypatch.setattr(
+        asyncio, "sleep", lambda x: real_sleep(0.01 * x)
+    )  # Speed up the test by patching sleep.
 
     async def fake_run(
         program_and_args: tuple[str, ...],
@@ -298,6 +306,7 @@ async def test_submit_first_considers_current_cluster(
         **other_kwargs,
     ) -> subprocess.CompletedProcess[str]:
         nonlocal this_cluster_wait_time, other_cluster_wait_time
+        nonlocal scancel_received_on_this_cluster, scancel_received_on_other_cluster
         full_command = shlex.join(program_and_args)
         run_commands.append(program_and_args)
 
@@ -315,6 +324,8 @@ async def test_submit_first_considers_current_cluster(
         # Querying for the job's state:
         if full_command.startswith(f"sacct -j {this_cluster_jobid} --format=State"):
             this_cluster_wait_time -= 1
+            if scancel_received_on_this_cluster:
+                return _result("CANCELLED")
             if this_cluster_wait_time > 0:
                 return _result("PENDING")
             return _result("RUNNING")
@@ -322,6 +333,8 @@ async def test_submit_first_considers_current_cluster(
             f"ssh {other_cluster} 'sacct -j {other_cluster_jobid} --format=State"
         ):
             other_cluster_wait_time -= 1
+            if scancel_received_on_other_cluster:
+                return _result("CANCELLED")
             if other_cluster_wait_time > 0:
                 return _result("PENDING")
             return _result("RUNNING")
@@ -331,8 +344,10 @@ async def test_submit_first_considers_current_cluster(
             runs_first_on_current_cluster
             and full_command == f"ssh {other_cluster} 'scancel {other_cluster_jobid}'"
         ):
+            scancel_received_on_other_cluster = True
             return _result("")
         if not runs_first_on_current_cluster and full_command == f"scancel {this_cluster_jobid}":
+            scancel_received_on_this_cluster = True
             return _result("")
         print(*run_commands, sep="\n")
         pytest.fail(f"Unexpected command: {full_command}, {runs_first_on_current_cluster=}")

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -1,6 +1,7 @@
 import asyncio
 import shlex
 import subprocess
+import sys
 import textwrap
 import unittest
 import unittest.mock
@@ -21,6 +22,7 @@ from cluv.cli.submit import (
 from cluv.cli.sync import sync
 from cluv.config import get_cluv_config
 from cluv.utils import current_cluster
+from tests.test_integration import IN_GITHUB_CLOUD_CI
 
 
 @pytest.fixture(autouse=True)
@@ -275,6 +277,11 @@ async def test_can_submit_on_current_cluster(
     mock.assert_called_once()
 
 
+@pytest.mark.xfail(
+    sys.platform == "darwin" and IN_GITHUB_CLOUD_CI,
+    reason="This test doesn't work on MacOS in the GitHub Cloud CI, not sure why.",
+    strict=True,
+)
 @pytest.mark.parametrize("runs_first_on_current_cluster", [True, False])
 async def test_submit_first_considers_current_cluster(
     monkeypatch: pytest.MonkeyPatch,
@@ -294,9 +301,9 @@ async def test_submit_first_considers_current_cluster(
     scancel_received_on_this_cluster = False
     scancel_received_on_other_cluster = False
     real_sleep = asyncio.sleep
-    monkeypatch.setattr(
-        asyncio, "sleep", lambda x: real_sleep(0.1 * x)
-    )  # Speed up the test by patching sleep.
+    # Speed up the test by patching sleep
+    # (we're not doing real sacct / scancel / sbatch.)
+    monkeypatch.setattr(asyncio, "sleep", lambda x: real_sleep(0.1 * x))
 
     async def fake_run(
         program_and_args: tuple[str, ...],
@@ -367,41 +374,11 @@ async def test_submit_first_considers_current_cluster(
         _mock := unittest.mock.AsyncMock(wraps=fake_run),
     )
 
-    # async def mock_sbatch(
-    #     remote: cluv.remote.Remote | None,
-    #     job_script: Path,
-    #     sbatch_args: list[str],
-    #     program_args: list[str],
-    #     git_commit: str,
-    # ):
-    #     sbatch_command = get_sbatch_command(
-    #         cluster=remote.hostname if remote else mock_current_cluster,
-    #         job_script=job_script,
-    #         sbatch_args=sbatch_args,
-    #         program_args=program_args,
-    #         git_commit=git_commit,
-    #     )
-    #     return subprocess.CompletedProcess(
-    #         sbatch_command if remote is None else ("ssh", remote.hostname, sbatch_command),
-    #         0,
-    #         str(this_cluster_jobid if remote is None else other_cluster_jobid),
-    #         "",
-    #     )
-
-    # monkeypatch.setattr(cluv.cli.submit, sbatch.__name__, mock_sbatch)
-
     # Pack `cluv sync` so it returns a Remote that is not for the current cluster.
     other_cluster = "mila" if mock_current_cluster != "mila" else "tamia"
     # Should be fine to use a 'real' remote here, since we patch the `run` function that is used
     # everywhere. There shouldn't be an actual call to `ssh other_cluster` that goes though.
     other_cluster_remote = cluv.remote.Remote(hostname=other_cluster)
-    # mock_remote = unittest.mock.Mock(
-    #     spec=cluv.remote.Remote,
-    #     hostname=other_cluster,
-    #     wraps=,
-    #     spec_set=True,
-    # )
-
     monkeypatch.setattr(
         cluv.cli.submit,
         sync.__name__,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -22,6 +22,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_cluv_sync_with_data_path(monkeypatch: pytest.MonkeyPatch, fake_scratch: Path):
     """Test for `cluv sync` with a project that has a 'datasets_path'.


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
- Fixes #82 
- Fixes a bug in the config, it was silently ignoring per-cluster results_path
- Fixes misconfigured values in the Pytorch example's pyproject.toml

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
