### PR TITLE
Fix integration tests for PRs from forks

### DIFF
--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -233,6 +233,18 @@ async def install_uv(remote: Remote):
         await remote.run(f"bash -l -c 'uv self update {uv_version_here}'", hide=True)
 
 
+def _github_pr_ref() -> str | None:
+    """The PR ref on the base repo (e.g. 'refs/pull/72/merge') when run by GitHub Actions for a PR.
+
+    Unlike the PR head branch, this ref exists on the base repo even when the PR comes
+    from a fork, so the project clones on the clusters can fetch it from their remote.
+    """
+    github_ref = os.environ.get("GITHUB_REF", "").strip()
+    if re.fullmatch(r"refs/pull/[0-9]+/(merge|head)", github_ref):
+        return github_ref
+    return None
+
+
 async def clone_project(remote: Remote):
     """Setup the project repo on all the remote clusters.
 
@@ -296,8 +308,22 @@ async def clone_project(remote: Remote):
             ):
                 raise RuntimeError(f"Invalid GITHUB_HEAD_REF value: {github_head_ref!r}")
             safe_head_ref = shlex.quote(github_head_ref)
-            safe_tracking_ref = shlex.quote(f"{git_remote_name}/{github_head_ref}")
             safe_remote_name = shlex.quote(git_remote_name)
+            github_pr_ref = _github_pr_ref()
+            if github_pr_ref:
+                # The head branch of a PR from a fork doesn't exist on the base repo, so
+                # fetch the PR ref instead and create the branch from FETCH_HEAD.
+                safe_pr_ref = shlex.quote(github_pr_ref)
+                await remote.run(
+                    f"git -C {git_root_path} fetch {safe_remote_name} {safe_pr_ref}",
+                    hide=False,
+                )
+                await remote.run(
+                    f"git -C {git_root_path} checkout -B {safe_head_ref} FETCH_HEAD",
+                    hide=False,
+                )
+                return
+            safe_tracking_ref = shlex.quote(f"{git_remote_name}/{github_head_ref}")
             await remote.run(
                 f"git -C {git_root_path} checkout -B {safe_head_ref} {safe_tracking_ref}",
                 hide=False,

--- a/tests/test_sync_refs.py
+++ b/tests/test_sync_refs.py
@@ -1,0 +1,35 @@
+"""Unit tests for the git ref resolution used by `cluv sync` in GitHub Actions."""
+
+import pytest
+
+from cluv.cli.sync import _github_pr_ref
+
+
+@pytest.mark.parametrize(
+    "github_ref",
+    ["refs/pull/72/merge", "refs/pull/123/head"],
+)
+def test_pr_ref_is_returned(monkeypatch: pytest.MonkeyPatch, github_ref: str):
+    monkeypatch.setenv("GITHUB_REF", github_ref)
+    assert _github_pr_ref() == github_ref
+
+
+@pytest.mark.parametrize(
+    "github_ref",
+    [
+        "refs/heads/master",
+        "refs/tags/v0.1.0",
+        "refs/pull//merge",
+        "refs/pull/72/merge; rm -rf /",
+        "",
+        "   ",
+    ],
+)
+def test_non_pr_ref_is_ignored(monkeypatch: pytest.MonkeyPatch, github_ref: str):
+    monkeypatch.setenv("GITHUB_REF", github_ref)
+    assert _github_pr_ref() is None
+
+
+def test_unset_github_ref(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("GITHUB_REF", raising=False)
+    assert _github_pr_ref() is None


### PR DESCRIPTION
Integration tests fail for every cross-repo PR. `clone_project` checks out the PR head branch from the base repo remote on each cluster, and that branch only exists there when the PR comes from the same repo:

```
fatal: 'origin/fix/ssh-config-hermeticity' is not a commit and a branch 'fix/ssh-config-hermeticity' cannot be created from it
```

([example failure](https://github.com/mila-iqia/cluv/actions/runs/27309557413/job/80678572374) on #72: `test_submit[mila]`, `test_submit[rorqual]`, `test_cluv_sync_with_data_path` all fail with exit 128 on that checkout.)

This PR fetches the PR ref (`refs/pull/<n>/merge`, taken from `GITHUB_REF`) instead. That ref lives on the base repo for fork and same-repo PRs alike, and it points at the same merge commit the runner checks out, so the integration tests exercise exactly what the unit tests ran against. The branch on the cluster is still created under the head ref name, so commands that push keep working. Workflows without a PR ref keep the existing branch-tracking behavior.

The ref-parsing helper has unit tests; the real proof is this PR's own `integration_tests` job, which comes from a fork and can only pass with the fix applied.