### PR TITLE
Feat/submit job array

### DIFF
--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -76,7 +76,10 @@ def main(argv: list[str] | None = None) -> None:
     status_parser = add_status_args(subparsers)
     _add_v_arg(status_parser)
 
-    args = parser.parse_args(argv)
+    # args = parser.parse_args(argv)
+    args, unused = parser.parse_known_args(
+        argv
+    )  # parse twice to avoid errors with REMAINDER args in some subcommands.
     args_dict = vars(args)
 
     verbose: int = args_dict.pop("verbose")
@@ -85,7 +88,13 @@ def main(argv: list[str] | None = None) -> None:
     function: Callable = args_dict.pop("func")
 
     if subcommand == "submit":
+        args_dict["sbatch_args"] = (
+            unused  # pass the unparsed args to the submit function, which will handle them as sbatch args.
+        )
         args_dict["program_args"] = submit_program_args
+    else:
+        # parser.parse_args
+        assert not unused, f"Unexpected extra arguments: {unused}"
 
     try:
         if inspect.iscoroutinefunction(function):
@@ -130,11 +139,18 @@ def add_submit_args(
         help="Path to the sbatch job script (relative to project root).",
     )
     submit_parser.add_argument(
-        "sbatch_args",
-        nargs=argparse.REMAINDER,
-        metavar="...",
-        help="sbatch flags (before --) and/or program arguments (after --).",
+        "--chunking",
+        dest="chunking",
+        action="store_true",
+        default=False,
+        help="Convert the job to a job array.",
     )
+    # submit_parser.add_argument(
+    #     "sbatch_args",
+    #     nargs=argparse.REMAINDER,
+    #     metavar="...",
+    #     help="sbatch flags (before --) and/or program arguments (after --).",
+    # )
     submit_parser.set_defaults(func=submit)
     return submit_parser
 

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -42,7 +42,7 @@ async def submit(
     Parameters:
         cluster: SSH hostname of the target cluster. Can be set to "first" to launch the job on all clusters and keep only the first one to starts.
         job_script: Path to the job script to submit, relative to the project root.
-        chunking: TODO
+        chunking: Whether to chunk the job into multiple smaller jobs.
         sbatch_args: List of additional flags to pass to `sbatch`.
         program_args: List of arguments to pass to the job script, for example `["python", "main.py"]`.
 

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path, PurePosixPath
 
 from cluv.cache import save_job
-from cluv.cli.submit_utils.chunking import get_n_chunks
+from cluv.cli.submit_utils.chunking import chunking_update_sbatch_ars
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_cluv_config
 from cluv.remote import Remote
@@ -267,21 +267,7 @@ def get_sbatch_command(
     if job_chunking:
         assert not in_job_packing, "can't do both right now."
         env_vars["SBATCH_OUTPUT"] = f"{cluster_results_path}/{cluster}_%A/slurm-%A_%a.out"
-
-        # Add job array
-        n_chunks = get_n_chunks(sbatch_args, env_vars, job_script)
-        sbatch_args.append(f"--array=0-{n_chunks - 1}%1")
-
-        # Update the time limit (add --time=3:00:00 to sbatch args if not already set,
-        # or update the existing time limit to be at most 3h)
-        if not any(arg.startswith(("--time", "-t")) for arg in sbatch_args):
-            sbatch_args.append("--time=3:00:00")
-        else:
-            for i, arg in enumerate(sbatch_args):
-                if arg.startswith(("--time", "-t")):
-                    sbatch_args[i] = "--time=3:00:00"
-                    break
-
+        sbatch_args = chunking_update_sbatch_ars(sbatch_args, env_vars, job_script)
     elif in_job_packing:
         env_vars["SBATCH_OUTPUT"] = f"{cluster_results_path}/{cluster}_%j_%t/slurm-%j_%t.out"
     else:

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -301,13 +301,13 @@ async def submit_first(
 
 def build_submit_command(
     cluster: str,
-    job_script: Path,
+    job_script: Path | None,
     sbatch_args: list[str],
     program_args: list[str],
 ) -> str:
     """Build the local `cluv submit` command line used to launch the job."""
     command_parts = ["cluv", "submit"]
-    command_parts.extend([cluster, str(job_script), *sbatch_args])
+    command_parts.extend([cluster, str(job_script or ""), *sbatch_args])
     if program_args:
         command_parts.extend(["--", *program_args])
     return shlex.join(command_parts)

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -95,9 +95,8 @@ async def submit(
         console.print(f"[red] Error during sbatch : {result.stderr}[/red]")
         return None
 
-    job_id = int(result.stdout.strip())
     job = Job(
-        job_id=job_id,
+        job_id=int(result.stdout.strip()),
         cluster=cluster,
         job_script=str(job_script),
         git_commit=git_commit,
@@ -108,8 +107,8 @@ async def submit(
     save_job(job)
 
     console.log(
-        f"Successfully submitted job {job_id} on the {cluster} cluster.\n"
-        f"Use `ssh {cluster} sacct -j {job_id}` to view its status, and `cluv sync {cluster}` to "
+        f"Successfully submitted job {job.job_id} on the {cluster} cluster.\n"
+        f"Use `ssh {cluster} sacct -j {job.job_id}` to view its status, and `cluv sync {cluster}` to "
         f"fetch results once it is complete."
     )
 
@@ -328,7 +327,7 @@ def get_sbatch_command(
     sbatch_args: list[str],
     program_args: list[str],
     git_commit: str,
-    job_chunking: bool,
+    chunking: bool,
 ) -> str:
     """
     Generate the command to submit the job via sbatch on the remote cluster, with the appropriate env vars set.
@@ -358,7 +357,7 @@ def get_sbatch_command(
     cluster_results_path = PurePosixPath(cluster_config.results_path)
     # TODO: Use the `get_run_id` function with the placeholder job id %j and task index %t:
 
-    if job_chunking:
+    if chunking:
         assert not in_job_packing, "can't do both right now."
         env_vars["SBATCH_OUTPUT"] = f"{cluster_results_path}/{cluster}_%A/slurm-%A_%a.out"
         sbatch_args = chunking_update_sbatch_ars(sbatch_args, env_vars, job_script)

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -73,7 +73,7 @@ async def submit(
     here = current_cluster()
 
     if cluster == "first":
-        job = await submit_first(job_script, sbatch_args, program_args, git_commit)
+        job = await submit_first(job_script, sbatch_args, program_args, git_commit, chunking)
         if job:
             save_job(job)
         return job
@@ -85,7 +85,7 @@ async def submit(
     else:
         # Submitting to the current cluster.
         remote = None
-    result = await sbatch(remote, job_script, sbatch_args, program_args, git_commit)
+    result = await sbatch(remote, job_script, sbatch_args, program_args, git_commit, chunking)
     submit_time = datetime.datetime.now()
 
     if result.returncode != 0:
@@ -135,7 +135,9 @@ async def submit_first(
 
     # Submit the job on all the clusters (and possibly locally).
     sbatch_commands = {
-        cluster: get_sbatch_command(cluster, job_script, sbatch_args, program_args, git_commit)
+        cluster: get_sbatch_command(
+            cluster, job_script, sbatch_args, program_args, git_commit, chunking
+        )
         for cluster in cluster_to_remote
     }
     sbatch_results = await asyncio.gather(
@@ -146,6 +148,7 @@ async def submit_first(
                 sbatch_args=sbatch_args,
                 program_args=program_args,
                 git_commit=git_commit,
+                chunking=chunking,
             )
             for remote in cluster_to_remote.values()
         ],

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import logging
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -15,6 +17,7 @@ from cluv.remote import Remote
 from cluv.slurm import FAILED_JOB_STATES
 from cluv.utils import console
 
+DEFAULT_CHUNCK_TIME = "3:00:00"
 RUNNING_JOB_STATES = ["PENDING", "RUNNING"]
 logger = logging.getLogger(__name__)
 
@@ -24,6 +27,7 @@ __all__ = ["submit"]
 async def submit(
     cluster: str,
     job_script: Path,
+    chunking: bool,
     sbatch_args: list[str],
     program_args: list[str],
 ) -> int | None:
@@ -40,6 +44,7 @@ async def submit(
     Parameters:
         cluster: SSH hostname of the target cluster. Can be set to "first" to launch the job on all clusters and keep only the first one to starts.
         job_script: Path to the job script to submit, relative to the project root.
+        chunking: TODO
         sbatch_args: List of additional flags to pass to `sbatch`.
         program_args: List of arguments to pass to the job script, for example `["python", "main.py"]`.
 
@@ -61,14 +66,14 @@ async def submit(
     git_commit = ensure_clean_git_state()
 
     if cluster == "first":
-        return await submit_first(job_script, sbatch_args, program_args, git_commit)
+        return await submit_first(job_script, sbatch_args, program_args, git_commit, chunking)
 
     # Sync.
     remotes = await sync(clusters=[cluster])
 
     # Run the sbatch command over SSH.
     remote = remotes[0]
-    result = await sbatch(remote, job_script, sbatch_args, program_args, git_commit)
+    result = await sbatch(remote, job_script, sbatch_args, program_args, git_commit, chunking)
 
     if result.returncode != 0:
         console.print(f"[red] Error during sbatch : {result.stderr}[/red]")
@@ -90,6 +95,7 @@ async def submit_first(
     sbatch_args: list[str],
     program_args: list[str],
     git_commit: str,
+    chunking: bool,
 ) -> int | None:
     """Submit the job on all clusters, and wait until one of them starts.
     Once one starts, cancel the others.
@@ -101,13 +107,7 @@ async def submit_first(
     # Submit the job on all the clusters
     sbatch_results = await asyncio.gather(
         *[
-            sbatch(
-                remote,
-                job_script,
-                sbatch_args,
-                program_args,
-                git_commit,
-            )
+            sbatch(remote, job_script, sbatch_args, program_args, git_commit, chunking)
             for remote in remotes
         ],
         return_exceptions=True,
@@ -186,7 +186,9 @@ async def submit_first(
         await cancel_all_jobs(clusters_to_remote, cluster_to_jobid, start_cluster)
 
     if start_job_id is not None and start_cluster is not None:
-        save_job(start_job_id, start_cluster, str(job_script), git_commit, sbatch_args, program_args)
+        save_job(
+            start_job_id, start_cluster, str(job_script), git_commit, sbatch_args, program_args
+        )
 
     return start_job_id
 
@@ -233,6 +235,7 @@ def get_sbatch_command(
     sbatch_args: list[str],
     program_args: list[str],
     git_commit: str,
+    in_job_chunking: bool,
 ) -> str:
     """
     Generate the command to submit the job via sbatch on the remote cluster, with the appropriate env vars set.
@@ -255,10 +258,10 @@ def get_sbatch_command(
     env_vars["SBATCH_JOB_NAME"] = f"cluv-{base_name}"
     env_vars["GIT_COMMIT"] = git_commit
 
-    in_job_chunking = False
+    # in_job_chunking = False
     in_job_packing = False
-    # SBATCH --output=logs/%j/slurm-%j.out
-    assert not in_job_chunking and not in_job_packing, "todo"
+
+    assert not in_job_packing, "todo"
     # might contain unresolved env vars.
     cluster_results_path = PurePosixPath(cluster_config.results_path)
     # TODO: Use the `get_run_id` function with the placeholder job id %j and task index %t:
@@ -266,6 +269,21 @@ def get_sbatch_command(
     if in_job_chunking:
         assert not in_job_packing, "can't do both right now."
         env_vars["SBATCH_OUTPUT"] = f"{cluster_results_path}/{cluster}_%A/slurm-%A_%a.out"
+
+        # Add job array
+        n_chunks = get_n_chunks(sbatch_args, env_vars, job_script)
+        sbatch_args.append(f"--array=0-{n_chunks - 1}%1")
+
+        # Update the time limit (add --time=3:00:00 to sbatch args if not already set,
+        # or update the existing time limit to be at most 3h)
+        if not any(arg.startswith(("--time", "-t")) for arg in sbatch_args):
+            sbatch_args.append("--time=3:00:00")
+        else:
+            for i, arg in enumerate(sbatch_args):
+                if arg.startswith(("--time", "-t")):
+                    sbatch_args[i] = "--time=3:00:00"
+                    break
+
     elif in_job_packing:
         env_vars["SBATCH_OUTPUT"] = f"{cluster_results_path}/{cluster}_%j_%t/slurm-%j_%t.out"
     else:
@@ -301,17 +319,89 @@ def get_sbatch_command(
     )
 
 
+def get_n_chunks(sbatch_args_str: list[str], env_vars: dict[str, str], job_script: Path) -> int:
+    """TODO"""
+    # The time of a job can be set at different places :
+    #   - As an env variable in the Cluv or the cluster config (with SBATCH_TIMELIMIT)
+    #   - As an arg to sbatch (with --time or -t)
+    #   - As a directive in the job script header (#SBATCH --time)
+    time = (
+        _get_time_from_sbatch_args(sbatch_args_str)
+        or env_vars.get("SBATCH_TIMELIMIT")
+        or _get_time_from_job_script_header(job_script)
+    )
+    console.log(env_vars.get("SBATCH_TIMELIMIT"))
+    console.log(_get_time_from_sbatch_args(sbatch_args_str))
+    console.log(_get_time_from_job_script_header(job_script))
+    console.log(
+        f"Chunking is enabled. Determining the number of chunks based on the job time limit (found {time})."
+    )
+
+    if not time:
+        raise ValueError(
+            "Could not find a time value for the job, which is required for chunking."
+        )
+
+    total_time = parse_time_arg(time)
+    total_hours = total_time.total_seconds() / 3600  # Total hours
+
+    # Split the total time into 3h chunks, and round up.
+    chunk_hours = 3
+    n_chunks = int((total_hours + chunk_hours - 1) // chunk_hours)
+
+    return n_chunks
+
+
+def parse_time_arg(time: str) -> datetime.timedelta:
+    """Parse a time value from the sbatch format to a timedelta object."""
+    # The SLURM time format is days-hours:minutes:seconds, with the days part optionnal.
+    match = re.match(r"(?:(\d+)-)?(\d{1,2}):(\d{2}):(\d{2})", time)
+    if not match:
+        raise ValueError(f"Could not parse time value: {time}")
+
+    return datetime.timedelta(
+        days=int(match.group(1) or 0),
+        hours=int(match.group(2)),
+        minutes=int(match.group(3)),
+        seconds=int(match.group(4)),
+    )
+
+
+def _get_time_from_sbatch_args(sbatch_args_str: list[str]) -> str | None:
+    """TODO"""
+    for arg in sbatch_args_str:
+        if arg.startswith(("--time", "-t")):
+            # Like "--time=00:10:00" or "-t=1-02:00:00"
+            return arg.split("=")[1]
+
+    return None
+
+
+def _get_time_from_job_script_header(job_script: Path) -> str | None:
+    """TODO"""
+    for line in job_script.read_text().splitlines():
+        if line.startswith("#SBATCH") and "--time=" in line:
+            # Like "#SBATCH --time=1:00:00"
+            return line[line.index("--time=") + len("--time=") :].split()[0]
+
+        if not line.strip().startswith("#"):
+            # Stop parsing once we leave the header.
+            return
+
+
 async def sbatch(
     remote: Remote,
     job_script: Path,
     sbatch_args: list[str],
     program_args: list[str],
     git_commit: str,
+    chunking: bool,
 ) -> subprocess.CompletedProcess[str]:
     """Submit the job via sbatch on the remote cluster, and return the job id."""
-    cluster = remote.hostname
+    remote_cmd = get_sbatch_command(
+        remote.hostname, job_script, sbatch_args, program_args, git_commit, chunking
+    )
 
-    remote_cmd = get_sbatch_command(cluster, job_script, sbatch_args, program_args, git_commit)
     return await remote.run(remote_cmd, display=True, warn=True, hide=True)
 
 

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -235,7 +235,7 @@ def get_sbatch_command(
     sbatch_args: list[str],
     program_args: list[str],
     git_commit: str,
-    in_job_chunking: bool,
+    job_chunking: bool,
 ) -> str:
     """
     Generate the command to submit the job via sbatch on the remote cluster, with the appropriate env vars set.
@@ -258,7 +258,6 @@ def get_sbatch_command(
     env_vars["SBATCH_JOB_NAME"] = f"cluv-{base_name}"
     env_vars["GIT_COMMIT"] = git_commit
 
-    # in_job_chunking = False
     in_job_packing = False
 
     assert not in_job_packing, "todo"
@@ -266,7 +265,7 @@ def get_sbatch_command(
     cluster_results_path = PurePosixPath(cluster_config.results_path)
     # TODO: Use the `get_run_id` function with the placeholder job id %j and task index %t:
 
-    if in_job_chunking:
+    if job_chunking:
         assert not in_job_packing, "can't do both right now."
         env_vars["SBATCH_OUTPUT"] = f"{cluster_results_path}/{cluster}_%A/slurm-%A_%a.out"
 

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import dataclasses
 import datetime
 import logging
 import os
@@ -10,7 +9,6 @@ import subprocess
 import sys
 from pathlib import Path, PurePosixPath
 
-import rich.panel
 import rich.syntax
 import rich.table
 import rich.text
@@ -18,10 +16,15 @@ from rich.live import Live
 
 from cluv.cache import Job, save_job
 from cluv.cli.submit_utils.chunking import chunking_update_sbatch_ars
+from cluv.cli.submit_utils.first import (
+    JobHandle,
+    cancel_job,
+    wait_for_jobs_to_cancel,
+    wait_for_running_job,
+)
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_cluv_config
 from cluv.remote import Remote, run
-from cluv.slurm import FAILED_JOB_STATES
 from cluv.utils import console, current_cluster
 
 logger = logging.getLogger(__name__)
@@ -271,7 +274,6 @@ async def submit_first(
             ]
         )
 
-    # TODO: Return the cluster and job id.
     assert first_running_job
     return Job(
         job_id=first_running_job.job_id,
@@ -281,123 +283,6 @@ async def submit_first(
         sbatch_args=sbatch_args,
         program_args=program_args,
         submitted_at=submit_time.isoformat(),
-    )
-
-
-@dataclasses.dataclass(frozen=True)
-class JobHandle:
-    cluster: str
-    job_id: int
-    state: str
-
-
-async def wait_for_running_job(
-    cluster_and_jobid_to_jobstate: dict[tuple[str, int], str],
-    cluster_to_remote: dict[str, Remote | None],
-    max_wait_time_seconds: int = 60,
-) -> JobHandle | None:
-    """Watch the jobs with sacct until one of them starts (or completes)."""
-
-    first_running_job: JobHandle | None = None
-    wait_time = 1
-
-    to_query = list(cluster_and_jobid_to_jobstate.keys())
-
-    while first_running_job is None and to_query:
-        # Initial sleep after sbatch to give time for job to appear in sacct.
-        await asyncio.sleep(wait_time)
-        wait_time = min(wait_time * 2, max_wait_time_seconds)
-
-        job_states = await asyncio.gather(
-            *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_query)
-        )
-
-        for (cluster, job_id), job_state in zip(to_query.copy(), job_states):
-            if (previous_state := cluster_and_jobid_to_jobstate[(cluster, job_id)]) != job_state:
-                console.print(
-                    f"Job {job_id} on cluster {cluster}: {previous_state} -> {job_state}"
-                )
-            cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
-            if job_state.startswith(("RUNNING", "COMPLETED")):
-                return JobHandle(job_id=job_id, cluster=cluster, state=job_state)
-            if job_state in FAILED_JOB_STATES:
-                to_query.remove((cluster, job_id))
-    # If all failed, `cluster_and_jobid_to_jobstate` is empty.
-    assert not to_query
-    return None
-
-
-async def wait_for_jobs_to_cancel(
-    cluster_and_jobid_to_jobstate: dict[tuple[str, int], str],
-    first_running_job: JobHandle,
-    cluster_to_remote: dict[str, Remote | None],
-    max_wait_time_seconds: int = 60,
-) -> JobHandle | None:
-    start_wait_time = 5
-    to_cancel = list(cluster_and_jobid_to_jobstate.keys())
-    to_cancel.remove((first_running_job.cluster, first_running_job.job_id))
-
-    job_states = await asyncio.gather(
-        *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
-    )
-    for (cluster, job_id), job_state in zip(to_cancel, job_states):
-        logger.info(f"Job {job_id} on cluster {cluster} state: {job_state}")
-        if job_state.startswith("CANCELLED by"):
-            job_state = "CANCELLED"  # just to avoid confusing users.
-        cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
-
-    to_cancel = [
-        (cluster, job_id)
-        for (cluster, job_id), job_state in zip(to_cancel, job_states)
-        if not job_state.startswith(("CANCELLED", "COMPLETED"))
-    ]
-
-    logger.info(f"Need to cancel the following jobs: {to_cancel}")
-
-    await asyncio.gather(
-        *[
-            cancel_job(cluster_to_remote[cluster], job_id, print=True)
-            for cluster, job_id in to_cancel
-        ]
-    )
-
-    wait_time = min(start_wait_time, max_wait_time_seconds)
-
-    while not all(
-        cluster_and_jobid_to_jobstate[cluster_jobid].startswith(
-            tuple(["CANCELLED"] + FAILED_JOB_STATES)
-        )
-        for cluster_jobid in to_cancel.copy()
-    ):
-        # Initial sleep after scancel to give time for job to be cancelled.
-        await asyncio.sleep(wait_time)
-        wait_time = min(wait_time * 2, max_wait_time_seconds)
-
-        job_states = await asyncio.gather(
-            *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
-        )
-        logger.debug(f"Job states: {job_states}")
-
-        for (cluster, job_id), job_state in zip(to_cancel, job_states):
-            logger.info(f"Job {job_id} on cluster {cluster} is in state: {job_state}")
-            if job_state.startswith("CANCELLED by"):
-                job_state = "CANCELLED"  # just to avoid confusing users.
-            if job_state == "FAILED":
-                # Cheat slightly, but it's fine because this is usually just one of the job
-                # steps that is marked "FAILED" in sacct on some clusters, while the others are
-                # marked "CANCELLED". With "FAILED" in red, users might get a bit worried.
-                job_state = "CANCELLED"
-            cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
-            if job_state.startswith(("CANCELLED", "COMPLETED")):
-                console.print(f"Job {job_id} on cluster {cluster} is now {job_state}.")
-                to_cancel.remove((cluster, job_id))
-                # TODO: Do we remove the jobs from the table if they failed?
-                # Also remove from `cluster_to_jobid` so the ctrl+c handler below doesn't
-                # try to cancel it again.
-                # cluster_and_jobid_to_jobstate.pop((cluster, job_id))
-    console.print(
-        f"Successfully cancelled all other jobs except for job {first_running_job.job_id} on "
-        f"cluster {first_running_job.cluster}."
     )
 
 
@@ -525,32 +410,10 @@ async def sbatch(
     # Should be set, since `remote` is None if current_cluster() is the same as the cluster argument
     # to `submit`.
     assert cluster
-    sbatch_command = get_sbatch_command(cluster, job_script, sbatch_args, program_args, git_commit)
+    sbatch_command = get_sbatch_command(
+        cluster, job_script, sbatch_args, program_args, git_commit, chunking
+    )
     if remote:
         return await remote.run(sbatch_command, display=False, warn=True, hide=True)
     # Run the sbatch command locally.
     return await run(tuple(shlex.split(sbatch_command)), _display=False, warn=True, hide=True)
-
-
-async def get_job_state(remote: Remote | None, job_id: int) -> str:
-    """Get the state of the job with the given id on the remote cluster with `sacct`."""
-    sacct_command = f"sacct -j {job_id} --format=State --parsable2 --noheader --allocations"
-    if remote:
-        return await remote.get_output(sacct_command, hide=True)
-    result = await run(tuple(shlex.split(sacct_command)), hide=True)
-    return result.stdout.strip()
-
-
-async def cancel_job(remote: Remote | None, job_id: int, print: bool = False) -> str:
-    """Cancel the job with the given id on the remote cluster."""
-    scancel_command = f"scancel {job_id}"
-    if remote:
-        output = await remote.get_output(scancel_command, hide=True)
-        if print:
-            console.print(f"Cancelled job {job_id} on cluster {remote.hostname}.")
-    else:
-        result = await run(tuple(shlex.split(scancel_command)), hide=True)
-        if print:
-            console.print(f"Cancelled job {job_id} on the current cluster.")
-        output = result.stdout
-    return output

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -16,7 +16,6 @@ from cluv.remote import Remote
 from cluv.slurm import FAILED_JOB_STATES
 from cluv.utils import console
 
-DEFAULT_CHUNCK_TIME = "3:00:00"
 RUNNING_JOB_STATES = ["PENDING", "RUNNING"]
 logger = logging.getLogger(__name__)
 

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
 import logging
 import os
-import re
 import shlex
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
 
 from cluv.cache import save_job
+from cluv.cli.submit_utils.chunking import get_n_chunks
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_cluv_config
 from cluv.remote import Remote
@@ -316,76 +315,6 @@ def get_sbatch_command(
         f"bash --login -c '{env_vars_prefix} sbatch --parsable --chdir={project_root_relative_to_home} "
         f"{sbatch_args_str} {remote_job_script} {program_args_str}'"
     )
-
-
-def get_n_chunks(sbatch_args_str: list[str], env_vars: dict[str, str], job_script: Path) -> int:
-    """TODO"""
-    # The time of a job can be set at different places :
-    #   - As an env variable in the Cluv or the cluster config (with SBATCH_TIMELIMIT)
-    #   - As an arg to sbatch (with --time or -t)
-    #   - As a directive in the job script header (#SBATCH --time)
-    time = (
-        _get_time_from_sbatch_args(sbatch_args_str)
-        or env_vars.get("SBATCH_TIMELIMIT")
-        or _get_time_from_job_script_header(job_script)
-    )
-    console.log(env_vars.get("SBATCH_TIMELIMIT"))
-    console.log(_get_time_from_sbatch_args(sbatch_args_str))
-    console.log(_get_time_from_job_script_header(job_script))
-    console.log(
-        f"Chunking is enabled. Determining the number of chunks based on the job time limit (found {time})."
-    )
-
-    if not time:
-        raise ValueError(
-            "Could not find a time value for the job, which is required for chunking."
-        )
-
-    total_time = parse_time_arg(time)
-    total_hours = total_time.total_seconds() / 3600  # Total hours
-
-    # Split the total time into 3h chunks, and round up.
-    chunk_hours = 3
-    n_chunks = int((total_hours + chunk_hours - 1) // chunk_hours)
-
-    return n_chunks
-
-
-def parse_time_arg(time: str) -> datetime.timedelta:
-    """Parse a time value from the sbatch format to a timedelta object."""
-    # The SLURM time format is days-hours:minutes:seconds, with the days part optionnal.
-    match = re.match(r"(?:(\d+)-)?(\d{1,2}):(\d{2}):(\d{2})", time)
-    if not match:
-        raise ValueError(f"Could not parse time value: {time}")
-
-    return datetime.timedelta(
-        days=int(match.group(1) or 0),
-        hours=int(match.group(2)),
-        minutes=int(match.group(3)),
-        seconds=int(match.group(4)),
-    )
-
-
-def _get_time_from_sbatch_args(sbatch_args_str: list[str]) -> str | None:
-    """TODO"""
-    for arg in sbatch_args_str:
-        if arg.startswith(("--time", "-t")):
-            # Like "--time=00:10:00" or "-t=1-02:00:00"
-            return arg.split("=")[1]
-
-    return None
-
-
-def _get_time_from_job_script_header(job_script: Path) -> str | None:
-    """TODO"""
-    for line in job_script.read_text().splitlines():
-        if line.startswith("#SBATCH") and "--time=" in line:
-            # Like "#SBATCH --time=1:00:00"
-            return line[line.index("--time=") + len("--time=") :].split()[0]
-
-        if not line.strip().startswith("#"):
-            # Stop parsing once we leave the header.
-            return
 
 
 async def sbatch(

--- a/cluv/cli/submit_utils/chunking.py
+++ b/cluv/cli/submit_utils/chunking.py
@@ -27,7 +27,7 @@ def chunking_update_sbatch_ars(
 
 
 def get_n_chunks(sbatch_args: list[str], env_vars: dict[str, str], job_script: Path) -> int:
-    """Get the number of chuncks required from the current time limit."""
+    """Get the number of chunks required from the current time limit."""
     # The time limit of a job can be set multiple way :
     # 1. As an arg to sbatch (with --time or -t)
     # 2. As an env variable in the Cluv or the cluster config (with SBATCH_TIMELIMIT)
@@ -76,7 +76,7 @@ def get_time_from_job_script_header(job_script: Path) -> str | None:
 
 def parse_slurm_time(time: str) -> datetime.timedelta:
     """Parse a time value from the sbatch format to a timedelta object."""
-    # The SLURM time format is days-hours:minutes:seconds, with the days part optionnal.
+    # The SLURM time format is days-hours:minutes:seconds, with the days part optional.
     match = re.match(r"(?:(\d+)-)?(\d{1,2}):(\d{2}):(\d{2})", time)
     if not match:
         raise ValueError(f"Could not parse time value: {time}")

--- a/cluv/cli/submit_utils/chunking.py
+++ b/cluv/cli/submit_utils/chunking.py
@@ -5,14 +5,34 @@ from pathlib import Path
 CHUNK_SIZE = 3  # In hours
 
 
-def get_n_chunks(sbatch_args_str: list[str], env_vars: dict[str, str], job_script: Path) -> int:
+def chunking_update_sbatch_ars(
+    sbatch_args: list[str], env_vars: dict[str, str], job_script: Path
+) -> list[str]:
+    # Add job array
+    n_chunks = get_n_chunks(sbatch_args, env_vars, job_script)
+    sbatch_args.append(f"--array=0-{n_chunks - 1}%1")
+
+    # Update the time limit (add --time=3:00:00 to sbatch args if not already set,
+    # or update the existing time limit to be at most 3h)
+    if not any(arg.startswith(("--time", "-t")) for arg in sbatch_args):
+        sbatch_args.append(f"--time={CHUNK_SIZE}:00:00")
+    else:
+        for i, arg in enumerate(sbatch_args):
+            if arg.startswith(("--time", "-t")):
+                sbatch_args[i] = f"--time={CHUNK_SIZE}:00:00"
+                break
+
+    return sbatch_args
+
+
+def get_n_chunks(sbatch_args: list[str], env_vars: dict[str, str], job_script: Path) -> int:
     """TODO"""
     # The time of a job can be set at different places :
     #   - As an env variable in the Cluv or the cluster config (with SBATCH_TIMELIMIT)
     #   - As an arg to sbatch (with --time or -t)
     #   - As a directive in the job script header (#SBATCH --time)
     time = (
-        _get_time_from_sbatch_args(sbatch_args_str)
+        _get_time_from_sbatch_args(sbatch_args)
         or env_vars.get("SBATCH_TIMELIMIT")
         or _get_time_from_job_script_header(job_script)
     )
@@ -25,15 +45,15 @@ def get_n_chunks(sbatch_args_str: list[str], env_vars: dict[str, str], job_scrip
     total_time = parse_time_arg(time)
     total_hours = total_time.total_seconds() / 3600  # Total hours
 
-    # Split the total time into 3h chunks, and round up.
+    # Split the total time into chunks, and round up.
     n_chunks = int((total_hours + CHUNK_SIZE - 1) // CHUNK_SIZE)
 
     return n_chunks
 
 
-def _get_time_from_sbatch_args(sbatch_args_str: list[str]) -> str | None:
+def _get_time_from_sbatch_args(sbatch_args: list[str]) -> str | None:
     """Return the SLURM time limit from the sbatch args if it exists."""
-    for arg in sbatch_args_str:
+    for arg in sbatch_args:
         if arg.startswith(("--time", "-t")):
             # Like "--time=00:10:00" or "-t=1-02:00:00"
             return arg.split("=")[1]

--- a/cluv/cli/submit_utils/chunking.py
+++ b/cluv/cli/submit_utils/chunking.py
@@ -1,0 +1,68 @@
+import datetime
+import re
+from pathlib import Path
+
+CHUNK_SIZE = 3  # In hours
+
+
+def get_n_chunks(sbatch_args_str: list[str], env_vars: dict[str, str], job_script: Path) -> int:
+    """TODO"""
+    # The time of a job can be set at different places :
+    #   - As an env variable in the Cluv or the cluster config (with SBATCH_TIMELIMIT)
+    #   - As an arg to sbatch (with --time or -t)
+    #   - As a directive in the job script header (#SBATCH --time)
+    time = (
+        _get_time_from_sbatch_args(sbatch_args_str)
+        or env_vars.get("SBATCH_TIMELIMIT")
+        or _get_time_from_job_script_header(job_script)
+    )
+
+    if not time:
+        raise ValueError(
+            "Could not find a time value for the job, which is required for chunking."
+        )
+
+    total_time = parse_time_arg(time)
+    total_hours = total_time.total_seconds() / 3600  # Total hours
+
+    # Split the total time into 3h chunks, and round up.
+    n_chunks = int((total_hours + CHUNK_SIZE - 1) // CHUNK_SIZE)
+
+    return n_chunks
+
+
+def _get_time_from_sbatch_args(sbatch_args_str: list[str]) -> str | None:
+    """Return the SLURM time limit from the sbatch args if it exists."""
+    for arg in sbatch_args_str:
+        if arg.startswith(("--time", "-t")):
+            # Like "--time=00:10:00" or "-t=1-02:00:00"
+            return arg.split("=")[1]
+
+    return None
+
+
+def _get_time_from_job_script_header(job_script: Path) -> str | None:
+    """Return the SLURM time limit from the job script header if it exists."""
+    for line in job_script.read_text().splitlines():
+        if line.startswith("#SBATCH") and "--time=" in line:
+            # Like "#SBATCH --time=1:00:00"
+            return line[line.index("--time=") + len("--time=") :].split()[0]
+
+        if not line.strip().startswith("#"):
+            # Stop parsing once we leave the header.
+            return
+
+
+def parse_time_arg(time: str) -> datetime.timedelta:
+    """Parse a time value from the sbatch format to a timedelta object."""
+    # The SLURM time format is days-hours:minutes:seconds, with the days part optionnal.
+    match = re.match(r"(?:(\d+)-)?(\d{1,2}):(\d{2}):(\d{2})", time)
+    if not match:
+        raise ValueError(f"Could not parse time value: {time}")
+
+    return datetime.timedelta(
+        days=int(match.group(1) or 0),
+        hours=int(match.group(2)),
+        minutes=int(match.group(3)),
+        seconds=int(match.group(4)),
+    )

--- a/cluv/cli/submit_utils/chunking.py
+++ b/cluv/cli/submit_utils/chunking.py
@@ -8,6 +8,7 @@ CHUNK_SIZE = 3  # In hours
 def chunking_update_sbatch_ars(
     sbatch_args: list[str], env_vars: dict[str, str], job_script: Path
 ) -> list[str]:
+    """Add the sbatch args (--array and --time) for chunking the job into multiple smaller jobs."""
     # Add job array
     n_chunks = get_n_chunks(sbatch_args, env_vars, job_script)
     sbatch_args.append(f"--array=0-{n_chunks - 1}%1")
@@ -26,24 +27,24 @@ def chunking_update_sbatch_ars(
 
 
 def get_n_chunks(sbatch_args: list[str], env_vars: dict[str, str], job_script: Path) -> int:
-    """TODO"""
-    # The time of a job can be set at different places :
-    #   - As an env variable in the Cluv or the cluster config (with SBATCH_TIMELIMIT)
-    #   - As an arg to sbatch (with --time or -t)
-    #   - As a directive in the job script header (#SBATCH --time)
-    time = (
-        _get_time_from_sbatch_args(sbatch_args)
+    """Get the number of chuncks required from the current time limit."""
+    # The time limit of a job can be set multiple way :
+    # 1. As an arg to sbatch (with --time or -t)
+    # 2. As an env variable in the Cluv or the cluster config (with SBATCH_TIMELIMIT)
+    # 3. As a directive in the job script header (#SBATCH --time)
+    slurm_time = (
+        get_time_from_sbatch_args(sbatch_args)
         or env_vars.get("SBATCH_TIMELIMIT")
-        or _get_time_from_job_script_header(job_script)
+        or get_time_from_job_script_header(job_script)
     )
 
-    if not time:
+    if not slurm_time:
         raise ValueError(
             "Could not find a time value for the job, which is required for chunking."
         )
 
-    total_time = parse_time_arg(time)
-    total_hours = total_time.total_seconds() / 3600  # Total hours
+    time = parse_slurm_time(slurm_time)
+    total_hours = time.total_seconds() / 3600  # Convert to hours
 
     # Split the total time into chunks, and round up.
     n_chunks = int((total_hours + CHUNK_SIZE - 1) // CHUNK_SIZE)
@@ -51,7 +52,7 @@ def get_n_chunks(sbatch_args: list[str], env_vars: dict[str, str], job_script: P
     return n_chunks
 
 
-def _get_time_from_sbatch_args(sbatch_args: list[str]) -> str | None:
+def get_time_from_sbatch_args(sbatch_args: list[str]) -> str | None:
     """Return the SLURM time limit from the sbatch args if it exists."""
     for arg in sbatch_args:
         if arg.startswith(("--time", "-t")):
@@ -61,7 +62,7 @@ def _get_time_from_sbatch_args(sbatch_args: list[str]) -> str | None:
     return None
 
 
-def _get_time_from_job_script_header(job_script: Path) -> str | None:
+def get_time_from_job_script_header(job_script: Path) -> str | None:
     """Return the SLURM time limit from the job script header if it exists."""
     for line in job_script.read_text().splitlines():
         if line.startswith("#SBATCH") and "--time=" in line:
@@ -73,7 +74,7 @@ def _get_time_from_job_script_header(job_script: Path) -> str | None:
             return
 
 
-def parse_time_arg(time: str) -> datetime.timedelta:
+def parse_slurm_time(time: str) -> datetime.timedelta:
     """Parse a time value from the sbatch format to a timedelta object."""
     # The SLURM time format is days-hours:minutes:seconds, with the days part optionnal.
     match = re.match(r"(?:(\d+)-)?(\d{1,2}):(\d{2}):(\d{2})", time)

--- a/cluv/cli/submit_utils/first.py
+++ b/cluv/cli/submit_utils/first.py
@@ -1,0 +1,151 @@
+import asyncio
+import dataclasses
+import logging
+import shlex
+
+from cluv.remote import Remote, run
+from cluv.slurm import FAILED_JOB_STATES
+from cluv.utils import console
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class JobHandle:
+    cluster: str
+    job_id: int
+    state: str
+
+
+async def get_job_state(remote: Remote | None, job_id: int) -> str:
+    """Get the state of the job with the given id on the remote cluster with `sacct`."""
+    sacct_command = f"sacct -j {job_id} --format=State --parsable2 --noheader --allocations"
+    if remote:
+        return await remote.get_output(sacct_command, hide=True)
+    result = await run(tuple(shlex.split(sacct_command)), hide=True)
+    return result.stdout.strip()
+
+
+async def cancel_job(remote: Remote | None, job_id: int, print: bool = False) -> str:
+    """Cancel the job with the given id on the remote cluster."""
+    scancel_command = f"scancel {job_id}"
+    if remote:
+        output = await remote.get_output(scancel_command, hide=True)
+        if print:
+            console.print(f"Cancelled job {job_id} on cluster {remote.hostname}.")
+    else:
+        result = await run(tuple(shlex.split(scancel_command)), hide=True)
+        if print:
+            console.print(f"Cancelled job {job_id} on the current cluster.")
+        output = result.stdout
+    return output
+
+
+async def wait_for_running_job(
+    cluster_and_jobid_to_jobstate: dict[tuple[str, int], str],
+    cluster_to_remote: dict[str, Remote | None],
+    max_wait_time_seconds: int = 60,
+) -> JobHandle | None:
+    """Watch the jobs with sacct until one of them starts (or completes)."""
+
+    first_running_job: JobHandle | None = None
+    wait_time = 1
+
+    to_query = list(cluster_and_jobid_to_jobstate.keys())
+
+    while first_running_job is None and to_query:
+        # Initial sleep after sbatch to give time for job to appear in sacct.
+        await asyncio.sleep(wait_time)
+        wait_time = min(wait_time * 2, max_wait_time_seconds)
+
+        job_states = await asyncio.gather(
+            *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_query)
+        )
+
+        for (cluster, job_id), job_state in zip(to_query.copy(), job_states):
+            if (previous_state := cluster_and_jobid_to_jobstate[(cluster, job_id)]) != job_state:
+                console.print(
+                    f"Job {job_id} on cluster {cluster}: {previous_state} -> {job_state}"
+                )
+            cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
+            if job_state.startswith(("RUNNING", "COMPLETED")):
+                return JobHandle(job_id=job_id, cluster=cluster, state=job_state)
+            if job_state in FAILED_JOB_STATES:
+                to_query.remove((cluster, job_id))
+    # If all failed, `cluster_and_jobid_to_jobstate` is empty.
+    assert not to_query
+    return None
+
+
+async def wait_for_jobs_to_cancel(
+    cluster_and_jobid_to_jobstate: dict[tuple[str, int], str],
+    first_running_job: JobHandle,
+    cluster_to_remote: dict[str, Remote | None],
+    max_wait_time_seconds: int = 60,
+) -> JobHandle | None:
+    start_wait_time = 5
+    to_cancel = list(cluster_and_jobid_to_jobstate.keys())
+    to_cancel.remove((first_running_job.cluster, first_running_job.job_id))
+
+    job_states = await asyncio.gather(
+        *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
+    )
+    for (cluster, job_id), job_state in zip(to_cancel, job_states):
+        logger.info(f"Job {job_id} on cluster {cluster} state: {job_state}")
+        if job_state.startswith("CANCELLED by"):
+            job_state = "CANCELLED"  # just to avoid confusing users.
+        cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
+
+    to_cancel = [
+        (cluster, job_id)
+        for (cluster, job_id), job_state in zip(to_cancel, job_states)
+        if not job_state.startswith(("CANCELLED", "COMPLETED"))
+    ]
+
+    logger.info(f"Need to cancel the following jobs: {to_cancel}")
+
+    await asyncio.gather(
+        *[
+            cancel_job(cluster_to_remote[cluster], job_id, print=True)
+            for cluster, job_id in to_cancel
+        ]
+    )
+
+    wait_time = min(start_wait_time, max_wait_time_seconds)
+
+    while not all(
+        cluster_and_jobid_to_jobstate[cluster_jobid].startswith(
+            tuple(["CANCELLED"] + FAILED_JOB_STATES)
+        )
+        for cluster_jobid in to_cancel.copy()
+    ):
+        # Initial sleep after scancel to give time for job to be cancelled.
+        await asyncio.sleep(wait_time)
+        wait_time = min(wait_time * 2, max_wait_time_seconds)
+
+        job_states = await asyncio.gather(
+            *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
+        )
+        logger.debug(f"Job states: {job_states}")
+
+        for (cluster, job_id), job_state in zip(to_cancel, job_states):
+            logger.info(f"Job {job_id} on cluster {cluster} is in state: {job_state}")
+            if job_state.startswith("CANCELLED by"):
+                job_state = "CANCELLED"  # just to avoid confusing users.
+            if job_state == "FAILED":
+                # Cheat slightly, but it's fine because this is usually just one of the job
+                # steps that is marked "FAILED" in sacct on some clusters, while the others are
+                # marked "CANCELLED". With "FAILED" in red, users might get a bit worried.
+                job_state = "CANCELLED"
+            cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
+            if job_state.startswith(("CANCELLED", "COMPLETED")):
+                console.print(f"Job {job_id} on cluster {cluster} is now {job_state}.")
+                to_cancel.remove((cluster, job_id))
+                # TODO: Do we remove the jobs from the table if they failed?
+                # Also remove from `cluster_to_jobid` so the ctrl+c handler below doesn't
+                # try to cancel it again.
+                # cluster_and_jobid_to_jobstate.pop((cluster, job_id))
+    console.print(
+        f"Successfully cancelled all other jobs except for job {first_running_job.job_id} on "
+        f"cluster {first_running_job.cluster}."
+    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,8 @@ from cluv.cache import Job
 from cluv.cli.init import DEFAULT_RESULTS_PATH, init
 from cluv.cli.login import get_remote_without_2fa_prompt, login
 from cluv.cli.status import ClusterStatus, get_cluster_status
-from cluv.cli.submit import get_job_state, submit
+from cluv.cli.submit import submit
+from cluv.cli.submit_utils.first import get_job_state
 from cluv.cli.sync import sync
 from cluv.config import get_cluv_config, load_cluv_config
 from cluv.remote import Remote, control_socket_is_running
@@ -166,20 +167,6 @@ async def test_status_gpu_model(cluster_status: ClusterStatus, cluster: str):
 @pytest.mark.timeout(30)
 @pytest.mark.xfail(reason="Status integration tests are flaky and will be reworked soon.")
 @pytest.mark.asyncio
-async def test_status_jobs(cluster_status: ClusterStatus, cluster: str):
-    if cluster not in STATUS_SUPPORTED_CLUSTERS:
-        pytest.xfail(f"Status integration test not supported on cluster {cluster}.")
-    # Job counts must be non-negative integers (tamia is a busy cluster)
-    assert cluster_status.jobs.running >= 0
-    assert cluster_status.jobs.pending >= 0
-    assert cluster_status.jobs.my_running >= 0
-    assert cluster_status.jobs.my_pending >= 0
-
-
-@pytest.mark.slow
-@pytest.mark.timeout(30)
-@pytest.mark.xfail(reason="Status integration tests are flaky and will be reworked soon.")
-@pytest.mark.asyncio
 async def test_status_storage(cluster_status: ClusterStatus):
     assert cluster_status.storage.home_quota > 0, "Expected non-zero home quota"
     assert cluster_status.storage.scratch_quota > 0, "Expected non-zero scratch quota"
@@ -221,6 +208,7 @@ async def test_submit(remote: Remote, fake_scratch: Path):
     job = await submit(
         cluster=remote.hostname,
         job_script=Path("scripts/job.sh"),
+        chunking=False,
         sbatch_args=["--time=00:00:30"],
         program_args=["python", "--version"],
     )

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -84,7 +84,7 @@ class TestGetSbatchCommand:
             sbatch_args=["--account=my_account", "--mem=8G"],
             program_args=["program_arg_1", "program_arg_2"],
             git_commit="abecdef",
-            job_chunking=False,
+            chunking=False,
         )
         job_script_relative_path = sbatch_script.relative_to(fake_home)
 
@@ -122,7 +122,7 @@ class TestGetSbatchCommand:
             sbatch_args=[],
             program_args=[],
             git_commit="abecdef",
-            job_chunking=False,
+            chunking=False,
         )
 
         assert sbatch_command == (
@@ -155,7 +155,7 @@ class TestGetSbatchCommand:
             sbatch_args=["--time=10:00:00"],
             program_args=[],
             git_commit="abecdef",
-            job_chunking=True,
+            chunking=True,
         )
 
         assert sbatch_command == (
@@ -290,6 +290,7 @@ async def test_can_submit_on_current_cluster(
     returned_job = await submit(
         cluster=here,
         job_script=job_script,
+        chunking=False,
         sbatch_args=sbatch_args,
         program_args=program_args,
     )
@@ -422,6 +423,7 @@ async def test_submit_first_considers_current_cluster(
     returned_job = await submit_first(
         job_script=job_script,
         sbatch_args=sbatch_args,
+        chunking=False,
         program_args=program_args,
         git_commit=dummy_commit,
     )

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -59,6 +59,7 @@ class TestGetSbatchCommand:
             sbatch_args=["--account=my_account", "--mem=8G"],
             program_args=["program_arg_1", "program_arg_2"],
             git_commit="abecdef",
+            job_chunking=False,
         )
         job_script_relative_path = sbatch_script.relative_to(fake_home)
 
@@ -96,12 +97,47 @@ class TestGetSbatchCommand:
             sbatch_args=[],
             program_args=[],
             git_commit="abecdef",
+            job_chunking=False,
         )
 
         assert sbatch_command == (
             "bash --login -c 'MY_VAR=2 SBATCH_JOB_NAME=cluv-my_script GIT_COMMIT=abecdef "
             f"SBATCH_OUTPUT={results_path}/mila_%j/slurm-%j.out "
             "sbatch --parsable --chdir=my_project  ~/my_project/scripts/my_script.sh '"
+        )
+
+    def test_use_correct_time_value_when_chunking(self, project_dir: Path) -> None:
+        p = project_dir / "pyproject.toml"
+        results_path = "results"
+        p.write_text(
+            textwrap.dedent(
+                f"""\
+            [tool.cluv]
+            results_path = "{results_path}"
+            [tool.cluv.env]
+            SBATCH_TIMELIMIT="5:00:00"
+            [tool.cluv.clusters.mila]
+            """
+            )
+        )
+        job_script = project_dir / "scripts" / "my_script.sh"
+        job_script.parent.mkdir()
+        job_script.write_text("#SBATCH --time=20:00:00")
+
+        sbatch_command = get_sbatch_command(
+            cluster="mila",
+            job_script=job_script,
+            sbatch_args=["--time=10:00:00"],
+            program_args=[],
+            git_commit="abecdef",
+            job_chunking=True,
+        )
+
+        assert sbatch_command == (
+            "bash --login -c 'SBATCH_TIMELIMIT=5:00:00 SBATCH_JOB_NAME=cluv-my_script "
+            f"GIT_COMMIT=abecdef SBATCH_OUTPUT={results_path}/mila_%A/slurm-%A_%a.out "
+            "sbatch --parsable --chdir=my_project --time=3:00:00 --array=0-3%1 "
+            "~/my_project/scripts/my_script.sh '"
         )
 
 


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Added `--chunking` arg to `cluv submit`. When set, cluv divide the job into an array of jobs of 3 hours each.
* Moved utils functions for `submit first` to `submit_utils/first.py`.
* Reworked how the `sbatch_args` are parsed.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/