### PR TITLE
Add an option to ignore a cluster in the config

### DIFF
--- a/cluv/cli/run.py
+++ b/cluv/cli/run.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import shlex
 from pathlib import Path
 from subprocess import CompletedProcess
 
-from rich.console import Group
-from rich.panel import Panel
-
-from cluv.cli.login import get_remote_without_2fa_prompt
 from cluv.cli.sync import sync
-from cluv.config import find_pyproject, get_cluv_config
-from cluv.remote import Remote
-from cluv.utils import console, current_cluster
+from cluv.config import find_pyproject
 
 logger = logging.getLogger(__name__)
 __all__ = ["run"]
@@ -37,87 +30,3 @@ async def run(command: str | list[str], cluster: str) -> CompletedProcess[str]:
     remote = (await sync(clusters=[cluster]))[0]
     project_path = find_pyproject().parent.relative_to(Path.home())
     return await remote.run(f"bash -l -c 'uv run --directory={project_path} {command}'")
-
-
-async def _get_cluster_remotes(clusters: list[str] | None) -> list[Remote]:
-    """Returns the list remote objects for each cluster with a current active connection."""
-    if clusters:
-        # User specified clusters
-        # We don't check for active connection if user explicitly asks for a cluster.
-        # Remote.connect will try to connect (and start the socket if needed/possible)
-        # When there isn't an existing connection, this might generate a ton of 2FA
-        # prompts at once.
-        return list(await asyncio.gather(*[Remote.connect(cluster) for cluster in clusters]))
-    # Use default list and filter for active connections
-    # We need to check which ones are active WITHOUT trying to connect interactively
-    # control_socket_is_running_async checks if the socket exists and is running
-
-    # We need to construct Remote objects to get the control path, but we
-    # shouldn't start them yet
-    # Actually Remote constructor doesn't start if _start_control_socket=False
-    this_cluster = current_cluster()
-    # When no cluster is passed, sync with clusters for which we have an active SSH connection.
-    clusters = get_cluv_config().clusters_names
-    if this_cluster and this_cluster in clusters:
-        clusters.remove(this_cluster)
-    connections = await asyncio.gather(
-        *(get_remote_without_2fa_prompt(cluster) for cluster in clusters)
-    )
-    remotes = [conn for conn in connections if conn]
-    if not remotes:
-        console.log(
-            "[red]Not currently connected to any Slurm cluster.[/red] "
-            "Use `cluv login` to login and create reusable connections."
-        )
-        return []
-    return remotes
-
-
-async def _run_multiple_clusters(
-    command: str | list[str], clusters: str | list[str] | None = None
-):
-    """CLI wrapper for the run command."""
-    if not command:
-        console.print("No command specified.", style="red")
-        return
-
-    if isinstance(command, str):
-        cmd_str = command
-    else:
-        # It's only a list of strings because of argparse.REMAINDER.
-        # This doesn't mean 'multiple commands'.
-        cmd_str = " ".join(command)
-
-    if isinstance(clusters, str):
-        clusters = [c.strip() for c in clusters.split(",")]
-
-    if not clusters:
-        console.print("No active cluster connections found.", style="yellow")
-        return
-
-    console.print(f"Running '{cmd_str}' on {len(clusters)} clusters...", style="bold blue")
-
-    results = await asyncio.gather(*(run(cmd_str, cluster) for cluster in clusters))
-
-    panels = []
-    for cluster, result in zip(clusters, results):
-        style = "green" if result.returncode == 0 else "red"
-        center = " (returncode: " + str(result.returncode) + ")" if result.returncode != 0 else ""
-        title = f"[bold]{cluster.hostname}{center}[/bold]"
-
-        content = ""
-        # If there is ONLY stdout, then don't add the 'Stdout:' header:
-        if result.stdout and not result.stderr:
-            content += result.stdout.strip()
-        elif result.stdout:
-            content += f"[bold]Stdout:[/bold]\n{result.stdout.strip()}\n"
-        if result.stderr:
-            content += f"[bold]Stderr:[/bold]\n{result.stderr.strip()}\n"
-
-        if not content:
-            content = "[italic]No output[/italic]"
-
-        panels.append(Panel(content, title=title, border_style=style))
-    # TODO: Do we want to display results differently depending on if all the results are single-line vs multi-line?
-
-    console.print(Group(*panels))

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -38,7 +38,7 @@ class PartialClusterConfig:
 
     ignore: bool = False
     """Whether to ignore this cluster when running commands on all clusters."""
-    
+
     job_script_path: str | None = None
     """Path to the job script to use by default on this cluster."""
 
@@ -63,7 +63,7 @@ class ClusterConfig:
 
     ignore: bool
     """Whether to ignore this cluster when running commands on all clusters."""
-    
+
     job_script_path: Path | None
     """Path to the job script to use by default on this cluster."""
 

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -36,6 +36,9 @@ class PartialClusterConfig:
     This folder will be synced from the current cluster to all other clusters at their respective `dataset_path`.
     """
 
+    ignore: bool = False
+    """Whether to ignore this cluster when running commands on all clusters."""
+
 
 @dataclass(frozen=True)
 class ClusterConfig:
@@ -54,6 +57,9 @@ class ClusterConfig:
 
     This folder will be synced from the current cluster to all other clusters at their respective `dataset_path`.
     """
+
+    ignore: bool = False
+    """Whether to ignore this cluster when running commands on all clusters."""
 
     def expandvars(self):
         return ClusterConfig(
@@ -94,7 +100,7 @@ class CluvConfig(BaseModel):
 
     @property
     def clusters_names(self) -> list[str]:
-        return list(self.clusters.keys())
+        return [name for name, config in self.clusters.items() if not config.ignore]
 
     def get_cluster_config(self, cluster: str) -> ClusterConfig:
         """Returns the cluster config for a specific cluster.

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -58,7 +58,7 @@ class ClusterConfig:
     This folder will be synced from the current cluster to all other clusters at their respective `dataset_path`.
     """
 
-    ignore: bool = False
+    ignore: bool
     """Whether to ignore this cluster when running commands on all clusters."""
 
     def expandvars(self):
@@ -68,6 +68,7 @@ class ClusterConfig:
             datasets_path=(
                 Path(os.path.expandvars(self.datasets_path)) if self.datasets_path else None
             ),
+            ignore=self.ignore,
         )
 
 
@@ -116,6 +117,7 @@ class CluvConfig(BaseModel):
             # TODO: Use the cluster-specific results_path if we add that option back in the future.
             results_path=Path(results_path),
             datasets_path=Path(datasets_path) if datasets_path else None,
+            ignore=cluster_config.ignore,
         )
 
 

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -143,11 +143,6 @@ def load_cluv_config(pyproject_path: Path) -> CluvConfig:
     return CluvConfig.model_validate(cluv, extra="forbid")
 
 
-def get_cluster_choices() -> list[str]:
-    """Return configured clusters or the defaults when config is missing/invalid."""
-    return get_cluv_config().clusters_names
-
-
 def current_cluster_config() -> ClusterConfig | None:
     """Returns the `ClusterConfig` of the current cluster, or None if not currently on a cluster."""
     cluster = current_cluster()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,6 +185,7 @@ class TestClusterConfigHelpers:
             env={},
             results_path=Path("$CLUV_TMP/results"),
             datasets_path=Path("$CLUV_TMP/data"),
+            ignore=False,
             job_script_path=Path("$CLUV_TMP/scripts/job.sh"),
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,6 +79,21 @@ SBATCH_ACCOUNT = "def-bengioy"
         assert cfg.clusters["mila"].env == {}
         assert cfg.clusters["rorqual"].env == {"SBATCH_ACCOUNT": "def-bengioy"}
 
+    def test_clusters_names_should_not_returned_ignored_clusters(self, tmp_path: Path) -> None:
+        p = write_pyproject(
+            tmp_path,
+            """
+    [tool.cluv]
+    results_path = "logs"
+    [tool.cluv.clusters.mila]
+    [tool.cluv.clusters.rorqual]
+    [tool.cluv.clusters.narval]
+    ignore = true
+    """,
+        )
+        cfg = load_cluv_config(p)
+        assert cfg.clusters_names == ["mila", "rorqual"]
+
 
 # ---------------------------------------------------------------------------
 # [tool.cluv.env] — global SBATCH_* defaults


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Add `ignore` to `ClusterConfig` and `PartialClusterConfig`.
* Remove unused functions `get_cluster_choices`, `_get_cluster_remotes` and `_run_multiple_clusters`.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
* Close #89