### PR TITLE
Add `--autocommit` flag to `cluv submit`

### DIFF
--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -127,6 +127,11 @@ def add_submit_args(subparsers: Subparsers):
         usage="cluv submit <cluster> [<job.sh>] [sbatch-args...] [-- program-args...]",
     )
     submit_parser.add_argument(
+        "--make-commit",
+        action="store_true",
+        help="Create a local commit with tracked changes before submitting the job.",
+    )
+    submit_parser.add_argument(
         "cluster",
         metavar="<cluster>",
         help=(

--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -127,7 +127,7 @@ def add_submit_args(subparsers: Subparsers):
         usage="cluv submit <cluster> [<job.sh>] [sbatch-args...] [-- program-args...]",
     )
     submit_parser.add_argument(
-        "--make-commit",
+        "--autocommit",
         action="store_true",
         help="Create a local commit with tracked changes before submitting the job.",
     )

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -66,15 +66,13 @@ async def submit(
     )
     ```
     """
-    submit_command: str | None = None
+    launched_job_command: str | None = None
     if make_commit:
-        submit_command = build_submit_command(
-            cluster, job_script, sbatch_args, program_args, make_commit
-        )
+        launched_job_command = build_submit_command(cluster, job_script, sbatch_args, program_args)
 
     # Check git is clean locally (untracked files are fine) and capture current commit hash.
     git_commit = ensure_clean_git_state(
-        make_commit=make_commit, launched_job_command=submit_command
+        make_commit=make_commit, launched_job_command=launched_job_command
     )
 
     here = current_cluster()
@@ -416,12 +414,10 @@ def build_submit_command(
     job_script: Path,
     sbatch_args: list[str],
     program_args: list[str],
-    make_commit: bool,
 ) -> str:
     """Build the local `cluv submit` command line used to launch the job."""
     command_parts = ["cluv", "submit"]
-    if make_commit:
-        command_parts.append("--make-commit")
+    command_parts.append("--make-commit")
     command_parts.extend([cluster, str(job_script), *sbatch_args])
     if program_args:
         command_parts.extend(["--", *program_args])

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -17,6 +17,9 @@ import rich.text
 from rich.live import Live
 
 from cluv.cache import Job, save_job
+from pathlib import Path
+from typing import Callable
+
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_cluv_config
 from cluv.remote import Remote, run
@@ -66,13 +69,14 @@ async def submit(
     )
     ```
     """
-    launched_job_command = (
-        build_submit_command(cluster, job_script, sbatch_args, program_args) if make_commit else None
-    )
-
     # Check git is clean locally (untracked files are fine) and capture current commit hash.
     git_commit = ensure_clean_git_state(
-        make_commit=make_commit, launched_job_command=launched_job_command
+        make_commit=make_commit,
+        launched_job_command_builder=(
+            (lambda: build_submit_command(cluster, job_script, sbatch_args, program_args))
+            if make_commit
+            else None
+        ),
     )
 
     here = current_cluster()
@@ -440,7 +444,7 @@ def create_submit_commit(launched_job_command: str) -> None:
 
 
 def ensure_clean_git_state(
-    make_commit: bool = False, launched_job_command: str | None = None
+    make_commit: bool = False, launched_job_command_builder: Callable[[], str] | None = None
 ) -> str:
     """
     Check git is clean locally and return the current commit hash.
@@ -449,8 +453,9 @@ def ensure_clean_git_state(
     dirty_lines = [line for line in git_status.stdout.splitlines() if not line.startswith("??")]
     if dirty_lines:
         if make_commit:
-            if launched_job_command is None:
-                raise ValueError("launched_job_command is required when make_commit=True")
+            if launched_job_command_builder is None:
+                raise ValueError("launched_job_command_builder is required when make_commit=True")
+            launched_job_command = launched_job_command_builder()
             create_submit_commit(launched_job_command=launched_job_command)
         elif not (os.environ.get("SKIP_CLEAN_GIT_CHECK", "0") == "1"):
             console.print(

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -417,7 +417,6 @@ def build_submit_command(
 ) -> str:
     """Build the local `cluv submit` command line used to launch the job."""
     command_parts = ["cluv", "submit"]
-    command_parts.append("--make-commit")
     command_parts.extend([cluster, str(job_script), *sbatch_args])
     if program_args:
         command_parts.extend(["--", *program_args])

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -16,7 +16,6 @@ import rich.text
 from rich.live import Live
 
 from cluv.cache import Job, save_job
-from typing import Callable
 
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_cluv_config
@@ -448,9 +447,7 @@ def create_submit_commit(submit_command: str) -> None:
         raise
 
 
-def ensure_clean_git_state(
-    autocommit: bool = False, submit_command: str | None = None
-) -> str:
+def ensure_clean_git_state(autocommit: bool = False, submit_command: str | None = None) -> str:
     """
     Check git is clean locally and return the current commit hash.
     """

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -66,7 +66,11 @@ async def submit(
     )
     ```
     """
-    submit_command = build_submit_command(cluster, job_script, sbatch_args, program_args, make_commit)
+    submit_command: str | None = None
+    if make_commit:
+        submit_command = build_submit_command(
+            cluster, job_script, sbatch_args, program_args, make_commit
+        )
 
     # Check git is clean locally (untracked files are fine) and capture current commit hash.
     git_commit = ensure_clean_git_state(
@@ -450,7 +454,9 @@ def ensure_clean_git_state(
     dirty_lines = [line for line in git_status.stdout.splitlines() if not line.startswith("??")]
     if dirty_lines:
         if make_commit:
-            create_submit_commit(launched_job_command=launched_job_command or "cluv submit")
+            if launched_job_command is None:
+                raise ValueError("launched_job_command is required when make_commit=True")
+            create_submit_commit(launched_job_command=launched_job_command)
         elif not (os.environ.get("SKIP_CLEAN_GIT_CHECK", "0") == "1"):
             console.print(
                 "[red]Working directory is dirty. Please commit your changes before submitting.[/red]",

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -71,11 +71,7 @@ async def submit(
     # Check git is clean locally (untracked files are fine) and capture current commit hash.
     git_commit = ensure_clean_git_state(
         autocommit=autocommit,
-        launched_job_command_builder=(
-            (lambda: build_submit_command(cluster, job_script, sbatch_args, program_args))
-            if autocommit
-            else None
-        ),
+        submit_command=build_submit_command(cluster, job_script, sbatch_args, program_args),
     )
 
     here = current_cluster()
@@ -426,7 +422,7 @@ def build_submit_command(
     return shlex.join(command_parts)
 
 
-def create_submit_commit(launched_job_command: str) -> None:
+def create_submit_commit(submit_command: str) -> None:
     """Create a commit with tracked changes and include the launched job command in the body."""
     try:
         subprocess.run(["git", "add", "-u"], check=True, capture_output=True, text=True)
@@ -437,7 +433,7 @@ def create_submit_commit(launched_job_command: str) -> None:
                 "-m",
                 "cluv submit: auto-commit tracked changes",
                 "-m",
-                f"Launched job command:\n\n{launched_job_command}",
+                f"Launched job command:\n\n{submit_command}",
             ],
             check=True,
             capture_output=True,
@@ -453,7 +449,7 @@ def create_submit_commit(launched_job_command: str) -> None:
 
 
 def ensure_clean_git_state(
-    autocommit: bool = False, launched_job_command_builder: Callable[[], str] | None = None
+    autocommit: bool = False, submit_command: str | None = None
 ) -> str:
     """
     Check git is clean locally and return the current commit hash.
@@ -462,10 +458,9 @@ def ensure_clean_git_state(
     dirty_lines = [line for line in git_status.stdout.splitlines() if not line.startswith("??")]
     if dirty_lines:
         if autocommit:
-            if launched_job_command_builder is None:
-                raise ValueError("launched_job_command_builder is required when autocommit=True")
-            launched_job_command = launched_job_command_builder()
-            create_submit_commit(launched_job_command=launched_job_command)
+            if submit_command is None:
+                raise ValueError("submit_command is required when autocommit=True")
+            create_submit_commit(submit_command)
         elif not (os.environ.get("SKIP_CLEAN_GIT_CHECK", "0") == "1"):
             console.print(
                 "[red]Working directory is dirty. Please commit your changes before submitting.[/red]",

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -17,7 +17,6 @@ import rich.text
 from rich.live import Live
 
 from cluv.cache import Job, save_job
-from pathlib import Path
 from typing import Callable
 
 from cluv.cli.sync import sync
@@ -36,7 +35,7 @@ async def submit(
     job_script: Path | None,
     sbatch_args: list[str],
     program_args: list[str],
-    make_commit: bool = False,
+    autocommit: bool = False,
 ) -> Job | None:
     """Submit a SLURM job on a remote cluster.
 
@@ -54,7 +53,7 @@ async def submit(
             When omitted, uses the configured default for the target cluster.
         sbatch_args: List of additional flags to pass to `sbatch`.
         program_args: List of arguments to pass to the job script, for example `["python", "main.py"]`.
-        make_commit: If True, automatically create a local commit with tracked changes before submitting.
+        autocommit: If True, automatically create a local commit with tracked changes before submitting.
 
     Returns:
         The job ID of the submitted job or None if the sbatch command fails.
@@ -72,10 +71,10 @@ async def submit(
     """
     # Check git is clean locally (untracked files are fine) and capture current commit hash.
     git_commit = ensure_clean_git_state(
-        make_commit=make_commit,
+        autocommit=autocommit,
         launched_job_command_builder=(
             (lambda: build_submit_command(cluster, job_script, sbatch_args, program_args))
-            if make_commit
+            if autocommit
             else None
         ),
     )
@@ -455,7 +454,7 @@ def create_submit_commit(launched_job_command: str) -> None:
 
 
 def ensure_clean_git_state(
-    make_commit: bool = False, launched_job_command_builder: Callable[[], str] | None = None
+    autocommit: bool = False, launched_job_command_builder: Callable[[], str] | None = None
 ) -> str:
     """
     Check git is clean locally and return the current commit hash.
@@ -463,9 +462,9 @@ def ensure_clean_git_state(
     git_status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
     dirty_lines = [line for line in git_status.stdout.splitlines() if not line.startswith("??")]
     if dirty_lines:
-        if make_commit:
+        if autocommit:
             if launched_job_command_builder is None:
-                raise ValueError("launched_job_command_builder is required when make_commit=True")
+                raise ValueError("launched_job_command_builder is required when autocommit=True")
             launched_job_command = launched_job_command_builder()
             create_submit_commit(launched_job_command=launched_job_command)
         elif not (os.environ.get("SKIP_CLEAN_GIT_CHECK", "0") == "1"):

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -54,6 +54,7 @@ async def submit(
             When omitted, uses the configured default for the target cluster.
         sbatch_args: List of additional flags to pass to `sbatch`.
         program_args: List of arguments to pass to the job script, for example `["python", "main.py"]`.
+        make_commit: If True, automatically create a local commit with tracked changes before submitting.
 
     Returns:
         The job ID of the submitted job or None if the sbatch command fails.
@@ -429,18 +430,28 @@ def build_submit_command(
 
 def create_submit_commit(launched_job_command: str) -> None:
     """Create a commit with tracked changes and include the launched job command in the body."""
-    subprocess.run(["git", "add", "-u"], check=True)
-    subprocess.run(
-        [
-            "git",
-            "commit",
-            "-m",
-            "cluv submit: auto-commit tracked changes",
-            "-m",
-            f"Launched job command:\n\n{launched_job_command}",
-        ],
-        check=True,
-    )
+    try:
+        subprocess.run(["git", "add", "-u"], check=True, capture_output=True, text=True)
+        subprocess.run(
+            [
+                "git",
+                "commit",
+                "-m",
+                "cluv submit: auto-commit tracked changes",
+                "-m",
+                f"Launched job command:\n\n{launched_job_command}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as err:
+        error_text = (err.stderr or err.stdout or str(err)).strip()
+        console.print(
+            "[red]Failed to create automatic submit commit before job submission:[/red] "
+            f"{error_text}"
+        )
+        raise
 
 
 def ensure_clean_git_state(

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -33,6 +33,7 @@ async def submit(
     job_script: Path | None,
     sbatch_args: list[str],
     program_args: list[str],
+    make_commit: bool = False,
 ) -> Job | None:
     """Submit a SLURM job on a remote cluster.
 
@@ -65,8 +66,12 @@ async def submit(
     )
     ```
     """
+    submit_command = build_submit_command(cluster, job_script, sbatch_args, program_args, make_commit)
+
     # Check git is clean locally (untracked files are fine) and capture current commit hash.
-    git_commit = ensure_clean_git_state()
+    git_commit = ensure_clean_git_state(
+        make_commit=make_commit, launched_job_command=submit_command
+    )
 
     here = current_cluster()
 
@@ -402,17 +407,55 @@ async def wait_for_jobs_to_cancel(
     )
 
 
-def ensure_clean_git_state() -> str:
+def build_submit_command(
+    cluster: str,
+    job_script: Path,
+    sbatch_args: list[str],
+    program_args: list[str],
+    make_commit: bool,
+) -> str:
+    """Build the local `cluv submit` command line used to launch the job."""
+    command_parts = ["cluv", "submit"]
+    if make_commit:
+        command_parts.append("--make-commit")
+    command_parts.extend([cluster, str(job_script), *sbatch_args])
+    if program_args:
+        command_parts.extend(["--", *program_args])
+    return shlex.join(command_parts)
+
+
+def create_submit_commit(launched_job_command: str) -> None:
+    """Create a commit with tracked changes and include the launched job command in the body."""
+    subprocess.run(["git", "add", "-u"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "commit",
+            "-m",
+            "cluv submit: auto-commit tracked changes",
+            "-m",
+            f"Launched job command:\n\n{launched_job_command}",
+        ],
+        check=True,
+    )
+
+
+def ensure_clean_git_state(
+    make_commit: bool = False, launched_job_command: str | None = None
+) -> str:
     """
     Check git is clean locally and return the current commit hash.
     """
     git_status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
     dirty_lines = [line for line in git_status.stdout.splitlines() if not line.startswith("??")]
-    if dirty_lines and not (os.environ.get("SKIP_CLEAN_GIT_CHECK", "0") == "1"):
-        console.print(
-            "[red]Working directory is dirty. Please commit your changes before submitting.[/red]",
-        )
-        sys.exit(1)
+    if dirty_lines:
+        if make_commit:
+            create_submit_commit(launched_job_command=launched_job_command or "cluv submit")
+        elif not (os.environ.get("SKIP_CLEAN_GIT_CHECK", "0") == "1"):
+            console.print(
+                "[red]Working directory is dirty. Please commit your changes before submitting.[/red]",
+            )
+            sys.exit(1)
 
     # In GitHub Actions PR jobs we can be on a detached merge commit that doesn't exist on
     # the synced remote checkout. Prefer the branch tip commit in that case.

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -66,9 +66,9 @@ async def submit(
     )
     ```
     """
-    launched_job_command: str | None = None
-    if make_commit:
-        launched_job_command = build_submit_command(cluster, job_script, sbatch_args, program_args)
+    launched_job_command = (
+        build_submit_command(cluster, job_script, sbatch_args, program_args) if make_commit else None
+    )
 
     # Check git is clean locally (untracked files are fine) and capture current commit hash.
     git_commit = ensure_clean_git_state(

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -270,7 +270,7 @@ class TestEnsureCleanGitState:
         assert (
             ensure_clean_git_state(
                 autocommit=True,
-                launched_job_command_builder=lambda: launched_job_command,
+                submit_command=launched_job_command,
             )
             == "dddddddddddddddddddddddddddddddddddddddd"
         )
@@ -301,7 +301,7 @@ class TestEnsureCleanGitState:
 
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
 
-        with pytest.raises(ValueError, match="launched_job_command_builder is required"):
+        with pytest.raises(ValueError, match="submit_command is required"):
             ensure_clean_git_state(autocommit=True)
 
     def test_prefers_branch_tip_in_github_actions_detached_head(

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -218,7 +218,9 @@ class TestEnsureCleanGitState:
             assert kwargs.get("capture_output") is True
             assert kwargs.get("text") is True
             if command == ["git", "status", "--porcelain"]:
-                return subprocess.CompletedProcess(command, 0, stdout=" M cluv/cli/submit.py\n", stderr="")
+                return subprocess.CompletedProcess(
+                    command, 0, stdout=" M cluv/cli/submit.py\n", stderr=""
+                )
             raise AssertionError(f"Unexpected subprocess.run call: {command}")
 
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
@@ -292,7 +294,9 @@ class TestEnsureCleanGitState:
             assert kwargs.get("capture_output") is True
             assert kwargs.get("text") is True
             if command == ["git", "status", "--porcelain"]:
-                return subprocess.CompletedProcess(command, 0, stdout=" M cluv/cli/submit.py\n", stderr="")
+                return subprocess.CompletedProcess(
+                    command, 0, stdout=" M cluv/cli/submit.py\n", stderr=""
+                )
             raise AssertionError(f"Unexpected subprocess.run call: {command}")
 
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -193,6 +193,75 @@ class TestSubmitCliParsing:
 
 
 class TestEnsureCleanGitState:
+    def test_dirty_repo_without_make_commit_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def mock_subprocess_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+            assert kwargs.get("capture_output") is True
+            assert kwargs.get("text") is True
+            if command == ["git", "status", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, stdout=" M cluv/cli/submit.py\n", stderr="")
+            raise AssertionError(f"Unexpected subprocess.run call: {command}")
+
+        monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
+
+        with pytest.raises(SystemExit):
+            ensure_clean_git_state()
+
+    def test_make_commit_creates_commit_with_tracked_changes_and_command(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        command_calls: list[tuple[list[str], dict]] = []
+
+        def mock_subprocess_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+            command_calls.append((command, kwargs))
+            if command == ["git", "status", "--porcelain"]:
+                return subprocess.CompletedProcess(
+                    command, 0, stdout=" M cluv/cli/submit.py\n?? notes.txt\n", stderr=""
+                )
+            if command == ["git", "add", "-u"]:
+                assert kwargs.get("check") is True
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            if command[:2] == ["git", "commit"]:
+                assert kwargs.get("check") is True
+                assert command[2:4] == ["-m", "cluv submit: auto-commit tracked changes"]
+                assert command[4] == "-m"
+                assert (
+                    command[5]
+                    == "Launched job command:\n\ncluv submit --make-commit mila scripts/job.sh -- --flag"
+                )
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            raise AssertionError(f"Unexpected subprocess.run call: {command}")
+
+        def mock_subprocess_check_output(command: list[str], **kwargs) -> str:
+            assert kwargs.get("text") is True
+            if command == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                return "main\n"
+            if command == ["git", "rev-parse", "HEAD"]:
+                return "dddddddddddddddddddddddddddddddddddddddd\n"
+            raise AssertionError(f"Unexpected subprocess.check_output call: {command}")
+
+        monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
+        monkeypatch.setattr(subprocess, "check_output", mock_subprocess_check_output)
+
+        assert (
+            ensure_clean_git_state(
+                make_commit=True,
+                launched_job_command="cluv submit --make-commit mila scripts/job.sh -- --flag",
+            )
+            == "dddddddddddddddddddddddddddddddddddddddd"
+        )
+        assert [call[0] for call in command_calls[:3]] == [
+            ["git", "status", "--porcelain"],
+            ["git", "add", "-u"],
+            [
+                "git",
+                "commit",
+                "-m",
+                "cluv submit: auto-commit tracked changes",
+                "-m",
+                "Launched job command:\n\ncluv submit --make-commit mila scripts/job.sh -- --flag",
+            ],
+        ]
+
     def test_prefers_branch_tip_in_github_actions_detached_head(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -151,6 +151,7 @@ class TestSubmitCliParsing:
                 "job_script": None,
                 "sbatch_args": [],
                 "program_args": ["python", "main.py"],
+                "make_commit": False,
             }
         )
 
@@ -169,6 +170,7 @@ class TestSubmitCliParsing:
                 "job_script": None,
                 "sbatch_args": ["--mem=8G"],
                 "program_args": ["python", "main.py"],
+                "make_commit": False,
             }
         )
 
@@ -190,6 +192,7 @@ class TestSubmitCliParsing:
                 "job_script": job_script,
                 "sbatch_args": [],
                 "program_args": [],
+                "make_commit": False,
             }
         )
 
@@ -376,7 +379,7 @@ async def test_can_submit_on_current_cluster(
         cluv.cli.submit,
         ensure_clean_git_state.__name__,
         mock_ensure_clean_git_state := unittest.mock.Mock(
-            wraps=ensure_clean_git_state, side_effect=lambda: dummy_commit
+            wraps=ensure_clean_git_state, side_effect=lambda *args, **kwargs: dummy_commit
         ),
     )
     here = mock_current_cluster

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -7,6 +7,7 @@ import unittest.mock
 from pathlib import Path
 from unittest import mock
 
+
 import pytest
 
 import cluv.__main__ as cluv_main
@@ -15,6 +16,7 @@ import cluv.cli.submit
 import cluv.remote
 import cluv.utils
 from cluv.cli.submit import (
+    build_submit_command,
     ensure_clean_git_state,
     get_sbatch_command,
     submit,
@@ -209,9 +211,18 @@ class TestEnsureCleanGitState:
     def test_make_commit_creates_commit_with_tracked_changes_and_command(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        launched_job_command = "cluv submit --make-commit mila scripts/job.sh -- --flag"
+        launched_job_command = "cluv submit mila scripts/job.sh -- --flag"
         expected_commit_body = f"Launched job command:\n\n{launched_job_command}"
         command_calls: list[tuple[list[str], dict]] = []
+        assert (
+            build_submit_command(
+                cluster="mila",
+                job_script=Path("scripts/job.sh"),
+                sbatch_args=[],
+                program_args=["--flag"],
+            )
+            == launched_job_command
+        )
 
         def mock_subprocess_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
             command_calls.append((command, kwargs))

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -262,6 +262,21 @@ class TestEnsureCleanGitState:
             ],
         ]
 
+    def test_make_commit_without_command_raises_value_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def mock_subprocess_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+            assert kwargs.get("capture_output") is True
+            assert kwargs.get("text") is True
+            if command == ["git", "status", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, stdout=" M cluv/cli/submit.py\n", stderr="")
+            raise AssertionError(f"Unexpected subprocess.run call: {command}")
+
+        monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
+
+        with pytest.raises(ValueError, match="launched_job_command is required"):
+            ensure_clean_git_state(make_commit=True)
+
     def test_prefers_branch_tip_in_github_actions_detached_head(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -259,7 +259,7 @@ class TestEnsureCleanGitState:
         assert (
             ensure_clean_git_state(
                 make_commit=True,
-                launched_job_command=launched_job_command,
+                launched_job_command_builder=lambda: launched_job_command,
             )
             == "dddddddddddddddddddddddddddddddddddddddd"
         )
@@ -288,7 +288,7 @@ class TestEnsureCleanGitState:
 
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
 
-        with pytest.raises(ValueError, match="launched_job_command is required"):
+        with pytest.raises(ValueError, match="launched_job_command_builder is required"):
             ensure_clean_git_state(make_commit=True)
 
     def test_prefers_branch_tip_in_github_actions_detached_head(

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -209,6 +209,8 @@ class TestEnsureCleanGitState:
     def test_make_commit_creates_commit_with_tracked_changes_and_command(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        launched_job_command = "cluv submit --make-commit mila scripts/job.sh -- --flag"
+        expected_commit_body = f"Launched job command:\n\n{launched_job_command}"
         command_calls: list[tuple[list[str], dict]] = []
 
         def mock_subprocess_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
@@ -224,10 +226,7 @@ class TestEnsureCleanGitState:
                 assert kwargs.get("check") is True
                 assert command[2:4] == ["-m", "cluv submit: auto-commit tracked changes"]
                 assert command[4] == "-m"
-                assert (
-                    command[5]
-                    == "Launched job command:\n\ncluv submit --make-commit mila scripts/job.sh -- --flag"
-                )
+                assert command[5] == expected_commit_body
                 return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
             raise AssertionError(f"Unexpected subprocess.run call: {command}")
 
@@ -245,7 +244,7 @@ class TestEnsureCleanGitState:
         assert (
             ensure_clean_git_state(
                 make_commit=True,
-                launched_job_command="cluv submit --make-commit mila scripts/job.sh -- --flag",
+                launched_job_command=launched_job_command,
             )
             == "dddddddddddddddddddddddddddddddddddddddd"
         )
@@ -258,7 +257,7 @@ class TestEnsureCleanGitState:
                 "-m",
                 "cluv submit: auto-commit tracked changes",
                 "-m",
-                "Launched job command:\n\ncluv submit --make-commit mila scripts/job.sh -- --flag",
+                expected_commit_body,
             ],
         ]
 

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -238,9 +238,13 @@ class TestEnsureCleanGitState:
                 )
             if command == ["git", "add", "-u"]:
                 assert kwargs.get("check") is True
+                assert kwargs.get("capture_output") is True
+                assert kwargs.get("text") is True
                 return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
             if command[:2] == ["git", "commit"]:
                 assert kwargs.get("check") is True
+                assert kwargs.get("capture_output") is True
+                assert kwargs.get("text") is True
                 assert command[2:4] == ["-m", "cluv submit: auto-commit tracked changes"]
                 assert command[4] == "-m"
                 assert command[5] == expected_commit_body

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -208,7 +208,9 @@ class TestBuildSubmitCommand:
 
 
 class TestEnsureCleanGitState:
-    def test_dirty_repo_without_make_commit_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_ensure_clean_git_state_exits_when_repo_dirty_without_make_commit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         def mock_subprocess_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
             assert kwargs.get("capture_output") is True
             assert kwargs.get("text") is True
@@ -221,7 +223,7 @@ class TestEnsureCleanGitState:
         with pytest.raises(SystemExit):
             ensure_clean_git_state()
 
-    def test_make_commit_creates_commit_with_tracked_changes_and_command(
+    def test_ensure_clean_git_state_creates_commit_when_make_commit_enabled(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         launched_job_command = "cluv submit mila scripts/job.sh -- --flag"
@@ -276,7 +278,7 @@ class TestEnsureCleanGitState:
             ],
         ]
 
-    def test_make_commit_without_command_raises_value_error(
+    def test_ensure_clean_git_state_raises_when_make_commit_without_builder(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         def mock_subprocess_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -194,6 +194,19 @@ class TestSubmitCliParsing:
         )
 
 
+class TestBuildSubmitCommand:
+    def test_build_submit_command_with_program_args(self) -> None:
+        assert (
+            build_submit_command(
+                cluster="mila",
+                job_script=Path("scripts/job.sh"),
+                sbatch_args=[],
+                program_args=["--flag"],
+            )
+            == "cluv submit mila scripts/job.sh -- --flag"
+        )
+
+
 class TestEnsureCleanGitState:
     def test_dirty_repo_without_make_commit_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def mock_subprocess_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
@@ -214,15 +227,6 @@ class TestEnsureCleanGitState:
         launched_job_command = "cluv submit mila scripts/job.sh -- --flag"
         expected_commit_body = f"Launched job command:\n\n{launched_job_command}"
         command_calls: list[tuple[list[str], dict]] = []
-        assert (
-            build_submit_command(
-                cluster="mila",
-                job_script=Path("scripts/job.sh"),
-                sbatch_args=[],
-                program_args=["--flag"],
-            )
-            == launched_job_command
-        )
 
         def mock_subprocess_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
             command_calls.append((command, kwargs))

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -151,7 +151,7 @@ class TestSubmitCliParsing:
                 "job_script": None,
                 "sbatch_args": [],
                 "program_args": ["python", "main.py"],
-                "make_commit": False,
+                "autocommit": False,
             }
         )
 
@@ -170,7 +170,7 @@ class TestSubmitCliParsing:
                 "job_script": None,
                 "sbatch_args": ["--mem=8G"],
                 "program_args": ["python", "main.py"],
-                "make_commit": False,
+                "autocommit": False,
             }
         )
 
@@ -192,7 +192,7 @@ class TestSubmitCliParsing:
                 "job_script": job_script,
                 "sbatch_args": [],
                 "program_args": [],
-                "make_commit": False,
+                "autocommit": False,
             }
         )
 
@@ -211,7 +211,7 @@ class TestBuildSubmitCommand:
 
 
 class TestEnsureCleanGitState:
-    def test_ensure_clean_git_state_exits_when_repo_dirty_without_make_commit(
+    def test_ensure_clean_git_state_exits_when_repo_dirty_without_autocommit(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         def mock_subprocess_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
@@ -226,7 +226,7 @@ class TestEnsureCleanGitState:
         with pytest.raises(SystemExit):
             ensure_clean_git_state()
 
-    def test_ensure_clean_git_state_creates_commit_when_make_commit_enabled(
+    def test_ensure_clean_git_state_creates_commit_when_autocommit_enabled(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         launched_job_command = "cluv submit mila scripts/job.sh -- --flag"
@@ -267,7 +267,7 @@ class TestEnsureCleanGitState:
 
         assert (
             ensure_clean_git_state(
-                make_commit=True,
+                autocommit=True,
                 launched_job_command_builder=lambda: launched_job_command,
             )
             == "dddddddddddddddddddddddddddddddddddddddd"
@@ -285,7 +285,7 @@ class TestEnsureCleanGitState:
             ],
         ]
 
-    def test_ensure_clean_git_state_raises_when_make_commit_without_builder(
+    def test_ensure_clean_git_state_raises_when_autocommit_without_builder(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         def mock_subprocess_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
@@ -298,7 +298,7 @@ class TestEnsureCleanGitState:
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
 
         with pytest.raises(ValueError, match="launched_job_command_builder is required"):
-            ensure_clean_git_state(make_commit=True)
+            ensure_clean_git_state(autocommit=True)
 
     def test_prefers_branch_tip_in_github_actions_detached_head(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
It seems I can't push to #47, so I'm making a new PR.

This adds an `--autocommit` option to `cluv submit` that commits changes if the repo is dirty.

The copilot code was mostly fine, I just had to fix tests and I renamed the option.
