### PR TITLE
Set GIT_SSH_COMMAND for git operations

### DIFF
--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -368,7 +368,9 @@ async def clone_project(remote: Remote, project_state: ProjectStateOnCluster):
                 hide=False,
             )
             await remote.run(
-                f"git -C {git_root_path} pull {safe_remote_name} {safe_head_ref}", hide=False, env=gitenv
+                f"git -C {git_root_path} pull {safe_remote_name} {safe_head_ref}",
+                hide=False,
+                env=gitenv,
             )
             return
 

--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -283,10 +283,11 @@ async def clone_project(remote: Remote):
             display=False,
         )
     ).returncode == 0
+    gitenv = {"GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=accept-new"}
     if not _is_cloned_on_cluster:
         logger.debug(f"Project isn't cloned yet on {remote.hostname}.")
-        await remote.run(f"git clone {github_repo_url} {git_root_path}", hide=True)
-    await remote.run(f"git -C {git_root_path} fetch --all --prune", hide=True)
+        await remote.run(f"git clone {github_repo_url} {git_root_path}", hide=True, env=gitenv)
+    await remote.run(f"git -C {git_root_path} fetch --all --prune", hide=True, env=gitenv)
     if detached_head:
         github_head_ref = os.environ.get("GITHUB_HEAD_REF", "").strip()
         if github_head_ref:
@@ -303,7 +304,7 @@ async def clone_project(remote: Remote):
                 hide=False,
             )
             await remote.run(
-                f"git -C {git_root_path} pull {safe_remote_name} {safe_head_ref}", hide=False
+                f"git -C {git_root_path} pull {safe_remote_name} {safe_head_ref}", hide=False, env=gitenv
             )
             return
         current_git_commit = subprocess.getoutput("git rev-parse HEAD").strip()
@@ -313,7 +314,7 @@ async def clone_project(remote: Remote):
         )
     else:
         await remote.run(f"git -C {git_root_path} checkout {safe_current_git_branch}", hide=False)
-        await remote.run(f"git -C {git_root_path} pull", hide=False)
+        await remote.run(f"git -C {git_root_path} pull", hide=False, env=gitenv)
 
 
 async def _pull_datasets(source_remote: Remote, source_path: str, local_datasets_path: Path):

--- a/cluv/remote.py
+++ b/cluv/remote.py
@@ -55,6 +55,7 @@ class Remote:
         display: bool = True,
         warn: bool = False,
         hide: Hide = False,
+        env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         if sys.platform == "win32":
             raise NotImplementedError(
@@ -65,6 +66,9 @@ class Remote:
                 "See https://learn.microsoft.com/en-us/windows/wsl/install for a guide on "
                 "setting up WSL."
             )
+        if env:
+            env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
+            command = f"{env_prefix} {command}"
         ssh_command = (
             "ssh",
             *get_multiplexing_options_to_use(self.hostname),


### PR DESCRIPTION
We want to use git with `ssh -o StrictHostKeyChecking=accept-new` to facilitate first communication with GitHub (notably on clusters that default to StrictHostKeyChecking=yes rather than ask), which can be configured with the `GIT_SSH_COMMAND` environment variable. To this purpose, to keep the interface clean-ish, I'm adding an `env` parameter to `Remote.run`.
