### PR TITLE
Add support for job array in `cluv status`

### DIFF
--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -49,7 +49,7 @@ class ArrayTaskInfo:
 @dataclass
 class LiveJobInfo:
     cluster: str
-    state: str
+    state: str | None = None
     elapsed: str | None = None  # sacct Elapsed field (HH:MM:SS or D-HH:MM:SS)
     wait_time: str | None = None
     array_tasks: list[ArrayTaskInfo] | None = None
@@ -160,7 +160,7 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
             if parent_id in array_tasks:
                 array_tasks[parent_id].append(task)
             else:
-                jobs[parent_id] = LiveJobInfo(cluster=cluster, state="ARRAY")
+                jobs[parent_id] = LiveJobInfo(cluster=cluster)
                 array_tasks[parent_id] = [task]
         else:
             job_id = int(job_id_str.strip())
@@ -275,7 +275,7 @@ def _state_text(state: str) -> Text:
         return Text(state, style="blue")
     elif state in FAILED_JOB_STATES:
         return Text(state, style="red")
-    return Text(state or "—", style="dim")
+    return Text(state)
 
 
 def _bar(used: float, total: float, width: int = 10) -> Text:
@@ -391,27 +391,26 @@ def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobI
             submitted_str = job.submitted_at
 
         job_id = Text(str(job.job_id))
+        state_cell, wait_cell, elapsed_cell = None, None, None
+
         if info is not None:
-            state_cell = _state_text(info.state)
-            wait_cell = info.wait_time or "-"
-            elapsed_cell = info.elapsed or "-"
             if info.array_tasks:
                 job_id += Text(f" [{len(info.array_tasks)}]", style="dim")
                 state_cell = _count_states(info.array_tasks)
                 wait_cell, elapsed_cell = "/", "/"
-        else:
-            state_cell = Text("-", style="dim")
-            wait_cell = "-"
-            elapsed_cell = "-"
+            else:
+                state_cell = _state_text(info.state or "-")
+                wait_cell = info.wait_time
+                elapsed_cell = info.elapsed
 
         table.add_row(
             job.cluster,
             job_id,
             job.git_commit[:7],
             submitted_str,
-            state_cell,
-            wait_cell,
-            elapsed_cell,
+            state_cell or "-",
+            wait_cell or "-",
+            elapsed_cell or "-",
         )
 
     return table

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -266,7 +266,7 @@ async def get_cluster_status(cluster: str) -> ClusterStatus:
 # UI helpers
 # ---------------------------------------------------------------------------
 def _format_duration(duration: timedelta | None) -> str:
-    if not duration:
+    if duration is None:
         return ""
 
     d, rem = divmod(int(duration.total_seconds()), 86400)

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -476,6 +476,17 @@ async def get_job_infos(
         elif info.state in ("COMPLETED", "COMPLETING"):
             cluster_stats.completed += 1
 
+        if info.array_tasks:
+            for task in info.array_tasks:
+                if task.state == "RUNNING":
+                    cluster_stats.running += 1
+                elif task.state == "PENDING":
+                    cluster_stats.pending += 1
+                elif task.state in FAILED_JOB_STATES:
+                    cluster_stats.cancelled += 1
+                elif task.state in ("COMPLETED", "COMPLETING"):
+                    cluster_stats.completed += 1
+
     return live_info, clusters_job_stats
 
 

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -98,7 +98,7 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
     ids_str = ",".join(str(jid) for jid in job_ids)
     cmd = (
         f"sacct -j {ids_str} --format=JobID,State,Start,Submit,Elapsed"
-        f" --noheader --allocations --parsable2 2>/dev/null"
+        f" --noheader --allocations --array --parsable2 2>/dev/null"
     )
     try:
         remote = await get_remote_without_2fa_prompt(cluster)

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -29,11 +29,11 @@ __all__ = ["status"]
 
 
 @dataclass
-class JobStats:
-    my_running: int
-    my_pending: int
-    my_cancelled: int
-    my_completed: int
+class ClusterJobStats:
+    running: int
+    pending: int
+    cancelled: int
+    completed: int
 
 
 @dataclass
@@ -281,7 +281,7 @@ def _gpu_bar(idle: int, total: int, width: int = 10) -> Text:
 # Main display
 # ---------------------------------------------------------------------------
 def _build_cluster_table(
-    data: list[ClusterStatus], clusters_job_stats: dict[str, JobStats]
+    data: list[ClusterStatus], clusters_job_stats: dict[str, ClusterJobStats]
 ) -> Table:
     """Build the cluster overview table with live status info and job counts."""
     table = Table(
@@ -302,10 +302,10 @@ def _build_cluster_table(
     for c in data:
         status = Text("● ", style="bold green") if c.online else Text("⚠ ", style="bold red")
         job_stats = clusters_job_stats.get(
-            c.name, JobStats(my_running=0, my_cancelled=0, my_completed=0, my_pending=0)
+            c.name, ClusterJobStats(running=0, cancelled=0, completed=0, pending=0)
         )
         my_jobs = Text(
-            f"{job_stats.my_running} / {job_stats.my_pending} / {job_stats.my_cancelled} / {job_stats.my_completed}",
+            f"{job_stats.running} / {job_stats.pending} / {job_stats.cancelled} / {job_stats.completed}",
             style="cyan",
         )
 
@@ -394,7 +394,7 @@ def _build_legend() -> Panel:
 
 async def get_job_infos(
     cached_jobs: list[Job], clusters: list[str]
-) -> tuple[dict[int, LiveJobInfo], dict[str, JobStats]]:
+) -> tuple[dict[int, LiveJobInfo], dict[str, ClusterJobStats]]:
     """Fetch live job info for all cached jobs, and count job statuses per cluster."""
     # Regroup jobs by cluster
     cluster_jobs: dict[str, list[int]] = {}
@@ -409,19 +409,20 @@ async def get_job_infos(
     live_info = {jid: info for cluster_result in results for jid, info in cluster_result.items()}
 
     # Count jobs status per cluster
-    clusters_job_stats: dict[str, JobStats] = {}
+    clusters_job_stats: dict[str, ClusterJobStats] = {}
     for info in live_info.values():
         cluster_stats = clusters_job_stats.setdefault(
-            info.cluster, JobStats(my_running=0, my_cancelled=0, my_completed=0, my_pending=0)
+            info.cluster,
+            ClusterJobStats(running=0, cancelled=0, completed=0, pending=0),
         )
         if info.state == "RUNNING":
-            cluster_stats.my_running += 1
+            cluster_stats.running += 1
         elif info.state == "PENDING":
-            cluster_stats.my_pending += 1
+            cluster_stats.pending += 1
         elif info.state in FAILED_JOB_STATES:
-            cluster_stats.my_cancelled += 1
+            cluster_stats.cancelled += 1
         elif info.state in ("COMPLETED", "COMPLETING"):
-            cluster_stats.my_completed += 1
+            cluster_stats.completed += 1
 
     return live_info, clusters_job_stats
 

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -16,6 +16,7 @@ from cluv.config import get_cluv_config
 from cluv.slurm import (
     FAILED_JOB_STATES,
     StorageStats,
+    clean_job_state,
     parse_disk_quota,
     parse_diskusage_report,
     parse_partition_stats,
@@ -149,13 +150,13 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
             pass
 
         job_id_str = job_id_str.strip()
-        state = state.strip()
+        state = clean_job_state(state.strip())
 
-        # If member of a job array
+        # Handle array tasks separately so we can aggregate them under their parent job.
         if "_" in job_id_str:
             parent_id_str, task_idx = job_id_str.split("_", 1)
             parent_id = int(parent_id_str)
-            task = ArrayTaskInfo(task_idx, state, elapsed=elapsed_out, wait_time=wait_time)
+            task = ArrayTaskInfo(task_idx, state=state, elapsed=elapsed_out, wait_time=wait_time)
 
             if parent_id in array_tasks:
                 array_tasks[parent_id].append(task)
@@ -165,7 +166,7 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
         else:
             job_id = int(job_id_str.strip())
             jobs[job_id] = LiveJobInfo(
-                cluster=cluster, state=state.strip(), elapsed=elapsed_out, wait_time=wait_time
+                cluster=cluster, state=state, elapsed=elapsed_out, wait_time=wait_time
             )
 
     # Merge jobs and array_tasks

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from rich import box
 from rich.panel import Panel
@@ -22,13 +22,13 @@ from cluv.slurm import (
     parse_partition_stats,
     parse_savail,
     parse_sinfo_nodes,
+    parse_slurm_time,
+    parse_timestamp,
 )
 from cluv.utils import console
 
 logger = logging.getLogger(__name__)
 __all__ = ["status"]
-
-_fmt = "%Y-%m-%dT%H:%M:%S"
 
 
 @dataclass
@@ -43,16 +43,16 @@ class ClusterJobStats:
 class ArrayTaskInfo:
     task_idx: str
     state: str
-    elapsed: str | None
-    wait_time: str | None
+    elapsed: timedelta | None
+    wait_time: timedelta | None
 
 
 @dataclass
 class LiveJobInfo:
     cluster: str
-    state: str | None = None
-    elapsed: str | None = None  # sacct Elapsed field (HH:MM:SS or D-HH:MM:SS)
-    wait_time: str | None = None
+    state: str | None = None  # YYYY-MM-DDTHH:MM:SS
+    elapsed: timedelta | None = None  # sacct Elapsed field (HH:MM:SS or D-HH:MM:SS)
+    wait_time: timedelta | None = None
     array_tasks: list[ArrayTaskInfo] | None = None
 
 
@@ -118,6 +118,7 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
             logger.info(f"No connection to [bold]{cluster}[/bold]; skipping jobs")
             return {}
         raw = await remote.get_output(cmd, hide=True, warn=True, display=False)
+        console.log(raw)
     except Exception:
         return {}
 
@@ -133,30 +134,27 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
             continue
         job_id_str, state, start_str, submit_str, elapsed = parts
 
-        elapsed_val = elapsed.strip()
-        elapsed_out = elapsed_val if elapsed_val and elapsed_val != "00:00:00" else None
-
         wait_time = None
         try:
-            submit_dt = datetime.strptime(submit_str.strip(), _fmt).replace(tzinfo=timezone.utc)
-            start = start_str.strip()
-            if start and start not in ("Unknown", "None"):
-                start_dt = datetime.strptime(start, _fmt).replace(tzinfo=timezone.utc)
-                delta_s = int((start_dt - submit_dt).total_seconds())
+            submit_dt = parse_timestamp(submit_str).replace(tzinfo=timezone.utc)
+            start = start_str.strip()  # If the job haven't started yet
+            if start in ("Unknown", "None"):
+                wait_time = now - submit_dt
             else:
-                delta_s = int((now - submit_dt).total_seconds())
-            wait_time = _format_duration(max(delta_s, 0))
+                start_dt = parse_timestamp(start).replace(tzinfo=timezone.utc)
+                wait_time = start_dt - submit_dt
         except (ValueError, OverflowError):
             pass
 
         job_id_str = job_id_str.strip()
         state = clean_job_state(state.strip())
+        elapsed_time = parse_slurm_time(elapsed)
 
         # Handle array tasks separately so we can aggregate them under their parent job.
         if "_" in job_id_str:
             parent_id_str, task_idx = job_id_str.split("_", 1)
             parent_id = int(parent_id_str)
-            task = ArrayTaskInfo(task_idx, state=state, elapsed=elapsed_out, wait_time=wait_time)
+            task = ArrayTaskInfo(task_idx, state=state, elapsed=elapsed_time, wait_time=wait_time)
 
             if parent_id in array_tasks:
                 array_tasks[parent_id].append(task)
@@ -166,7 +164,7 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
         else:
             job_id = int(job_id_str.strip())
             jobs[job_id] = LiveJobInfo(
-                cluster=cluster, state=state, elapsed=elapsed_out, wait_time=wait_time
+                cluster=cluster, state=state, elapsed=elapsed_time, wait_time=wait_time
             )
 
     # Merge jobs and array_tasks
@@ -256,10 +254,17 @@ async def get_cluster_status(cluster: str) -> ClusterStatus:
 # ---------------------------------------------------------------------------
 # UI helpers
 # ---------------------------------------------------------------------------
-def _format_duration(total_seconds: int) -> str:
-    h, rem = divmod(total_seconds, 3600)
+def _format_duration(duration: timedelta | None) -> str:
+    if not duration:
+        return ""
+
+    d, rem = divmod(int(duration.total_seconds()), 86400)
+    h, rem = divmod(rem, 3600)
     m, s = divmod(rem, 60)
-    if h:
+
+    if d:
+        return f"{d}d{h:02d}h"
+    elif h:
         return f"{h}h{m:02d}m"
     elif m:
         return f"{m}m{s:02d}s"
@@ -401,8 +406,8 @@ def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobI
                 wait_time, elapsed_time = "/", "/"
             else:
                 state = _state_text(info.state or "-")
-                wait_time = info.wait_time
-                elapsed_time = info.elapsed
+                wait_time = _format_duration(info.wait_time)
+                elapsed_time = _format_duration(info.elapsed)
 
         table.add_row(
             job.cluster,

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -55,6 +55,19 @@ class LiveJobInfo:
     waited: timedelta | None = None
     array_tasks: list[ArrayTaskInfo] | None = None
 
+    def array_elapse_time(self) -> timedelta | None:
+        """Total elapse time for all the tasks in the array"""
+        if not self.array_tasks:
+            return None
+
+        sum_tasks = timedelta()
+        for task in self.array_tasks:
+            if task.elapsed is None:
+                continue
+            sum_tasks += task.elapsed
+
+        return sum_tasks
+
 
 @dataclass
 class ClusterStatus:
@@ -401,7 +414,8 @@ def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobI
             if info.array_tasks:
                 job_id += Text(f" [{len(info.array_tasks)}]", style="dim")
                 state = _count_states(info.array_tasks)
-                wait_time, elapsed_time = "/", "/"
+                wait_time = "/"
+                elapsed_time = _format_duration(info.array_elapse_time())
             else:
                 state = _state_text(info.state or "-")
                 wait_time = _format_duration(info.waited)

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -391,26 +391,26 @@ def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobI
             submitted_str = job.submitted_at
 
         job_id = Text(str(job.job_id))
-        state_cell, wait_cell, elapsed_cell = None, None, None
+        state, wait_time, elapsed_time = "-", "-", "-"
 
-        if info is not None:
+        if info:
             if info.array_tasks:
                 job_id += Text(f" [{len(info.array_tasks)}]", style="dim")
-                state_cell = _count_states(info.array_tasks)
-                wait_cell, elapsed_cell = "/", "/"
+                state = _count_states(info.array_tasks)
+                wait_time, elapsed_time = "/", "/"
             else:
-                state_cell = _state_text(info.state or "-")
-                wait_cell = info.wait_time
-                elapsed_cell = info.elapsed
+                state = _state_text(info.state or "-")
+                wait_time = info.wait_time
+                elapsed_time = info.elapsed
 
         table.add_row(
             job.cluster,
             job_id,
             job.git_commit[:7],
             submitted_str,
-            state_cell or "-",
-            wait_cell or "-",
-            elapsed_cell or "-",
+            state,
+            wait_time,
+            elapsed_time,
         )
 
     return table

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -27,6 +27,8 @@ from cluv.utils import console
 logger = logging.getLogger(__name__)
 __all__ = ["status"]
 
+_fmt = "%Y-%m-%dT%H:%M:%S"
+
 
 @dataclass
 class ClusterJobStats:
@@ -37,11 +39,20 @@ class ClusterJobStats:
 
 
 @dataclass
+class ArrayTaskInfo:
+    task_idx: str
+    state: str
+    elapsed: str | None
+    wait_time: str | None
+
+
+@dataclass
 class LiveJobInfo:
     cluster: str
     state: str
-    elapsed: str | None  # sacct Elapsed field (HH:MM:SS or D-HH:MM:SS)
-    wait_time: str | None  # formatted time from Submit to Start (or to now if still pending)
+    elapsed: str | None = None  # sacct Elapsed field (HH:MM:SS or D-HH:MM:SS)
+    wait_time: str | None = None
+    array_tasks: list[ArrayTaskInfo] | None = None
 
 
 @dataclass
@@ -109,9 +120,10 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
     except Exception:
         return {}
 
-    result: dict[int, LiveJobInfo] = {}
+    jobs: dict[int, LiveJobInfo] = {}
+    array_tasks: dict[int, list[ArrayTaskInfo]] = {}
+
     now = datetime.now(timezone.utc)
-    _fmt = "%Y-%m-%dT%H:%M:%S"
 
     for line in raw.splitlines():
         # Should have 5 columns
@@ -136,17 +148,36 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
         except (ValueError, OverflowError):
             pass
 
-        job_id = int(job_id_str.strip())
-        result[job_id] = LiveJobInfo(
-            cluster=cluster, state=state.strip(), elapsed=elapsed_out, wait_time=wait_time
-        )
+        job_id_str = job_id_str.strip()
+        state = state.strip()
+
+        # If member of a job array
+        if "_" in job_id_str:
+            parent_id_str, task_idx = job_id_str.split("_", 1)
+            parent_id = int(parent_id_str)
+            task = ArrayTaskInfo(task_idx, state, elapsed=elapsed_out, wait_time=wait_time)
+
+            if parent_id in array_tasks:
+                array_tasks[parent_id].append(task)
+            else:
+                jobs[parent_id] = LiveJobInfo(cluster=cluster, state="ARRAY")
+                array_tasks[parent_id] = [task]
+        else:
+            job_id = int(job_id_str.strip())
+            jobs[job_id] = LiveJobInfo(
+                cluster=cluster, state=state.strip(), elapsed=elapsed_out, wait_time=wait_time
+            )
+
+    # Merge jobs and array_tasks
+    for job_id, array in array_tasks.items():
+        jobs[job_id].array_tasks = array
 
     logger.info(
-        f"Fetched {len(result)} [bold]{cluster}[/bold] jobs in "
+        f"Fetched {len(jobs)} [bold]{cluster}[/bold] jobs in "
         f"{(datetime.now() - start_time).total_seconds()} seconds"
     )
 
-    return result
+    return jobs
 
 
 async def get_cluster_status(cluster: str) -> ClusterStatus:
@@ -359,10 +390,15 @@ def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobI
         except (ValueError, TypeError):
             submitted_str = job.submitted_at
 
+        job_id = Text(str(job.job_id))
         if info is not None:
             state_cell = _state_text(info.state)
             wait_cell = info.wait_time or "-"
             elapsed_cell = info.elapsed or "-"
+            if info.array_tasks:
+                job_id += Text(f" [{len(info.array_tasks)}]", style="dim")
+                state_cell = _count_states(info.array_tasks)
+                wait_cell, elapsed_cell = "/", "/"
         else:
             state_cell = Text("-", style="dim")
             wait_cell = "-"
@@ -370,7 +406,7 @@ def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobI
 
         table.add_row(
             job.cluster,
-            str(job.job_id),
+            job_id,
             job.git_commit[:7],
             submitted_str,
             state_cell,
@@ -379,6 +415,22 @@ def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobI
         )
 
     return table
+
+
+def _count_states(tasks: list[ArrayTaskInfo]) -> Text:
+    counter: dict[str, int] = {}
+
+    for task in tasks:
+        if task.state not in counter:
+            counter[task.state] = 1
+        else:
+            counter[task.state] += 1
+
+    total = Text()
+    for state, n in counter.items():
+        total += _state_text(state) + Text(f" [{n}] ", style="dim")
+
+    return total
 
 
 def _build_legend() -> Panel:

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -118,7 +118,6 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
             logger.info(f"No connection to [bold]{cluster}[/bold]; skipping jobs")
             return {}
         raw = await remote.get_output(cmd, hide=True, warn=True, display=False)
-        console.log(raw)
     except Exception:
         return {}
 

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -50,8 +50,8 @@ class ArrayTaskInfo:
 @dataclass
 class LiveJobInfo:
     cluster: str
-    state: str | None = None  # YYYY-MM-DDTHH:MM:SS
-    elapsed: timedelta | None = None  # sacct Elapsed field (HH:MM:SS or D-HH:MM:SS)
+    state: str | None = None
+    elapsed: timedelta | None = None
     wait_time: timedelta | None = None
     array_tasks: list[ArrayTaskInfo] | None = None
 

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -44,7 +44,7 @@ class ArrayTaskInfo:
     task_idx: str
     state: str
     elapsed: timedelta | None
-    wait_time: timedelta | None
+    waited: timedelta | None
 
 
 @dataclass
@@ -52,7 +52,7 @@ class LiveJobInfo:
     cluster: str
     state: str | None = None
     elapsed: timedelta | None = None
-    wait_time: timedelta | None = None
+    waited: timedelta | None = None
     array_tasks: list[ArrayTaskInfo] | None = None
 
 
@@ -123,7 +123,6 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
 
     jobs: dict[int, LiveJobInfo] = {}
     array_tasks: dict[int, list[ArrayTaskInfo]] = {}
-
     now = datetime.now(timezone.utc)
 
     for line in raw.splitlines():
@@ -131,29 +130,29 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
         parts = line.strip().split("|")
         if len(parts) != 5:
             continue
-        job_id_str, state, start_str, submit_str, elapsed = parts
+        job_id_str, state, start_str, submit_str, elapsed_str = parts
 
-        wait_time = None
+        waited = None
         try:
             submit_dt = parse_timestamp(submit_str).replace(tzinfo=timezone.utc)
             start = start_str.strip()  # If the job haven't started yet
             if start in ("Unknown", "None"):
-                wait_time = now - submit_dt
+                waited = now - submit_dt
             else:
                 start_dt = parse_timestamp(start).replace(tzinfo=timezone.utc)
-                wait_time = start_dt - submit_dt
+                waited = start_dt - submit_dt
         except (ValueError, OverflowError):
             pass
 
         job_id_str = job_id_str.strip()
         state = clean_job_state(state.strip())
-        elapsed_time = parse_slurm_time(elapsed)
+        elapsed = parse_slurm_time(elapsed_str)
 
         # Handle array tasks separately so we can aggregate them under their parent job.
         if "_" in job_id_str:
             parent_id_str, task_idx = job_id_str.split("_", 1)
             parent_id = int(parent_id_str)
-            task = ArrayTaskInfo(task_idx, state=state, elapsed=elapsed_time, wait_time=wait_time)
+            task = ArrayTaskInfo(task_idx, state=state, elapsed=elapsed, waited=waited)
 
             if parent_id in array_tasks:
                 array_tasks[parent_id].append(task)
@@ -163,7 +162,7 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
         else:
             job_id = int(job_id_str.strip())
             jobs[job_id] = LiveJobInfo(
-                cluster=cluster, state=state, elapsed=elapsed_time, wait_time=wait_time
+                cluster=cluster, state=state, elapsed=elapsed, waited=waited
             )
 
     # Merge jobs and array_tasks
@@ -405,7 +404,7 @@ def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobI
                 wait_time, elapsed_time = "/", "/"
             else:
                 state = _state_text(info.state or "-")
-                wait_time = _format_duration(info.wait_time)
+                wait_time = _format_duration(info.waited)
                 elapsed_time = _format_duration(info.elapsed)
 
         table.add_row(

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -10,7 +10,6 @@ import subprocess
 import sys
 from pathlib import Path, PurePosixPath
 
-import rich.panel
 import rich.syntax
 import rich.table
 import rich.text
@@ -20,7 +19,7 @@ from cluv.cache import Job, save_job
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_cluv_config
 from cluv.remote import Remote, run
-from cluv.slurm import FAILED_JOB_STATES
+from cluv.slurm import FAILED_JOB_STATES, clean_job_state
 from cluv.utils import console, current_cluster
 
 logger = logging.getLogger(__name__)
@@ -343,8 +342,7 @@ async def wait_for_jobs_to_cancel(
     )
     for (cluster, job_id), job_state in zip(to_cancel, job_states):
         logger.info(f"Job {job_id} on cluster {cluster} state: {job_state}")
-        if job_state.startswith("CANCELLED by"):
-            job_state = "CANCELLED"  # just to avoid confusing users.
+        job_state = clean_job_state(job_state)
         cluster_and_jobid_to_jobstate[(cluster, job_id)] = job_state
 
     to_cancel = [

--- a/cluv/slurm.py
+++ b/cluv/slurm.py
@@ -192,9 +192,7 @@ def parse_sinfo_nodes(output: str) -> tuple[int, int, list[str]]:
         if not matches:
             continue
 
-        entries: list[tuple[str, int]] = [
-            (model, int(count_str)) for model, count_str in matches
-        ]
+        entries: list[tuple[str, int]] = [(model, int(count_str)) for model, count_str in matches]
 
         for model, _ in entries:
             models.add(_normalize_gpu_model(model))
@@ -256,9 +254,9 @@ def parse_savail(output: str) -> tuple[int, int, list[str]]:
 # Columns: filesystem, used, soft-quota, hard-limit, ...
 # We want column 1 (used) and column 3 (hard limit = effective quota).
 _LFS_DATA_RE = re.compile(
-    r"^\s+\S*/home\S*\s+"          # filesystem path containing "home"
+    r"^\s+\S*/home\S*\s+"  # filesystem path containing "home"
     r"([\d.]+)\s*([KMGTP]i?[Bb]?)"  # used  + unit
-    r"\s+\S+"                        # soft quota (skip)
+    r"\s+\S+"  # soft quota (skip)
     r"\s+([\d.]+)\s*([KMGTP]i?[Bb]?)",  # hard limit + unit
 )
 
@@ -271,11 +269,21 @@ _BEEGFS_DATA_RE = re.compile(
 )
 
 _UNIT_TO_GIB: dict[str, float] = {
-    "K": 1 / 1024**2, "KB": 1 / 1024**2, "KiB": 1 / 1024**2,
-    "M": 1 / 1024,    "MB": 1 / 1024,    "MiB": 1 / 1024,
-    "G": 1.0,         "GB": 1.0,         "GiB": 1.0,
-    "T": 1024.0,      "TB": 1024.0,      "TiB": 1024.0,
-    "P": 1024**2,     "PB": 1024**2,     "PiB": 1024**2,
+    "K": 1 / 1024**2,
+    "KB": 1 / 1024**2,
+    "KiB": 1 / 1024**2,
+    "M": 1 / 1024,
+    "MB": 1 / 1024,
+    "MiB": 1 / 1024,
+    "G": 1.0,
+    "GB": 1.0,
+    "GiB": 1.0,
+    "T": 1024.0,
+    "TB": 1024.0,
+    "TiB": 1024.0,
+    "P": 1024**2,
+    "PB": 1024**2,
+    "PiB": 1024**2,
 }
 
 

--- a/cluv/slurm.py
+++ b/cluv/slurm.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 
 FAILED_JOB_STATES = ["FAILED", "CANCELLED", "TIMEOUT", "NODE_FAIL", "OUT_OF_MEMORY", "PREEMPTED"]
 
@@ -25,6 +26,25 @@ def clean_job_state(state: str) -> str:
     if "CANCELLED by" in state:
         return "CANCELLED"
     return state
+
+
+def parse_timestamp(timestamp: str) -> datetime:
+    return datetime.strptime(timestamp.strip(), "%Y-%m-%dT%H:%M:%S").replace(tzinfo=timezone.utc)
+
+
+def parse_slurm_time(time: str) -> timedelta:
+    """Parse a time value from the sbatch format to a timedelta object."""
+    # The SLURM time format is days-hours:minutes:seconds, with the days part optional.
+    match = re.match(r"(?:(\d+)-)?(\d{1,2}):(\d{2}):(\d{2})", time.strip())
+    if not match:
+        raise ValueError(f"Could not parse time value: {time}")
+
+    return timedelta(
+        days=int(match.group(1) or 0),
+        hours=int(match.group(2)),
+        minutes=int(match.group(3)),
+        seconds=int(match.group(4)),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/cluv/slurm.py
+++ b/cluv/slurm.py
@@ -10,13 +10,22 @@ from dataclasses import dataclass
 
 FAILED_JOB_STATES = ["FAILED", "CANCELLED", "TIMEOUT", "NODE_FAIL", "OUT_OF_MEMORY", "PREEMPTED"]
 
+
 @dataclass
 class StorageStats:
     """Disk usage as (used_gib, quota_gib) for $HOME and $SCRATCH."""
+
     home_used: float
     home_quota: float
     scratch_used: float
     scratch_quota: float
+
+
+def clean_job_state(state: str) -> str:
+    if "CANCELLED by" in state:
+        return "CANCELLED"
+    return state
+
 
 # ---------------------------------------------------------------------------
 # partition-stats (DRAC-only)

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -4,6 +4,8 @@ All tests are pure (no I/O, no SSH). Fixture strings are taken from real
 cluster output captured during development.
 """
 
+from datetime import timedelta
+
 import pytest
 
 from cluv.slurm import (
@@ -12,6 +14,7 @@ from cluv.slurm import (
     parse_partition_stats,
     parse_savail,
     parse_sinfo_nodes,
+    parse_slurm_time,
 )
 
 pytestmark = pytest.mark.timeout(10)
@@ -409,3 +412,13 @@ class TestParseDiskusageReport:
         assert storage.home_quota == 0.0
         assert storage.scratch_used == 0.0
         assert storage.scratch_quota == 0.0
+
+
+class TestParseTime:
+    def test_parse_slurm_time(self) -> None:
+        td = parse_slurm_time("12:28:45")
+        assert td == timedelta(hours=12, minutes=28, seconds=45)
+
+    def test_parse_slurm_time_with_day(self) -> None:
+        td = parse_slurm_time("07-12:28:45")
+        assert td == timedelta(days=7, hours=12, minutes=28, seconds=45)


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Add support for job array in `cluv status`.
   * Add [`--array`](https://slurm.schedmd.com/sacct.html#OPT_array) to the `sacct` command to make sure each job of the array have a dedicated line in the command output.
   * Show the size of the array in the `Job ID` column.
   * Show the status of the jobs in the array in the `Job status`.
   * Count the jobs in "My jobs".
* Rename `JobStats` to `ClusterJobStats`.
* Refactor wait time and elapse time handling of a job.
* Format `slurm.py`.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/

## Example
<img width="993" height="243" alt="Capture d’écran, le 2026-06-18 à 14 18 36" src="https://github.com/user-attachments/assets/249fc6e9-fb0e-40dd-b610-803140de7cb5" />
