### PR TITLE
Try to login to all clusters even if a connection fails

### DIFF
--- a/cluv/cli/login.py
+++ b/cluv/cli/login.py
@@ -34,14 +34,20 @@ async def login(clusters: list[str]) -> list[Remote]:
         )
     else:
         console.log("No active connections to any clusters found.")
+
     missing_connections = [cluster for cluster, remote in zip(clusters, connections) if not remote]
     if missing_connections:
         console.log(f"Will attempt to connect to the following clusters: {missing_connections}")
+
     # Need to do each thing sequentially to avoid triggering multiple 2FA prompts at the same time.
-    return [
-        remote if remote is not None else (await Remote.connect(cluster))
-        for cluster, remote in zip(clusters, connections)
-    ]
+    remotes: list[Remote] = []
+    for cluster, remote in zip(clusters, connections):
+        try:
+            remotes.append(remote if remote is not None else await Remote.connect(cluster))
+        except BaseException as e:
+            console.log(e, style="red")
+
+    return remotes
 
 
 async def get_remote_without_2fa_prompt(cluster_hostname: str) -> Remote | None:

--- a/cluv/cli/login.py
+++ b/cluv/cli/login.py
@@ -44,7 +44,7 @@ async def login(clusters: list[str]) -> list[Remote]:
     for cluster, remote in zip(clusters, connections):
         try:
             remotes.append(remote if remote is not None else await Remote.connect(cluster))
-        except BaseException as e:
+        except Exception as e:
             console.log(e, style="red")
 
     return remotes

--- a/cluv/remote.py
+++ b/cluv/remote.py
@@ -40,10 +40,10 @@ class Remote:
         """
         remote = cls(hostname)
         if not (await control_socket_is_running(hostname)):
-            result = await remote.run("echo OK", display=False, hide="out")
+            result = await remote.run("echo OK", display=False, warn=True, hide=True)
             if "OK" not in result.stdout:
                 raise RuntimeError(
-                    f"Some strange error occurred when connecting to hostname {hostname}: {result.stderr}"
+                    f"An error occurred when connecting to hostname {hostname}: {result.stderr}"
                 )
         return remote
 


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Refactor login connection handling to avoid stopping the command if the connection to a cluster fail.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
* Close #31 