### PR TITLE
Add a guide on how the cluv config is applied when submitting jobs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,3 +37,10 @@ uv run pytest -m "not integration"
 ```bash
 uv run pre-commit run --all-files
 ```
+
+### Docs
+
+Host a server to see changes in real time :
+```bash
+uv run mkdocs serve --livereload
+```

--- a/README.md
+++ b/README.md
@@ -51,47 +51,10 @@ See the [examples](examples) folder for sample projects using cluv. Each example
 
 ## Configuration
 
-Add a `[tool.cluv]` section to the `pyproject.toml` of your project. `cluv init` generates a default config, or you can write it by hand.
-See the config at the project root for an example, or refer to the schema below.
+Add a `[tool.cluv]` section to the `pyproject.toml` of your project to manage the behavior of the tool.
+The command `cluv init` will add a default config if it doesn't already exists in the `.toml`.
 
-### Top-level fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `clusters` | table | Per-cluster settings, keyed by SSH hostname from `~/.ssh/config`. |
-| `env` | table | Global environment variables applied to all clusters. |
-| `results_path` | string | Path relative to the project root for storing results. `cluv sync` rsyncs that directory back from each remote cluster. |
-
-### `[tool.cluv.clusters.<name>.env]`
-Environment variables for a specific cluster. Values here are merged on top of `[tool.cluv.env]` when submitting.
-
-### Variables priority
-Environment variables can be set at multiple levels when submitting jobs, with the following precedence (highest to lowest):
-1. Command-line arguments to `cluv submit`.
-2. Cluster-specific variables in `[tool.cluv.clusters.<name>.env]`
-3. Global variables in `[tool.cluv.env]`
-4. SBATCH directives inside the job script (e.g. `#SBATCH --export=VAR=value`)
-5. Default values from the cluster (e.g. `SBATCH_PARTITION`)
-
-### Example
-
-Here's an example `pyproject.toml` with cluv configuration for three clusters, and some global and cluster-specific environment variables:
-
-```toml
-[tool.cluv]
-results_path = "logs"
-
-[tool.cluv.env]
-SBATCH_TIMELIMIT = "3:00:00"
-WANDB_MODE = "offline"
-
-[tool.cluv.clusters.mila]
-env = { WANDB_MODE="online", SBATCH_PARTITION="long" }
-
-[tool.cluv.clusters.narval]
-
-[tool.cluv.clusters.tamia]
-```
+See the config at the project root for an example, or refer to the [docs](https://mila-iqia.github.io/cluv/).
 
 ## Commands
 

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -74,6 +74,9 @@ def init(path: Path | None = None) -> None:
     console.print()
     console.print("Next steps :")
     console.print(
+        "=>  Learn more how to use cluv with user guides : https://mila-iqia.github.io/cluv/"
+    )
+    console.print(
         "=> [bold] cluv login [/bold] : open a SSH connections to all configured clusters."
     )
     console.print(

--- a/docs/guides/submit-config.md
+++ b/docs/guides/submit-config.md
@@ -1,0 +1,138 @@
+# Configuring job submission with `cluv submit`
+
+`cluv submit` reads your `pyproject.toml` to build the final `sbatch` command. This guide explains
+which config fields are used, how global and per-cluster values are merged, and what is injected
+automatically.
+
+## Config fields used by `cluv submit`
+
+| Field | Scope | Purpose |
+|---|---|---|
+| `job_script_path` | global / per-cluster | Default job script when none is passed on the CLI |
+| `results_path` | global / per-cluster | Controls `SBATCH_OUTPUT` (where Slurm writes stdout/stderr) |
+| `env` | global / per-cluster | Extra environment variables exported before `sbatch` |
+| `sbatch_args` | global / per-cluster | Extra `sbatch` flags (e.g. `--time`, `--gpus`) |
+
+Per-cluster values are set under `[tool.cluv.clusters.<name>]`.
+
+## How global and per-cluster settings merge
+
+For both `env` and `sbatch_args`, per-cluster values are merged on top of the global defaults.
+A per-cluster key **overrides** the same global key; keys present only in the global config are
+kept as-is.
+
+```toml
+[tool.cluv]
+results_path = "$SCRATCH/results"
+
+[tool.cluv.env]
+SBATCH_MEM_PER_NODE = "16G"
+SBATCH_CPUS_PER_TASK = "4"
+
+[tool.cluv.sbatch_args]
+time = "4:00:00"
+gpus = "1"
+
+[tool.cluv.clusters.narval]
+results_path = "$SCRATCH/results/narval"
+
+[tool.cluv.clusters.narval.env]
+SBATCH_MEM_PER_NODE = "32G"           # overrides the global 16G on narval
+
+[tool.cluv.clusters.narval.sbatch_args]
+time = "12:00:00"             # overrides global time on narval
+```
+
+When submitting to `narval`, the effective settings are:
+
+- `env`: `SBATCH_MEM_PER_NODE=32G`, `SBATCH_CPUS_PER_TASK=4` (cluster overrides global, rest kept)
+- `sbatch_args`: `--time=12:00:00 --gpus=1` (cluster overrides global, rest kept)
+- `results_path`: `$SCRATCH/results/narval`
+
+When submitting to any other cluster, the global values apply.
+
+## What cluv injects automatically
+
+Regardless of your config, `cluv submit` always sets these variables before calling `sbatch`:
+
+| Variable | Value |
+|---|---|
+| `GIT_COMMIT` | SHA of the current local `HEAD` commit |
+| `SBATCH_JOB_NAME` | Your configured name (or the job script stem) prefixed with `cluv-` |
+| `SBATCH_OUTPUT` | `{results_path}/{cluster}_%j/slurm-%j.out` |
+
+`GIT_COMMIT` is available inside your job script, so you can use it to tag results or check out
+the exact commit that was running.
+
+!!! note "`SBATCH_OUTPUT` overrides `#SBATCH --output` in your script"
+    If your job script contains an `#SBATCH --output` directive, it will be silently overridden by
+    the value cluv computes from `results_path`. This is intentional — it lets `cluv sync` know
+    where to fetch results. You will see a warning in the console if this happens.
+
+## Variables priority
+
+Settings can reach `sbatch` through multiple levels. When the same option is set at more than one
+level, the following order applies — **higher rows win**:
+
+| Priority | Source | Mechanism |
+|---|---|---|
+| 1 | `cluv submit` CLI flags (e.g. `--time=1:00:00`) | sbatch CLI flag — appended last |
+| 2 | `[tool.cluv.clusters.<name>.sbatch_args]` | sbatch CLI flag — prepended before CLI flags |
+| 3 | `[tool.cluv.sbatch_args]` | sbatch CLI flag — base, overridden by cluster |
+| 4 | cluv auto-injected (`SBATCH_OUTPUT`, `SBATCH_JOB_NAME`) | `SBATCH_*` env var — set after merging user env |
+| 5 | `[tool.cluv.clusters.<name>.env]` | `SBATCH_*` env var — merged over global env |
+| 6 | `[tool.cluv.env]` | `SBATCH_*` env var — global baseline |
+| 7 | `#SBATCH` directives inside the job script | Slurm script directive |
+
+Two important things to understand about this table:
+
+**`sbatch_args` vs `env` are different mechanisms with different Slurm priorities.** Slurm itself
+resolves settings in the order: sbatch CLI flags > `SBATCH_*` env vars > `#SBATCH` script
+directives. This means a `time = "4:00:00"` entry in `sbatch_args` (rows 1–3) will always win
+over an `SBATCH_TIMELIMIT` entry in `env` (rows 4–6) for the same setting, regardless of where
+each was configured.
+
+**Cluv always controls `SBATCH_OUTPUT` and `SBATCH_JOB_NAME`.** These are set unconditionally
+after merging your `env` config (row 4), so they cannot be overridden through `[tool.cluv.env]`
+or `[tool.cluv.clusters.<name>.env]`. For `SBATCH_JOB_NAME`, cluv uses your configured value as
+the *base* and prepends `cluv-` to it — you can influence the name but not remove the prefix.
+Any `#SBATCH --output` directive in your job script will also be silently overridden by cluv's
+computed `SBATCH_OUTPUT`.
+
+## CLI flags and program args
+
+Extra flags passed on the command line are **appended after** the flags from config. For most
+sbatch options the last occurrence wins, so CLI flags effectively override config values for a
+single run.
+
+```console
+# Config sets --time=4:00:00; this run overrides it to 1:00:00
+cluv submit mila job.sh --time=1:00:00
+
+# Arguments after -- are forwarded to the job script, not to sbatch
+cluv submit mila job.sh --time=1:00:00 -- python train.py --lr 0.01
+```
+
+## Default job script
+
+If no job script is passed on the CLI, cluv uses the `job_script_path` configured for that
+cluster, falling back to the global `job_script_path`.
+
+```toml
+[tool.cluv]
+job_script_path = "scripts/job.sh"    # used by all clusters
+
+[tool.cluv.clusters.narval]
+job_script_path = "scripts/job_narval.sh"   # used only on narval
+```
+
+A submission without an explicit script then resolves as follows:
+
+```console
+cluv submit mila           # uses scripts/job.sh
+cluv submit narval         # uses scripts/job_narval.sh
+cluv submit narval job.sh  # always uses job.sh, ignoring config
+```
+
+If neither a CLI script nor a configured `job_script_path` exists for the target cluster, `cluv
+submit` exits with an error.

--- a/docs/guides/submit-config.md
+++ b/docs/guides/submit-config.md
@@ -22,7 +22,9 @@ For both `env` and `sbatch_args`, per-cluster values are merged on top of the gl
 A per-cluster key **overrides** the same global key; keys present only in the global config are
 kept as-is.
 
-```toml
+For example, the following config:
+
+```toml title="pyproject.toml"
 [tool.cluv]
 results_path = "$SCRATCH/results"
 
@@ -36,8 +38,8 @@ gpus = "1"
 results_path = "$SCRATCH/results/narval"
 
 [tool.cluv.clusters.narval.sbatch_args]
-mem = "32G"           # overrides the global 16G on narval
-time = "12:00:00"    # overrides global time on narval
+mem = "32G"             # overrides the global 16G on narval
+time = "12:00:00"       # overrides global time on narval
 ```
 
 When submitting to `narval`, the effective settings are:
@@ -66,35 +68,6 @@ the exact commit that was running.
     output dir based on the cluster the job runs on. The cluster name would otherwise have to
     be hard-coded in the job script file. You will see a warning in the console if this happens.
 
-## Variables priority
-
-Settings can reach `sbatch` through multiple levels. When the same option is set at more than one
-level, the following order applies — **higher rows win**:
-
-| Priority | Source | Mechanism |
-|---|---|---|
-| 1 | `cluv submit` CLI flags (e.g. `--time=1:00:00`) | sbatch CLI flag — appended last |
-| 2 | `[tool.cluv.clusters.<name>.sbatch_args]` | sbatch CLI flag — prepended before CLI flags |
-| 3 | `[tool.cluv.sbatch_args]` | sbatch CLI flag — base, overridden by cluster |
-| 4 | cluv auto-injected (`SBATCH_OUTPUT`, `SBATCH_JOB_NAME`) | `SBATCH_*` env var — set after merging user env |
-| 5 | `[tool.cluv.clusters.<name>.env]` | `SBATCH_*` env var — merged over global env |
-| 6 | `[tool.cluv.env]` | `SBATCH_*` env var — global baseline |
-| 7 | `#SBATCH` directives inside the job script | Slurm script directive |
-
-Two important things to understand about this table:
-
-**`sbatch_args` vs `env` are different mechanisms with different Slurm priorities.** Slurm itself
-resolves settings in the order: sbatch CLI flags > `SBATCH_*` env vars > `#SBATCH` script
-directives. This means a `time = "4:00:00"` entry in `sbatch_args` (rows 1–3) will always win
-over an `SBATCH_TIMELIMIT` entry in `env` (rows 4–6) for the same setting, regardless of where
-each was configured.
-
-**Cluv always controls `SBATCH_OUTPUT` and `SBATCH_JOB_NAME`.** These are set unconditionally
-after merging your `env` config (row 4), so they cannot be overridden through `[tool.cluv.env]`
-or `[tool.cluv.clusters.<name>.env]`. For `SBATCH_JOB_NAME`, cluv uses your configured value as
-the *base* and prepends `cluv-` to it — you can influence the name but not remove the prefix.
-Any `#SBATCH --output` directive in your job script will also be silently overridden by cluv's
-computed `SBATCH_OUTPUT`.
 
 ## CLI flags and program args
 
@@ -115,7 +88,7 @@ cluv submit mila job.sh --time=1:00:00 -- python train.py --lr 0.01
 If no job script is passed on the CLI, cluv uses the `job_script_path` configured for that
 cluster, falling back to the global `job_script_path`.
 
-```toml
+```toml title="pyproject.toml"
 [tool.cluv]
 job_script_path = "scripts/job.sh"    # used by all clusters
 
@@ -126,9 +99,9 @@ job_script_path = "scripts/job_narval.sh"   # used only on narval
 A submission without an explicit script then resolves as follows:
 
 ```console
-cluv submit mila           # uses scripts/job.sh
-cluv submit narval         # uses scripts/job_narval.sh
-cluv submit narval job.sh  # always uses job.sh, ignoring config
+cluv submit mila                # uses scripts/job.sh
+cluv submit narval              # uses scripts/job_narval.sh
+cluv submit narval new_job.sh   # uses new_job.sh, ignoring config
 ```
 
 If neither a CLI script nor a configured `job_script_path` exists for the target cluster, `cluv

--- a/docs/guides/submit-config.md
+++ b/docs/guides/submit-config.md
@@ -1,4 +1,4 @@
-# Configuring job submission with `cluv submit`
+# Configuring job submission
 
 `cluv submit` reads your `pyproject.toml` to build the final `sbatch` command. This guide explains
 which config fields are used, how global and per-cluster values are merged, and what is injected

--- a/docs/guides/submit-config.md
+++ b/docs/guides/submit-config.md
@@ -9,7 +9,8 @@ automatically.
 | Field | Scope | Purpose |
 |---|---|---|
 | `job_script_path` | global / per-cluster | Default job script when none is passed on the CLI |
-| `results_path` | global / per-cluster | Controls `SBATCH_OUTPUT` (where Slurm writes stdout/stderr) |
+| `project_dir` | global / per-cluster | Where the project is replicated on clusters. |
+| `results_path` | global / per-cluster | Results directory to sync back to the current cluster. |
 | `env` | global / per-cluster | Extra environment variables exported before `sbatch` |
 | `sbatch_args` | global / per-cluster | Extra `sbatch` flags (e.g. `--time`, `--gpus`) |
 
@@ -25,28 +26,23 @@ kept as-is.
 [tool.cluv]
 results_path = "$SCRATCH/results"
 
-[tool.cluv.env]
-SBATCH_MEM_PER_NODE = "16G"
-SBATCH_CPUS_PER_TASK = "4"
-
 [tool.cluv.sbatch_args]
+mem = "16G"
+cpus-per-task = 4
 time = "4:00:00"
 gpus = "1"
 
 [tool.cluv.clusters.narval]
 results_path = "$SCRATCH/results/narval"
 
-[tool.cluv.clusters.narval.env]
-SBATCH_MEM_PER_NODE = "32G"           # overrides the global 16G on narval
-
 [tool.cluv.clusters.narval.sbatch_args]
-time = "12:00:00"             # overrides global time on narval
+mem = "32G"           # overrides the global 16G on narval
+time = "12:00:00"    # overrides global time on narval
 ```
 
 When submitting to `narval`, the effective settings are:
 
-- `env`: `SBATCH_MEM_PER_NODE=32G`, `SBATCH_CPUS_PER_TASK=4` (cluster overrides global, rest kept)
-- `sbatch_args`: `--time=12:00:00 --gpus=1` (cluster overrides global, rest kept)
+- `sbatch_args`: `--mem=32G --cpus-per-task=4 --time=12:00:00 --gpus=1` (cluster overrides global, rest kept)
 - `results_path`: `$SCRATCH/results/narval`
 
 When submitting to any other cluster, the global values apply.
@@ -66,8 +62,9 @@ the exact commit that was running.
 
 !!! note "`SBATCH_OUTPUT` overrides `#SBATCH --output` in your script"
     If your job script contains an `#SBATCH --output` directive, it will be silently overridden by
-    the value cluv computes from `results_path`. This is intentional — it lets `cluv sync` know
-    where to fetch results. You will see a warning in the console if this happens.
+    the value cluv computes from `results_path`. This is intentional - it lets `cluv` change the
+    output dir based on the cluster the job runs on. The cluster name would otherwise have to
+    be hard-coded in the job script file. You will see a warning in the console if this happens.
 
 ## Variables priority
 


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Add a guide on how the cluv config is apply when submitting jobs with :
   * The configurable fields.
   * How the global and per-cluster fields are merge.
   * Variables priority (env variables vs command-line arguments)
   * What variables cluv modify (`SBATCH_OUTPUT` and `SBATCH_JOB_NAME`).
* Update `README.md` and `CONTRIBUTING.md`.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
* Close #110 