### PR TITLE
Fix `cluv status` not showing infos of current cluster

### DIFF
--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import shlex
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
@@ -13,6 +14,7 @@ from rich.text import Text
 from cluv.cache import Job, load_jobs
 from cluv.cli.login import get_remote_without_2fa_prompt
 from cluv.config import get_cluv_config
+from cluv.remote import run
 from cluv.slurm import (
     FAILED_JOB_STATES,
     StorageStats,
@@ -25,7 +27,7 @@ from cluv.slurm import (
     parse_slurm_time,
     parse_timestamp,
 )
-from cluv.utils import console
+from cluv.utils import console, current_cluster
 
 logger = logging.getLogger(__name__)
 __all__ = ["status"]
@@ -120,17 +122,22 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
     """Batch-fetch Slurm state, elapsed, and wait-time for a list of job IDs."""
     start_time = datetime.now()
 
+    remote = await get_remote_without_2fa_prompt(cluster)
+    if remote is None and cluster is not current_cluster():
+        logger.info(f"No connection to [bold]{cluster}[/bold]; skipping jobs")
+        return {}
+
     ids_str = ",".join(str(jid) for jid in job_ids)
     cmd = (
         f"sacct -j {ids_str} --format=JobID,State,Start,Submit,Elapsed"
         f" --noheader --allocations --array --parsable2 2>/dev/null"
     )
+
     try:
-        remote = await get_remote_without_2fa_prompt(cluster)
-        if remote is None:
-            logger.info(f"No connection to [bold]{cluster}[/bold]; skipping jobs")
-            return {}
-        raw = await remote.get_output(cmd, hide=True, warn=True, display=False)
+        if remote:
+            raw = await remote.get_output(cmd, hide=True, warn=True, display=False)
+        else:
+            raw = (await run(tuple(shlex.split(cmd)), hide=True)).stdout.strip()
     except Exception:
         return {}
 
@@ -202,19 +209,18 @@ async def get_cluster_status(cluster: str) -> ClusterStatus:
     # "current" cluster the way login() does. A working socket for mila is
     # perfectly usable even when /home/mila is mounted locally.
     remote = await get_remote_without_2fa_prompt(cluster)
-    if remote is None:
+    if remote is None and cluster is not current_cluster():
         logger.info(f"No connection to [bold]{cluster}[/bold]; returning empty status")
         return get_default_cluster_status(cluster)
 
     script = _REMOTE_SCRIPT_MILA if cluster in _MILA_CLUSTERS else _REMOTE_SCRIPT_DRAC
+    command = f"bash -l -c '{script}'"
 
     try:
-        raw = await remote.get_output(
-            f"bash -l -c '{script}'",
-            hide=True,
-            warn=True,
-            display=False,
-        )
+        if remote:
+            raw = await remote.get_output(command, hide=True, warn=True, display=False)
+        else:
+            raw = (await run(tuple(shlex.split(command)), hide=True)).stdout.strip()
     except Exception as exc:
         logger.warning(f"[red]Could not reach {cluster}: {exc}[/red]")
         return get_default_cluster_status(cluster)

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -26,6 +26,7 @@ from cluv.slurm import (
     parse_sinfo_nodes,
     parse_slurm_time,
     parse_timestamp,
+    sacct_job,
 )
 from cluv.utils import console, current_cluster
 
@@ -127,17 +128,12 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
         logger.info(f"No connection to [bold]{cluster}[/bold]; skipping jobs")
         return {}
 
-    ids_str = ",".join(str(jid) for jid in job_ids)
-    cmd = (
-        f"sacct -j {ids_str} --format=JobID,State,Start,Submit,Elapsed"
-        f" --noheader --allocations --array --parsable2"
-    )
+    ids_str = ",".join(str(id) for id in job_ids)
 
     try:
-        if remote:
-            raw = await remote.get_output(cmd, hide=True, warn=True, display=False)
-        else:
-            raw = (await run(tuple(shlex.split(cmd)), hide=True)).stdout.strip()
+        raw = await sacct_job(
+            remote, ids_str, format="JobID,State,Start,Submit,Elapsed", additional_args="--array"
+        )
     except Exception as exc:
         logger.warning(f"[red]Could not get jobs {ids_str} for {cluster}: {exc}[/red]")
         return {}

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -130,7 +130,7 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
     ids_str = ",".join(str(jid) for jid in job_ids)
     cmd = (
         f"sacct -j {ids_str} --format=JobID,State,Start,Submit,Elapsed"
-        f" --noheader --allocations --array --parsable2 2>/dev/null"
+        f" --noheader --allocations --array --parsable2"
     )
 
     try:
@@ -138,7 +138,8 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
             raw = await remote.get_output(cmd, hide=True, warn=True, display=False)
         else:
             raw = (await run(tuple(shlex.split(cmd)), hide=True)).stdout.strip()
-    except Exception:
+    except Exception as exc:
+        logger.warning(f"[red]Could not get jobs {ids_str} for {cluster}: {exc}[/red]")
         return {}
 
     jobs: dict[int, LiveJobInfo] = {}

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -123,7 +123,7 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
     start_time = datetime.now()
 
     remote = await get_remote_without_2fa_prompt(cluster)
-    if remote is None and cluster is not current_cluster():
+    if remote is None and cluster != current_cluster():
         logger.info(f"No connection to [bold]{cluster}[/bold]; skipping jobs")
         return {}
 
@@ -209,7 +209,7 @@ async def get_cluster_status(cluster: str) -> ClusterStatus:
     # "current" cluster the way login() does. A working socket for mila is
     # perfectly usable even when /home/mila is mounted locally.
     remote = await get_remote_without_2fa_prompt(cluster)
-    if remote is None and cluster is not current_cluster():
+    if remote is None and cluster != current_cluster():
         logger.info(f"No connection to [bold]{cluster}[/bold]; returning empty status")
         return get_default_cluster_status(cluster)
 

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -26,7 +26,7 @@ from cluv.slurm import (
     parse_sinfo_nodes,
     parse_slurm_time,
     parse_timestamp,
-    sacct_job,
+    run_sacct,
 )
 from cluv.utils import console, current_cluster
 
@@ -131,7 +131,7 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
     ids_str = ",".join(str(id) for id in job_ids)
 
     try:
-        raw = await sacct_job(
+        raw = await run_sacct(
             remote, ids_str, format="JobID,State,Start,Submit,Elapsed", additional_args="--array"
         )
     except Exception as exc:

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -16,11 +16,10 @@ import rich.text
 from rich.live import Live
 
 from cluv.cache import Job, save_job
-
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_cluv_config
 from cluv.remote import Remote, run
-from cluv.slurm import FAILED_JOB_STATES, clean_job_state
+from cluv.slurm import FAILED_JOB_STATES, clean_job_state, sacct_job
 from cluv.utils import console, current_cluster
 
 logger = logging.getLogger(__name__)
@@ -352,7 +351,7 @@ async def wait_for_running_job(
         wait_time = min(wait_time * 2, max_wait_time_seconds)
 
         job_states = await asyncio.gather(
-            *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_query)
+            *(sacct_job(cluster_to_remote[cluster], job_id) for cluster, job_id in to_query)
         )
 
         for (cluster, job_id), job_state in zip(to_query.copy(), job_states):
@@ -381,7 +380,7 @@ async def wait_for_jobs_to_cancel(
     to_cancel.remove((first_running_job.cluster, first_running_job.job_id))
 
     job_states = await asyncio.gather(
-        *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
+        *(sacct_job(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
     )
     for (cluster, job_id), job_state in zip(to_cancel, job_states):
         logger.info(f"Job {job_id} on cluster {cluster} state: {job_state}")
@@ -416,7 +415,7 @@ async def wait_for_jobs_to_cancel(
         wait_time = min(wait_time * 2, max_wait_time_seconds)
 
         job_states = await asyncio.gather(
-            *(get_job_state(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
+            *(sacct_job(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
         )
         logger.debug(f"Job states: {job_states}")
 
@@ -629,15 +628,6 @@ async def sbatch(
         return await remote.run(sbatch_command, display=False, warn=True, hide=True)
     # Run the sbatch command locally.
     return await run(tuple(shlex.split(sbatch_command)), _display=False, warn=True, hide=True)
-
-
-async def get_job_state(remote: Remote | None, job_id: int) -> str:
-    """Get the state of the job with the given id on the remote cluster with `sacct`."""
-    sacct_command = f"sacct -j {job_id} --format=State --parsable2 --noheader --allocations"
-    if remote:
-        return await remote.get_output(sacct_command, hide=True)
-    result = await run(tuple(shlex.split(sacct_command)), hide=True)
-    return result.stdout.strip()
 
 
 async def cancel_job(remote: Remote | None, job_id: int, print: bool = False) -> str:

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -19,7 +19,7 @@ from cluv.cache import Job, save_job
 from cluv.cli.sync import sync
 from cluv.config import find_pyproject, get_cluv_config
 from cluv.remote import Remote, run
-from cluv.slurm import FAILED_JOB_STATES, clean_job_state, sacct_job
+from cluv.slurm import FAILED_JOB_STATES, clean_job_state, run_sacct
 from cluv.utils import console, current_cluster
 
 logger = logging.getLogger(__name__)
@@ -351,7 +351,7 @@ async def wait_for_running_job(
         wait_time = min(wait_time * 2, max_wait_time_seconds)
 
         job_states = await asyncio.gather(
-            *(sacct_job(cluster_to_remote[cluster], job_id) for cluster, job_id in to_query)
+            *(run_sacct(cluster_to_remote[cluster], job_id) for cluster, job_id in to_query)
         )
 
         for (cluster, job_id), job_state in zip(to_query.copy(), job_states):
@@ -380,7 +380,7 @@ async def wait_for_jobs_to_cancel(
     to_cancel.remove((first_running_job.cluster, first_running_job.job_id))
 
     job_states = await asyncio.gather(
-        *(sacct_job(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
+        *(run_sacct(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
     )
     for (cluster, job_id), job_state in zip(to_cancel, job_states):
         logger.info(f"Job {job_id} on cluster {cluster} state: {job_state}")
@@ -415,7 +415,7 @@ async def wait_for_jobs_to_cancel(
         wait_time = min(wait_time * 2, max_wait_time_seconds)
 
         job_states = await asyncio.gather(
-            *(sacct_job(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
+            *(run_sacct(cluster_to_remote[cluster], job_id) for cluster, job_id in to_cancel)
         )
         logger.debug(f"Job states: {job_states}")
 

--- a/cluv/slurm.py
+++ b/cluv/slurm.py
@@ -6,8 +6,11 @@ All functions are free of I/O and can be unit-tested against fixture strings.
 from __future__ import annotations
 
 import re
+import shlex
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+
+from cluv.remote import Remote, run
 
 FAILED_JOB_STATES = ["FAILED", "CANCELLED", "TIMEOUT", "NODE_FAIL", "OUT_OF_MEMORY", "PREEMPTED"]
 
@@ -45,6 +48,20 @@ def parse_slurm_time(time: str) -> timedelta:
         minutes=int(match.group(3)),
         seconds=int(match.group(4)),
     )
+
+
+async def sacct_job(
+    remote: Remote | None, job_id: str | int, format: str = "State", additional_args: str = ""
+) -> str:
+    """Run sacct on the given job id(s) and return the output."""
+    sacct_command = (
+        f"sacct -j {job_id} --format={format} "
+        f"--parsable2 --noheader --allocations {additional_args}"
+    )
+    if remote:
+        return await remote.get_output(sacct_command, hide=True)
+    result = await run(tuple(shlex.split(sacct_command)), hide=True)
+    return result.stdout.strip()
 
 
 # ---------------------------------------------------------------------------

--- a/cluv/slurm.py
+++ b/cluv/slurm.py
@@ -50,13 +50,12 @@ def parse_slurm_time(time: str) -> timedelta:
     )
 
 
-async def sacct_job(
-    remote: Remote | None, job_id: str | int, format: str = "State", additional_args: str = ""
+async def run_sacct(
+    remote: Remote | None, jobs: str | int, format: str = "State", additional_args: str = ""
 ) -> str:
     """Run sacct on the given job id(s) and return the output."""
     sacct_command = (
-        f"sacct -j {job_id} --format={format} "
-        f"--parsable2 --noheader --allocations {additional_args}"
+        f"sacct -j {jobs} --format={format} --parsable2 --noheader --allocations {additional_args}"
     )
     if remote:
         return await remote.get_output(sacct_command, hide=True)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,10 +21,11 @@ from cluv.cache import Job
 from cluv.cli.init import DEFAULT_RESULTS_PATH, init
 from cluv.cli.login import get_remote_without_2fa_prompt, login
 from cluv.cli.status import ClusterStatus, get_cluster_status
-from cluv.cli.submit import get_job_state, submit
+from cluv.cli.submit import submit
 from cluv.cli.sync import sync
 from cluv.config import get_cluv_config, load_cluv_config
 from cluv.remote import Remote, control_socket_is_running
+from cluv.slurm import sacct_job
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -246,7 +247,7 @@ async def test_submit(remote: Remote, fake_scratch: Path):
             "DEADLINE",
         }
         async with asyncio.timeout(TEST_SUBMIT_TIMEOUT_SECONDS):
-            while (job_state := await get_job_state(remote, job_id)) not in TERMINAL_STATES:
+            while (job_state := await sacct_job(remote, job_id)) not in TERMINAL_STATES:
                 print(
                     f"Job {job_id} is in state {job_state}, waiting for it to reach a terminal state..."
                 )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,7 +25,7 @@ from cluv.cli.submit import submit
 from cluv.cli.sync import sync
 from cluv.config import get_cluv_config, load_cluv_config
 from cluv.remote import Remote, control_socket_is_running
-from cluv.slurm import sacct_job
+from cluv.slurm import run_sacct
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -247,7 +247,7 @@ async def test_submit(remote: Remote, fake_scratch: Path):
             "DEADLINE",
         }
         async with asyncio.timeout(TEST_SUBMIT_TIMEOUT_SECONDS):
-            while (job_state := await sacct_job(remote, job_id)) not in TERMINAL_STATES:
+            while (job_state := await run_sacct(remote, job_id)) not in TERMINAL_STATES:
                 print(
                     f"Job {job_id} is in state {job_state}, waiting for it to reach a terminal state..."
                 )

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -7,13 +7,13 @@ import unittest.mock
 from pathlib import Path
 from unittest import mock
 
-
 import pytest
 
 import cluv.__main__ as cluv_main
 import cluv.cli.init
 import cluv.cli.submit
 import cluv.remote
+import cluv.slurm
 import cluv.utils
 from cluv.cli.submit import (
     build_submit_command,
@@ -624,6 +624,9 @@ async def test_submit_first_considers_current_cluster(
 
     monkeypatch.setattr(
         cluv.remote, cluv.remote.run.__name__, _mock := unittest.mock.AsyncMock(wraps=fake_run)
+    )
+    monkeypatch.setattr(
+        cluv.slurm, cluv.slurm.run.__name__, _mock := unittest.mock.AsyncMock(wraps=fake_run)
     )
     monkeypatch.setattr(
         cluv.cli.submit,


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* `cluv status` now runs the commands to fetch the clusters and jobs infos locally if already on a cluster (ex: mila).

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
* Close #100 