### PR TITLE
docs: remove outdated claims, document undocumented features

### DIFF
--- a/docs/guides/introduction.md
+++ b/docs/guides/introduction.md
@@ -23,8 +23,10 @@ These are the main goals of Cluv:
 
 ### Easily dispatch jobs to different Slurm clusters
 - `cluv submit rorqual job.sh`: Synchronize the project and submit a job on the rorqual cluster.
-- `cluv submit auto job.sh`: Find the best cluster to run this job. I don't care where it runs.
+- `cluv submit first job.sh`: Submit the job on every configured cluster at once, keep whichever
+  one starts running first, and cancel the rest.
 - `cluv sync`: Fetch the results from the clusters where I ran jobs previously.
+- `cluv run mila -- nvidia-smi`: Sync the project and run a one-off command on a specific cluster.
 
 ### Intuitive monitoring of jobs and cluster health across clusters
 

--- a/docs/guides/introduction.md
+++ b/docs/guides/introduction.md
@@ -26,7 +26,7 @@ These are the main goals of Cluv:
 - `cluv submit first job.sh`: Submit the job on every configured cluster at once, keep whichever
   one starts running first, and cancel the rest.
 - `cluv sync`: Fetch the results from the clusters where I ran jobs previously.
-- `cluv run mila -- nvidia-smi`: Sync the project and run a one-off command on a specific cluster.
+- `cluv run mila -- ls logs`: Sync the project and run a command in the project dir on a cluster.
 
 ### Intuitive monitoring of jobs and cluster health across clusters
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,3 +59,13 @@ cluv sync rorqual
 ```console
 cluv submit rorqual scripts/job.sh --time=00:10:00 -- python main.py
 ```
+
+### Run a one-off command on a specific cluster
+```console
+cluv run mila -- nvidia-smi
+```
+
+### Check the status of your clusters and jobs
+```console
+cluv status
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,9 +60,9 @@ cluv sync rorqual
 cluv submit rorqual scripts/job.sh --time=00:10:00 -- python main.py
 ```
 
-### Run a one-off command on a specific cluster
+### Run a command in the synced project a specific cluster
 ```console
-cluv run mila -- nvidia-smi
+cluv run mila -- ls logs
 ```
 
 ### Check the status of your clusters and jobs

--- a/docs/reference/cli/status.md
+++ b/docs/reference/cli/status.md
@@ -1,0 +1,4 @@
+::: cluv.cli.status
+    options:
+        members:
+            - status


### PR DESCRIPTION
## Summary
- Removes a fabricated `cluv submit auto job.sh` line from the introduction guide — no such mode exists. The real special value is `first` (submit on every configured cluster, keep whichever starts first, cancel the rest), documented in its place.
- Documents `cluv run`, which is fully implemented but wasn't mentioned anywhere in the docs.
- Adds a `cluv status` quickstart example and a missing `docs/reference/cli/status.md` reference page (it was the only implemented CLI command without one).
- `docs/reference/config.md` and the other `docs/reference/cli/*.md` pages are mkdocstrings auto-renders of docstrings already in the code, so `project_dir`, per-cluster `sbatch_args`, `ignore`, and `--autocommit` were already accurately documented there — verified, no changes needed.
- `docs/guides/syncing-datasets.md` checked against `sync.py`/`config.py` and found accurate as-is.

Note: `CLAUDE.md` still claims `cluv init`/`cluv run` are unimplemented stubs — both are actually fully implemented. Left as-is since it's outside this PR's scope (agent instructions, not user docs).

## Test plan
- [x] `uv run mkdocs build --strict` — clean, no warnings
- [ ] Skim the rendered site locally (`uv run mkdocs serve`) to sanity-check the new/edited pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)