### PR TITLE
feat: add `cluv clean` command to remove pruned run results from clusters

### DIFF
--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -20,6 +20,7 @@ import rich.logging
 import rich_argparse
 import simple_parsing
 
+from .cli.clean import clean
 from .cli.init import init
 from .cli.login import login
 from .cli.run import run
@@ -70,6 +71,9 @@ def main(argv: list[str] | None = None) -> None:
 
     sync_parser = add_sync_args(subparsers)
     _add_v_arg(sync_parser)
+
+    clean_parser = add_clean_args(subparsers)
+    _add_v_arg(clean_parser)
 
     submit_parser = add_submit_args(subparsers)
     _add_v_arg(submit_parser)
@@ -225,6 +229,37 @@ def add_sync_args(subparsers: Subparsers):
     # )
     sync_parser.set_defaults(func=sync)
     return sync_parser
+
+
+def add_clean_args(subparsers: Subparsers):
+    clean_parser = subparsers.add_parser(
+        "clean",
+        help="Remove run results from clusters that have been deleted from the local results dir.",
+        formatter_class=rich_argparse.RichHelpFormatter,
+    )
+    clean_parser.add_argument(
+        "clusters",
+        nargs="*",
+        default=None,
+        metavar="<cluster>",
+        help=(
+            "The cluster(s) to clean. Leave empty to clean every cluster that has been "
+            "synced before."
+        ),
+    )
+    clean_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Skip the confirmation prompt.",
+    )
+    clean_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be deleted, without deleting anything.",
+    )
+    clean_parser.set_defaults(func=clean)
+    return clean_parser
 
 
 def add_login_args(subparsers: Subparsers):

--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -243,8 +243,8 @@ def add_clean_args(subparsers: Subparsers):
         default=None,
         metavar="<cluster>",
         help=(
-            "The cluster(s) to clean. Leave empty to clean every cluster that has been "
-            "synced before."
+            "The cluster(s) to clean. Leave empty to clean every currently logged in cluster "
+            "that has been synced before."
         ),
     )
     clean_parser.add_argument(

--- a/cluv/cache.py
+++ b/cluv/cache.py
@@ -38,6 +38,10 @@ class ProjectStateOnCluster:
     last_uv_sync_git_commit: str | None = None
     last_pushed_datasets: datetime | None = None
     checked_out_git_commit: str | None = None
+    last_fetch_watermark: datetime | None = None
+    """Max mtime seen among this cluster's `results_path` run dirs, as of the last
+    successful `fetch_results` call. Used by `cluv clean` to distinguish runs the
+    user pruned locally from runs that were never fetched."""
 
 
 @dataclass

--- a/cluv/cli/clean.py
+++ b/cluv/cli/clean.py
@@ -59,7 +59,7 @@ async def clean(
     clusters: list[str] | None = None,
     force: bool = False,
     dry_run: bool = False,
-) -> None:
+) -> dict[str, list[str]]:
     """Removes run directories from remote clusters that were pruned from the local results dir.
 
     Does not run `sync` first: it only reads state cached by the last successful sync of each
@@ -67,6 +67,8 @@ async def clean(
     to distinguish a pruned run from one that's simply never been fetched. Running or pending
     Slurm jobs, and cross-cluster run-name collisions, are not specially handled (see the design
     spec's "Non-goals" section).
+
+    Returns a dictionary mapping from cluster hostname to a list of run directories that were removed.
     """
     logger.info(f"Starting cluv clean: clusters={clusters}, force={force}, dry_run={dry_run}")
     config = get_cluv_config()
@@ -119,11 +121,16 @@ async def clean(
     if not per_cluster_to_delete:
         logger.info("Nothing to clean.")
         console.print("[green]Nothing to clean.[/green]")
-        return
+        return {}
+
+    def _y_or_ies(n: int) -> str:
+        return "y" if n == 1 else "ies"
 
     total = sum(len(names) for names in per_cluster_to_delete.values())
-    logger.info(f"{total} run director{'y' if total == 1 else 'ies'} eligible for deletion")
-    console.print("[bold]The following run directories will be removed:[/bold]")
+    logger.info(f"{total} run director{_y_or_ies(total)} eligible for deletion")
+    console.print(
+        f"[bold]The following run directories {'would' if dry_run else 'will'} be removed:[/bold]"
+    )
     for cluster, names in per_cluster_to_delete.items():
         console.print(f"  [cyan]{cluster}[/cyan]:")
         for name in names:
@@ -131,20 +138,21 @@ async def clean(
 
     if dry_run:
         logger.info("Dry run: not deleting anything.")
-        return
+        return per_cluster_to_delete
 
     if not force and not Confirm.ask(
-        f"Delete {total} run director{'y' if total == 1 else 'ies'} across "
+        f"Delete {total} run director{_y_or_ies(total)} across "
         f"{len(per_cluster_to_delete)} cluster(s)?",
         default=False,
     ):
         logger.info("User declined to delete. Aborting.")
         console.print("Aborted.")
-        return
+        return {}
 
     remote_by_hostname = {remote.hostname: remote for remote in remotes}
     removed = 0
     failed: list[tuple[str, str]] = []
+    actually_removed_per_cluster: dict[str, list[str]] = {}
     for cluster, names in per_cluster_to_delete.items():
         remote = remote_by_hostname[cluster]
         cluster_config = config.get_cluster_config(cluster)
@@ -158,14 +166,12 @@ async def clean(
                 failed.append((cluster, name))
             else:
                 removed += 1
-
-    logger.info(
-        f"Removed {removed} run director{'y' if removed == 1 else 'ies'}; {len(failed)} failed"
-    )
-    console.print(
-        f"[green]Removed {removed} run director{'y' if removed == 1 else 'ies'}.[/green]"
-    )
+                actually_removed_per_cluster.setdefault(cluster, []).append(name)
+    logger.info(f"Removed {removed} run director{_y_or_ies(removed)}; {len(failed)} failed")
+    console.print(f"[green]Removed {removed} run director{_y_or_ies(removed)}.[/green]")
     if failed:
         console.print(f"[red]Failed to remove {len(failed)}:[/red]")
         for cluster, name in failed:
             console.print(f"  {cluster}: {name}")
+
+    return actually_removed_per_cluster

--- a/cluv/cli/clean.py
+++ b/cluv/cli/clean.py
@@ -1,0 +1,51 @@
+"""`cluv clean`: remove run results from clusters once they're gone from the local results dir."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+# Unused until clean()'s body is implemented (Task 5) -- kept here now as monkeypatch
+# targets for tests/test_clean.py's orchestration tests.
+from rich.prompt import Confirm  # noqa: F401
+from cluv.cache import CacheContent, read_cache  # noqa: F401
+from cluv.cli.login import login  # noqa: F401
+from cluv.cli.sync import expandvars, get_active_remotes  # noqa: F401
+from cluv.config import get_cluv_config  # noqa: F401
+from cluv.remote import Remote, list_remote_run_dirs  # noqa: F401
+from cluv.utils import console  # noqa: F401
+
+__all__ = ["clean", "compute_runs_to_delete"]
+
+
+def compute_runs_to_delete(
+    local_names: set[str],
+    remote_runs: list[tuple[str, datetime]],
+    watermark: datetime | None,
+) -> list[str]:
+    """Returns the names of remote run dirs that are safe to delete.
+
+    A remote run dir is safe to delete only if it has no local counterpart AND it's
+    older than `watermark` (the max remote mtime observed during the last successful
+    sync of that cluster). A genuinely new, never-fetched run always has
+    `mtime >= watermark`, so it's never selected even though it also has no local
+    counterpart -- only runs the user pruned locally are.
+
+    Returns an empty list if `watermark` is `None` (the cluster has never been synced).
+    """
+    raise NotImplementedError
+
+
+async def clean(
+    clusters: list[str] | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> None:
+    """Removes run directories from remote clusters that were pruned from the local results dir.
+
+    Does not run `sync` first: it only reads state cached by the last successful sync of each
+    cluster. Clusters that have never been synced are skipped, since there is no watermark yet
+    to distinguish a pruned run from one that's simply never been fetched. Running or pending
+    Slurm jobs, and cross-cluster run-name collisions, are not specially handled (see the design
+    spec's "Non-goals" section).
+    """
+    raise NotImplementedError

--- a/cluv/cli/clean.py
+++ b/cluv/cli/clean.py
@@ -96,13 +96,15 @@ async def clean(
     logger.debug(f"Local run dirs in {results_path_here}: {sorted(local_names)}")
 
     per_cluster_to_delete: dict[str, list[str]] = {}
-    skipped: list[str] = []
     for remote in remotes:
         cluster = remote.hostname
         watermark = _watermark_for(cache, cluster)
         if watermark is None:
             logger.debug(f"{cluster}: no fetch watermark cached, skipping")
-            skipped.append(cluster)
+            console.print(
+                f"Skipping {cluster}: never synced. Run `cluv sync {cluster}` first.",
+                style="yellow",
+            )
             continue
         cluster_config = config.get_cluster_config(cluster)
         results_path_on_cluster = await expandvars(remote, cluster_config.results_path)
@@ -113,11 +115,6 @@ async def clean(
         to_delete = compute_runs_to_delete(local_names, remote_runs, watermark)
         if to_delete:
             per_cluster_to_delete[cluster] = to_delete
-
-    for cluster in skipped:
-        console.print(
-            f"Skipping {cluster}: never synced. Run `cluv sync {cluster}` first.", style="yellow"
-        )
 
     if not per_cluster_to_delete:
         logger.info("Nothing to clean.")

--- a/cluv/cli/clean.py
+++ b/cluv/cli/clean.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from rich.prompt import Confirm
 
-from cluv.cache import CacheContent, read_cache
+from cluv.cache import CacheContent, get_disabled_clusters, read_cache
 from cluv.cli.login import login
 from cluv.cli.sync import expandvars, get_active_remotes
 from cluv.config import get_cluv_config

--- a/cluv/cli/clean.py
+++ b/cluv/cli/clean.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 from datetime import datetime
+from pathlib import Path
 
-# Unused until clean()'s body is implemented (Task 5) -- kept here now as monkeypatch
-# targets for tests/test_clean.py's orchestration tests.
-from rich.prompt import Confirm  # noqa: F401
-from cluv.cache import CacheContent, read_cache  # noqa: F401
-from cluv.cli.login import login  # noqa: F401
-from cluv.cli.sync import expandvars, get_active_remotes  # noqa: F401
-from cluv.config import get_cluv_config  # noqa: F401
-from cluv.remote import Remote, list_remote_run_dirs  # noqa: F401
-from cluv.utils import console  # noqa: F401
+from rich.prompt import Confirm
+
+from cluv.cache import CacheContent, read_cache
+from cluv.cli.login import login
+from cluv.cli.sync import expandvars, get_active_remotes
+from cluv.config import get_cluv_config
+from cluv.remote import list_remote_run_dirs
+from cluv.utils import console
 
 __all__ = ["clean", "compute_runs_to_delete"]
 
@@ -32,7 +34,16 @@ def compute_runs_to_delete(
 
     Returns an empty list if `watermark` is `None` (the cluster has never been synced).
     """
-    raise NotImplementedError
+    if watermark is None:
+        return []
+    return sorted(
+        name for name, mtime in remote_runs if name not in local_names and mtime < watermark
+    )
+
+
+def _watermark_for(cache: CacheContent, cluster: str) -> datetime | None:
+    project_state = cache.project_states.get(cluster)
+    return project_state.last_fetch_watermark if project_state else None
 
 
 async def clean(
@@ -48,4 +59,88 @@ async def clean(
     Slurm jobs, and cross-cluster run-name collisions, are not specially handled (see the design
     spec's "Non-goals" section).
     """
-    raise NotImplementedError
+    config = get_cluv_config()
+
+    all_remotes = await get_active_remotes()
+    if clusters:
+        remotes = await login(clusters)
+    elif not all_remotes:
+        raise RuntimeError(
+            "[red]Not currently connected to any Slurm cluster.[/red] "
+            "Use `cluv login` to login and create reusable connections."
+        )
+    else:
+        remotes = all_remotes.copy()
+
+    cache = read_cache()
+    results_path_here = Path(os.path.expandvars(config.results_path))
+    local_names = (
+        {p.name for p in results_path_here.iterdir() if p.is_dir()}
+        if results_path_here.exists()
+        else set()
+    )
+
+    per_cluster_to_delete: dict[str, list[str]] = {}
+    skipped: list[str] = []
+    for remote in remotes:
+        cluster = remote.hostname
+        watermark = _watermark_for(cache, cluster)
+        if watermark is None:
+            skipped.append(cluster)
+            continue
+        cluster_config = config.get_cluster_config(cluster)
+        results_path_on_cluster = await expandvars(remote, cluster_config.results_path)
+        remote_runs = await list_remote_run_dirs(remote, results_path_on_cluster)
+        to_delete = compute_runs_to_delete(local_names, remote_runs, watermark)
+        if to_delete:
+            per_cluster_to_delete[cluster] = to_delete
+
+    for cluster in skipped:
+        console.print(
+            f"[yellow]Skipping {cluster}: never synced. Run `cluv sync {cluster}` first.[/yellow]"
+        )
+
+    if not per_cluster_to_delete:
+        console.print("[green]Nothing to clean.[/green]")
+        return
+
+    total = sum(len(names) for names in per_cluster_to_delete.values())
+    console.print("[bold]The following run directories will be removed:[/bold]")
+    for cluster, names in per_cluster_to_delete.items():
+        console.print(f"  [cyan]{cluster}[/cyan]:")
+        for name in names:
+            console.print(f"    {name}")
+
+    if dry_run:
+        return
+
+    if not force and not Confirm.ask(
+        f"Delete {total} run director{'y' if total == 1 else 'ies'} across "
+        f"{len(per_cluster_to_delete)} cluster(s)?",
+        default=False,
+    ):
+        console.print("Aborted.")
+        return
+
+    remote_by_hostname = {remote.hostname: remote for remote in remotes}
+    removed = 0
+    failed: list[tuple[str, str]] = []
+    for cluster, names in per_cluster_to_delete.items():
+        remote = remote_by_hostname[cluster]
+        cluster_config = config.get_cluster_config(cluster)
+        results_path_on_cluster = await expandvars(remote, cluster_config.results_path)
+        for name in names:
+            try:
+                await remote.run(f"rm -rf {results_path_on_cluster / name}", hide=True)
+            except subprocess.CalledProcessError:
+                failed.append((cluster, name))
+            else:
+                removed += 1
+
+    console.print(
+        f"[green]Removed {removed} run director{'y' if removed == 1 else 'ies'}.[/green]"
+    )
+    if failed:
+        console.print(f"[red]Failed to remove {len(failed)}:[/red]")
+        for cluster, name in failed:
+            console.print(f"  {cluster}: {name}")

--- a/cluv/cli/clean.py
+++ b/cluv/cli/clean.py
@@ -75,7 +75,8 @@ async def clean(
 
     all_remotes = await get_active_remotes()
     if clusters:
-        remotes = await login(clusters)
+        disabled = get_disabled_clusters()
+        remotes = await login(clusters, disabled)
     elif not all_remotes:
         raise RuntimeError(
             "[red]Not currently connected to any Slurm cluster.[/red] "
@@ -115,12 +116,12 @@ async def clean(
 
     for cluster in skipped:
         console.print(
-            f"[yellow]Skipping {cluster}: never synced. Run `cluv sync {cluster}` first.[/yellow]"
+            f"Skipping {cluster}: never synced. Run `cluv sync {cluster}` first.", style="yellow"
         )
 
     if not per_cluster_to_delete:
         logger.info("Nothing to clean.")
-        console.print("[green]Nothing to clean.[/green]")
+        console.print("Nothing to clean.", style="green")
         return {}
 
     def _y_or_ies(n: int) -> str:
@@ -132,7 +133,7 @@ async def clean(
         f"[bold]The following run directories {'would' if dry_run else 'will'} be removed:[/bold]"
     )
     for cluster, names in per_cluster_to_delete.items():
-        console.print(f"  [cyan]{cluster}[/cyan]:")
+        console.print(f"  {cluster}:", style="cyan")
         for name in names:
             console.print(f"    {name}")
 
@@ -168,9 +169,9 @@ async def clean(
                 removed += 1
                 actually_removed_per_cluster.setdefault(cluster, []).append(name)
     logger.info(f"Removed {removed} run director{_y_or_ies(removed)}; {len(failed)} failed")
-    console.print(f"[green]Removed {removed} run director{_y_or_ies(removed)}.[/green]")
+    console.print(f"Removed {removed} run director{_y_or_ies(removed)}.", style="green")
     if failed:
-        console.print(f"[red]Failed to remove {len(failed)}:[/red]")
+        console.print(f"Failed to remove {len(failed)}:", style="red")
         for cluster, name in failed:
             console.print(f"  {cluster}: {name}")
 

--- a/cluv/cli/clean.py
+++ b/cluv/cli/clean.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shlex
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -156,9 +157,13 @@ async def clean(
         cluster_config = config.get_cluster_config(cluster)
         results_path_on_cluster = await expandvars(remote, cluster_config.results_path)
         for name in names:
-            logger.debug(f"Removing {cluster}:{results_path_on_cluster / name}")
+            dir_to_remove_on_cluster = shlex.quote(str(results_path_on_cluster / name))
+            if name.strip() in ["", ".", ".."]:
+                logger.warning(f"Skipping {cluster}:{dir_to_remove_on_cluster}: invalid name")
+                continue
+            logger.debug(f"Removing {cluster}:{dir_to_remove_on_cluster}")
             try:
-                await remote.run(f"rm -rf {results_path_on_cluster / name}", hide=True)
+                await remote.run(f"rm -rf {dir_to_remove_on_cluster}", hide=True)
             except subprocess.CalledProcessError as err:
                 logger.warning(f"Failed to remove {cluster}:{name}: {err}")
                 failed.append((cluster, name))

--- a/cluv/cli/clean.py
+++ b/cluv/cli/clean.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 from datetime import datetime
@@ -18,6 +19,8 @@ from cluv.utils import console
 
 __all__ = ["clean", "compute_runs_to_delete"]
 
+logger = logging.getLogger(__name__)
+
 
 def compute_runs_to_delete(
     local_names: set[str],
@@ -26,19 +29,25 @@ def compute_runs_to_delete(
 ) -> list[str]:
     """Returns the names of remote run dirs that are safe to delete.
 
-    A remote run dir is safe to delete only if it has no local counterpart AND it's
-    older than `watermark` (the max remote mtime observed during the last successful
-    sync of that cluster). A genuinely new, never-fetched run always has
-    `mtime >= watermark`, so it's never selected even though it also has no local
-    counterpart -- only runs the user pruned locally are.
+    A remote run dir is safe to delete only if it has no local counterpart AND it was already
+    visible during the last successful sync of that cluster, i.e. `mtime <= watermark` (the max
+    remote mtime observed during that sync). A genuinely new, never-fetched run always has
+    `mtime > watermark`, so it's never selected even though it also has no local counterpart --
+    only runs the user pruned locally are.
 
     Returns an empty list if `watermark` is `None` (the cluster has never been synced).
     """
     if watermark is None:
         return []
-    return sorted(
-        name for name, mtime in remote_runs if name not in local_names and mtime < watermark
+    to_delete = sorted(
+        name for name, mtime in remote_runs if name not in local_names and mtime <= watermark
     )
+    logger.debug(
+        f"watermark={watermark.isoformat()}, "
+        f"remote_runs={[(name, mtime.isoformat()) for name, mtime in remote_runs]}, "
+        f"local_names={sorted(local_names)}, to_delete={to_delete}"
+    )
+    return to_delete
 
 
 def _watermark_for(cache: CacheContent, cluster: str) -> datetime | None:
@@ -59,6 +68,7 @@ async def clean(
     Slurm jobs, and cross-cluster run-name collisions, are not specially handled (see the design
     spec's "Non-goals" section).
     """
+    logger.info(f"Starting cluv clean: clusters={clusters}, force={force}, dry_run={dry_run}")
     config = get_cluv_config()
 
     all_remotes = await get_active_remotes()
@@ -71,6 +81,7 @@ async def clean(
         )
     else:
         remotes = all_remotes.copy()
+    logger.debug(f"Cleaning on remotes: {[remote.hostname for remote in remotes]}")
 
     cache = read_cache()
     results_path_here = Path(os.path.expandvars(config.results_path))
@@ -79,6 +90,7 @@ async def clean(
         if results_path_here.exists()
         else set()
     )
+    logger.debug(f"Local run dirs in {results_path_here}: {sorted(local_names)}")
 
     per_cluster_to_delete: dict[str, list[str]] = {}
     skipped: list[str] = []
@@ -86,11 +98,15 @@ async def clean(
         cluster = remote.hostname
         watermark = _watermark_for(cache, cluster)
         if watermark is None:
+            logger.debug(f"{cluster}: no fetch watermark cached, skipping")
             skipped.append(cluster)
             continue
         cluster_config = config.get_cluster_config(cluster)
         results_path_on_cluster = await expandvars(remote, cluster_config.results_path)
         remote_runs = await list_remote_run_dirs(remote, results_path_on_cluster)
+        logger.debug(
+            f"{cluster}: {len(remote_runs)} remote run dir(s) in {results_path_on_cluster}"
+        )
         to_delete = compute_runs_to_delete(local_names, remote_runs, watermark)
         if to_delete:
             per_cluster_to_delete[cluster] = to_delete
@@ -101,10 +117,12 @@ async def clean(
         )
 
     if not per_cluster_to_delete:
+        logger.info("Nothing to clean.")
         console.print("[green]Nothing to clean.[/green]")
         return
 
     total = sum(len(names) for names in per_cluster_to_delete.values())
+    logger.info(f"{total} run director{'y' if total == 1 else 'ies'} eligible for deletion")
     console.print("[bold]The following run directories will be removed:[/bold]")
     for cluster, names in per_cluster_to_delete.items():
         console.print(f"  [cyan]{cluster}[/cyan]:")
@@ -112,6 +130,7 @@ async def clean(
             console.print(f"    {name}")
 
     if dry_run:
+        logger.info("Dry run: not deleting anything.")
         return
 
     if not force and not Confirm.ask(
@@ -119,6 +138,7 @@ async def clean(
         f"{len(per_cluster_to_delete)} cluster(s)?",
         default=False,
     ):
+        logger.info("User declined to delete. Aborting.")
         console.print("Aborted.")
         return
 
@@ -130,13 +150,18 @@ async def clean(
         cluster_config = config.get_cluster_config(cluster)
         results_path_on_cluster = await expandvars(remote, cluster_config.results_path)
         for name in names:
+            logger.debug(f"Removing {cluster}:{results_path_on_cluster / name}")
             try:
                 await remote.run(f"rm -rf {results_path_on_cluster / name}", hide=True)
-            except subprocess.CalledProcessError:
+            except subprocess.CalledProcessError as err:
+                logger.warning(f"Failed to remove {cluster}:{name}: {err}")
                 failed.append((cluster, name))
             else:
                 removed += 1
 
+    logger.info(
+        f"Removed {removed} run director{'y' if removed == 1 else 'ies'}; {len(failed)} failed"
+    )
     console.print(
         f"[green]Removed {removed} run director{'y' if removed == 1 else 'ies'}.[/green]"
     )

--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -197,11 +197,17 @@ async def sync_task_function(report_progress: ReportProgressFn, remote: Remote) 
 
     num_tasks = 5 if config.data_source else 4
 
-    cache = read_cache()
-    project_state = cache.project_states.setdefault(cluster, ProjectStateOnCluster())
+    project_state = read_cache().project_states.get(cluster) or ProjectStateOnCluster()
 
     def _save():
-        assert cache.project_states[cluster] is project_state
+        # Re-read the cache right before writing, instead of reusing the snapshot read at the
+        # top of this function: multiple clusters' sync_task_function calls run concurrently in
+        # the same event loop, each starting from its own initial read, so writing back a stale
+        # full snapshot would clobber other clusters' updates. read_cache/write_cache are
+        # synchronous (no `await` in between), so this merge-and-write is atomic with respect to
+        # the other concurrently-running cluster tasks.
+        cache = read_cache()
+        cache.project_states[cluster] = project_state
         write_cache(cache)
 
     _update_progress(0, "Checking/Installing UV", num_tasks)

--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -28,7 +28,7 @@ from cluv.cli.disable import print_disabled_clusters
 from cluv.cli.login import get_remote_without_2fa_prompt, login
 from cluv.config import CluvConfig, find_pyproject, get_cluv_config, load_cluv_config
 from cluv.job import get_datasets_path
-from cluv.remote import Remote, get_ssh_options_for_host, run
+from cluv.remote import Remote, get_ssh_options_for_host, list_remote_run_dirs, run
 from cluv.utils import console, console_lock, current_cluster
 
 milatools.cli.console = console
@@ -217,7 +217,8 @@ async def sync_task_function(report_progress: ReportProgressFn, remote: Remote) 
     _save()
 
     _update_progress(3, "Fetching results", num_tasks)
-    new_runs = await fetch_results(remote, config)
+    new_runs = await fetch_results(remote, config, project_state)
+    _save()
 
     if config.data_source:
         _update_progress(4, "Syncing datasets", num_tasks)
@@ -579,11 +580,13 @@ async def _push_datasets_to_remote(
     project_state.last_pushed_datasets = last_push_datetime
 
 
-async def fetch_results(remote: Remote, config: CluvConfig) -> list[Path]:
+async def fetch_results(
+    remote: Remote, config: CluvConfig, project_state: ProjectStateOnCluster
+) -> list[Path]:
     """Fetches results from a remote cluster to local using rsync via the results symlink.
 
     Returns the list of newly-synced run directories (those that did not exist locally before
-    the rsync ran).
+    the rsync ran). Also updates `project_state.last_fetch_watermark` (see `cluv clean`).
     """
     results_path_here = Path(os.path.expandvars(config.results_path))
     results_path_here.mkdir(parents=True, exist_ok=True)
@@ -629,6 +632,10 @@ async def fetch_results(remote: Remote, config: CluvConfig) -> list[Path]:
         warn=True,
         hide=False,
     )
+
+    remote_runs = await list_remote_run_dirs(remote, results_path_on_cluster)
+    if remote_runs:
+        project_state.last_fetch_watermark = max(mtime for _, mtime in remote_runs)
 
     if not results_path_here.exists():
         return []

--- a/cluv/remote.py
+++ b/cluv/remote.py
@@ -7,7 +7,9 @@ import functools
 import shlex
 import subprocess
 import sys
+from datetime import datetime, timezone
 from logging import getLogger as get_logger
+from pathlib import PurePosixPath
 from typing import Callable, Literal, Self, TypeVar
 
 from cluv.utils import console, console_lock
@@ -105,6 +107,23 @@ class Remote:
     ) -> str:
         """Runs the command asynchronously and returns the stripped output string."""
         return (await self.run(command, display=display, warn=warn, hide=hide)).stdout.strip()
+
+
+async def list_remote_run_dirs(remote: Remote, path: PurePosixPath) -> list[tuple[str, datetime]]:
+    """Lists the immediate subdirectories of `path` on the remote, with their mtimes.
+
+    Returns an empty list if `path` doesn't exist on the remote (rather than raising).
+    """
+    output = await remote.get_output(
+        f"find {path} -maxdepth 1 -mindepth 1 -type d -printf '%T@ %f\\n'", warn=True
+    )
+    entries: list[tuple[str, datetime]] = []
+    for line in output.splitlines():
+        epoch_str, _, name = line.partition(" ")
+        if not epoch_str or not name:
+            continue
+        entries.append((name, datetime.fromtimestamp(float(epoch_str), tz=timezone.utc)))
+    return entries
 
 
 async def run(

--- a/docs/guides/cleaning-runs.md
+++ b/docs/guides/cleaning-runs.md
@@ -44,7 +44,7 @@ note telling you to run `cluv sync` first.
 
 !!! note
     Editing files inside a local run folder (adding notes, running analysis
-    scripts that write into it, etc.) doesn't affect whether the folder will be deted or not — `clean` doesn't look
+    scripts that write into it, etc.) doesn't affect whether the folder will be deleted or not — `clean` doesn't look
     at your local folders' modification times, only at whether the folder
     exists.
 

--- a/docs/guides/cleaning-runs.md
+++ b/docs/guides/cleaning-runs.md
@@ -1,11 +1,5 @@
 # Cleaning up run results on the clusters
 
-!!! note "Planned feature"
-    `cluv clean` is not implemented yet — this page describes how it's designed
-    to work, based on [issue #65](https://github.com/mila-iqia/cluv/issues/65).
-    It documents the target behavior so it can be reviewed before the command is
-    built.
-
 ## The problem
 
 `cluv sync` copies run results (logs, checkpoints, anything under your
@@ -62,7 +56,8 @@ Preview what would be deleted, without deleting anything:
 cluv clean --dry-run
 ```
 
-Clean up all clusters you've synced before, with a confirmation prompt:
+Clean up every cluster you're currently connected to (and that's been synced
+before), with a confirmation prompt:
 
 ```console
 cluv clean

--- a/docs/guides/cleaning-runs.md
+++ b/docs/guides/cleaning-runs.md
@@ -1,0 +1,107 @@
+# Cleaning up run results on the clusters
+
+!!! note "Planned feature"
+    `cluv clean` is not implemented yet — this page describes how it's designed
+    to work, based on [issue #65](https://github.com/mila-iqia/cluv/issues/65).
+    It documents the target behavior so it can be reviewed before the command is
+    built.
+
+## The problem
+
+`cluv sync` copies run results (logs, checkpoints, anything under your
+`results_path`) from each cluster back to your machine. It's a one-way copy: it
+never deletes anything, on either side. Two things follow from that:
+
+- Deleting a run folder locally and running `cluv sync` again just re-downloads
+  it — the files are still sitting on the cluster.
+- Every job you run adds another folder under `results_path` (usually somewhere
+  under `$SCRATCH`) on every cluster, forever. Nothing ever gets removed from
+  there on its own.
+
+`cluv clean` is the other half of that workflow: once you're happy with a run and
+have deleted its local folder, `clean` removes the matching folder from the
+cluster(s) it came from.
+
+## How it decides what's safe to delete
+
+Your local results folder (the `logs` symlink in your project, pointing at
+wherever `results_path` resolves to) is treated as the source of truth for what
+you still want to keep. Anything under a cluster's `results_path` that has no
+matching folder locally is a *candidate* for deletion — but not automatically,
+because that description also matches a run that finished on the cluster five
+minutes ago and simply hasn't been fetched yet.
+
+To tell those two cases apart, `cluv clean` only considers a remote folder
+deletable if **both** are true:
+
+1. There's no folder with that name in your local results folder.
+2. It's older than the last time `cluv sync` successfully pulled results from
+   that cluster.
+
+In practice: if you've synced recently, anything that showed up on the cluster
+*after* that sync is left alone (it hasn't been fetched yet — `clean` never
+deletes something you haven't seen), and anything from *before* that sync which
+you don't have locally is treated as something you deliberately deleted, and
+gets cleaned up remotely too.
+
+This means `clean` needs at least one prior `cluv sync` for a cluster before it
+can safely clean it. Clusters that have never been synced are skipped, with a
+note telling you to run `cluv sync` first.
+
+!!! note
+    Editing files inside a local run folder (adding notes, running analysis
+    scripts that write into it, etc.) doesn't change this — `clean` doesn't look
+    at your local folders' modification times, only at whether the folder
+    exists.
+
+## Usage
+
+Preview what would be deleted, without deleting anything:
+
+```console
+cluv clean --dry-run
+```
+
+Clean up all clusters you've synced before, with a confirmation prompt:
+
+```console
+cluv clean
+```
+
+You'll see a list of what's about to be removed, grouped by cluster, before
+being asked to confirm.
+
+Clean specific clusters only:
+
+```console
+cluv clean rorqual narval
+```
+
+Skip the confirmation prompt (useful in scripts):
+
+```console
+cluv clean --force
+```
+
+## Typical workflow
+
+```console
+cluv sync              # fetch results from all clusters
+rm -rf logs/12345       # you're done with this run, delete it locally
+cluv clean              # remove the matching folder from wherever it ran
+```
+
+## Things to know
+
+- **Running or pending jobs aren't specially protected.** If a job's output
+  folder happens to look old enough and isn't present locally, `clean` doesn't
+  check Slurm queue state before removing it. In practice this is unlikely to
+  bite you (an actively running job keeps writing to its folder, which usually
+  keeps it looking "new"), but it isn't guarded against explicitly.
+- **Same job ID on two clusters is treated as two independent decisions.** If a
+  folder with the same name exists on two different clusters, `clean` looks at
+  each cluster's copy independently. Keeping the local copy keeps it on
+  *every* cluster that has a folder with that name, even if only one of them is
+  actually "the" run you meant.
+- **Deletion happens over SSH (`rm -rf`) and is not recoverable.** There's no
+  remote trash/undo. Use `--dry-run` first if you're unsure.

--- a/docs/guides/cleaning-runs.md
+++ b/docs/guides/cleaning-runs.md
@@ -44,7 +44,7 @@ note telling you to run `cluv sync` first.
 
 !!! note
     Editing files inside a local run folder (adding notes, running analysis
-    scripts that write into it, etc.) doesn't change this — `clean` doesn't look
+    scripts that write into it, etc.) doesn't affect whether the folder will be deted or not — `clean` doesn't look
     at your local folders' modification times, only at whether the folder
     exists.
 

--- a/docs/guides/introduction.md
+++ b/docs/guides/introduction.md
@@ -27,6 +27,7 @@ These are the main goals of Cluv:
   one starts running first, and cancel the rest.
 - `cluv sync`: Fetch the results from the clusters where I ran jobs previously.
 - `cluv run mila -- ls logs`: Sync the project and run a command in the project dir on a cluster.
+- `cluv clean`: Once I've deleted a run's results locally, remove the matching results from the cluster(s) it ran on. See the [cleaning up runs guide](cleaning-runs.md).
 
 ### Intuitive monitoring of jobs and cluster health across clusters
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,13 @@ See the [Hydra launcher guide](guides/hydra-launcher.md) for setup and usage.
 cluv sync rorqual
 ```
 
+### Clean up old run results from the clusters
+```console
+cluv clean
+```
+
+See the [cleaning up runs guide](guides/cleaning-runs.md) for details on how this decides what's safe to delete.
+
 ### Submit a job to a specific cluster
 ```console
 cluv submit rorqual scripts/job.sh --time=00:10:00 -- python main.py

--- a/hydra_plugins/cluv/cluv_launcher.py
+++ b/hydra_plugins/cluv/cluv_launcher.py
@@ -22,6 +22,7 @@ from omegaconf import DictConfig, OmegaConf
 from remote_slurm_executor.slurm_remote import RemoteSlurmJob
 from submitit.slurm.slurm import SlurmExecutor, _make_sbatch_string
 
+from cluv.cache import ProjectStateOnCluster, read_cache, write_cache
 from cluv.cli.submit import display_commands, submit
 from cluv.cli.sync import expandvars, fetch_results, get_active_remotes, sync
 from cluv.config import CluvConfig, find_pyproject, get_cluv_config
@@ -371,13 +372,21 @@ async def run_sweep(
 
     # Creates a rich.Live table and updates it as the status of the jobs change.
     await monitor_jobs_async(job_infos, poll_interval_seconds=30)
+    project_states = {
+        cluster: read_cache().project_states.get(cluster) or ProjectStateOnCluster()
+        for cluster in cluster_remotes.keys()
+    }
 
     await asyncio.gather(
         *(
-            fetch_results(cluster_remote, cluv_config)
-            for cluster_remote in cluster_remotes.values()
+            fetch_results(cluster_remote, cluv_config, project_states[cluster])
+            for cluster, cluster_remote in cluster_remotes.items()
         )
     )
+    cache = read_cache()
+    for cluster, updated_project_state in project_states.items():
+        cache.project_states[cluster] = updated_project_state
+    write_cache(cache)
 
     return job_infos
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,11 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 
+import cluv.cli.clean
+import cluv.cli.disable
+import cluv.cli.login
+import cluv.cli.submit
+import cluv.cli.sync
 import cluv.config
 from cluv.cli.login import get_remote_without_2fa_prompt
 from cluv.config import find_pyproject, get_cluv_config, set_local_env_vars
@@ -67,6 +72,8 @@ def use_normal_project_dir_on_cluster_instead_of_action_runners_path(
         return config
 
     monkeypatch.setattr(cluv.config, get_cluv_config.__name__, mock_get_cluv_config)
+    monkeypatch.setattr(cluv.cli.submit, get_cluv_config.__name__, mock_get_cluv_config)
+    monkeypatch.setattr(cluv.cli.clean, get_cluv_config.__name__, mock_get_cluv_config)
 
 
 @pytest_asyncio.fixture(scope="session", params=ALL_CLUSTERS)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,7 @@ import pytest
 import pytest_asyncio
 
 import cluv.cli.clean
-import cluv.cli.disable
-import cluv.cli.login
 import cluv.cli.submit
-import cluv.cli.sync
 import cluv.config
 from cluv.cli.login import get_remote_without_2fa_prompt
 from cluv.config import find_pyproject, get_cluv_config, set_local_env_vars

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def reset_cluv_config():
 
 @pytest.fixture(autouse=IN_SELF_HOSTED_GITHUB_CI)
 def use_normal_project_dir_on_cluster_instead_of_action_runners_path(
-    monkeypatch: pytest.MonkeyPatch, reset_cluv_config: None
+    monkeypatch: pytest.MonkeyPatch, reset_cluv_config: None, request: pytest.FixtureRequest
 ):
     """The self-hosted runner is running from ~/action-runners/.../_work/cluv/cluv.
 
@@ -57,6 +57,10 @@ def use_normal_project_dir_on_cluster_instead_of_action_runners_path(
     As a consequence of this, the ~/repos/cluv path on the clusters might be changed by the test runners.
     This is kind-of to be expected though, and is not different than doing a `cluv sync` ourselves.
     """
+
+    # Only do this mocking if the test that is going to be run is marked with @pytest.mark.integration.
+    if request.node.get_closest_marker("integration") is None:
+        return  # don't patch get_cluv_config to not interfere with unit tests.
 
     def mock_get_cluv_config() -> cluv.config.CluvConfig:
         config = get_cluv_config()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -29,6 +29,5 @@ def test_last_fetch_watermark_roundtrip(fake_cache_dir: Path):
     assert reloaded.project_states["mila"].last_fetch_watermark == watermark
 
 
-def test_last_fetch_watermark_defaults_to_none(fake_cache_dir: Path):
-    cache = read_cache()
-    assert cache.project_states.get("mila") is None
+def test_last_fetch_watermark_defaults_to_none():
+    assert ProjectStateOnCluster().last_fetch_watermark is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -13,7 +13,7 @@ from cluv.cache import CacheContent, ProjectStateOnCluster, read_cache, write_ca
 def fake_cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir(parents=True)
-    monkeypatch.setattr(cluv.cache, "_get_cache_dir", lambda: cache_dir)
+    monkeypatch.setattr(cluv.cache, cluv.cache._get_cache_dir.__name__, lambda: cache_dir)
     return cache_dir
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,34 @@
+"""Tests for the local project-state cache."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import cluv.cache
+from cluv.cache import CacheContent, ProjectStateOnCluster, read_cache, write_cache
+
+
+@pytest.fixture
+def fake_cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir(parents=True)
+    monkeypatch.setattr(cluv.cache, "_get_cache_dir", lambda: cache_dir)
+    return cache_dir
+
+
+def test_last_fetch_watermark_roundtrip(fake_cache_dir: Path):
+    watermark = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+    cache = CacheContent(
+        project_states={"mila": ProjectStateOnCluster(last_fetch_watermark=watermark)}
+    )
+    write_cache(cache)
+
+    reloaded = read_cache()
+
+    assert reloaded.project_states["mila"].last_fetch_watermark == watermark
+
+
+def test_last_fetch_watermark_defaults_to_none(fake_cache_dir: Path):
+    cache = read_cache()
+    assert cache.project_states.get("mila") is None

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -353,9 +353,17 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
     never-fetched run is left alone."""
     assert not current_cluster(), "test needs to run locally for now."
     assert cluv.cache.read_cache() == CacheContent(), "test assumes no previous cache content"
+
     monkeypatch.chdir("examples/pytorch-example")
     config = get_cluv_config()
-    results_path_on_cluster = config.get_cluster_config(cluster).results_path
+    try:
+        results_path_on_cluster = config.get_cluster_config(cluster).results_path
+    except KeyError as err:
+        pytest.skip(
+            f"We have an existing connection to the {cluster!r} cluster, but it "
+            f"is not configured in the cluv section of that example's pyproject.toml file. (err={err})"
+        )
+
     # sanity check
     assert results_path_on_cluster == PurePosixPath("$SCRATCH/logs/pytorch_example")
     results_path_on_cluster = await expandvars(remote, results_path_on_cluster)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -23,6 +23,7 @@ from cluv.cli.sync import (
     expandvars,
     fetch_results,
     get_active_remotes,
+    remote_test,
     sync,
 )
 from cluv.config import CluvConfig, PartialClusterConfig, get_cluv_config
@@ -363,9 +364,16 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
     # Move the local results dir:
     if local_results_path.exists():
         local_results_path.rename(local_results_path.with_suffix(".backup"))
+
+    remote_backup_dir = results_path_on_cluster.with_suffix(".backup")
+    assert not (await remote_test("-d", remote_backup_dir, remote)), (
+        f"Stale backup already exists on {cluster} at {results_path_on_cluster}! "
+        f"Some Manual cleanup will probably be needed."
+    )
+
     # Move the directory temporarily, instead of deleting it, so we can clean up after the test.
     await remote.run(
-        f"mv {results_path_on_cluster} {results_path_on_cluster.with_suffix('.backup')}",
+        f"mv {results_path_on_cluster} {remote_backup_dir}",
         hide=False,
     )
     try:
@@ -406,6 +414,6 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
         await remote.run(f"rmdir {results_path_on_cluster / 'new_run'}", hide=False, warn=True)
         await remote.run(f"rmdir {results_path_on_cluster}", hide=False)
         await remote.run(
-            f"mv {results_path_on_cluster.with_suffix('.backup')} {results_path_on_cluster}",
+            f"mv {remote_backup_dir} {results_path_on_cluster}",
             hide=False,
         )

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,45 @@
+"""Tests for `cluv clean` and the fetch-watermark mechanism it depends on."""
+
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from cluv.cache import ProjectStateOnCluster
+from cluv.cli.sync import fetch_results
+from cluv.config import CluvConfig, PartialClusterConfig
+from cluv.remote import Remote
+
+# `cluv/cli/__init__.py` does `from .sync import sync`, which shadows the `cluv.cli.sync`
+# submodule attribute with the `sync` function. Use `importlib.import_module` (same idiom as
+# `tests/test_init.py`) to get the actual module object for monkeypatching.
+sync_module = importlib.import_module("cluv.cli.sync")
+
+
+async def test_fetch_results_updates_watermark(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    async def fake_list_remote_run_dirs(remote, path):
+        return [
+            ("run_a", datetime(2026, 7, 1, tzinfo=timezone.utc)),
+            ("run_b", datetime(2026, 7, 3, tzinfo=timezone.utc)),
+        ]
+
+    monkeypatch.setattr(sync_module, "list_remote_run_dirs", fake_list_remote_run_dirs)
+    monkeypatch.setattr(
+        sync_module, "create_results_dir_with_symlink_to_scratch", mock.AsyncMock()
+    )
+    monkeypatch.setattr(sync_module, "run", mock.AsyncMock())
+
+    config = CluvConfig(
+        results_path=str(tmp_path / "results"),
+        clusters={"mila": PartialClusterConfig(project_dir="/home/user/myproject")},
+    )
+    remote = Remote(hostname="mila")
+    project_state = ProjectStateOnCluster()
+
+    await fetch_results(remote, config, project_state)
+
+    assert project_state.last_fetch_watermark == datetime(2026, 7, 3, tzinfo=timezone.utc)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -27,7 +27,9 @@ from cluv.cli.sync import (
 from cluv.config import CluvConfig, PartialClusterConfig, get_cluv_config
 from cluv.remote import Remote, list_remote_run_dirs, run
 from cluv.utils import current_cluster
-from tests.test_integration import IN_GITHUB_CLOUD_CI
+
+# Note: Need to import these fixtures for now. If they were moved to conftest, we wouldn't need to.
+from tests.test_integration import IN_GITHUB_CLOUD_CI, cluster, remote  # noqa
 
 # `cluv/cli/__init__.py` does `from .sync import sync`, which shadows the `cluv.cli.sync`
 # submodule attribute with the `sync` function. Use `importlib.import_module` (same idiom as
@@ -54,7 +56,7 @@ async def test_fetch_results_updates_watermark(tmp_path: Path, monkeypatch: pyte
         results_path=str(tmp_path / "results"),
         clusters={"foo": PartialClusterConfig(project_dir="/home/user/myproject")},
     )
-    remote = Remote(hostname="foo")
+    remote = Remote(hostname="foo")  # noqa
     project_state = ProjectStateOnCluster()
 
     await fetch_results(remote, config, project_state)
@@ -163,8 +165,8 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(cluv.cli.clean, read_cache.__name__, lambda: cache)
 
-    async def fake_list_remote_run_dirs(remote: Remote, path: str):
-        cluster = remote.hostname
+    async def fake_list_remote_run_dirs(remote: Remote):  # noqa
+        cluster = remote.hostname  # noqa
         return [
             (f"{cluster}_run_kept", datetime(2026, 6, 20, tzinfo=timezone.utc)),
             (f"{cluster}_run_pruned", datetime(2026, 6, 20, tzinfo=timezone.utc)),
@@ -301,7 +303,6 @@ def test_clean_cli_parses_force_and_dry_run(monkeypatch: pytest.MonkeyPatch) -> 
     mock_clean.assert_called_once_with(clusters=["rorqual", "narval"], force=True, dry_run=True)
 
 
-@pytest.mark.parametrize("cluster", "tamia", indirect=True)
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.skipif(
@@ -309,7 +310,9 @@ def test_clean_cli_parses_force_and_dry_run(monkeypatch: pytest.MonkeyPatch) -> 
     reason="Integration tests are only run on a self-hosted github runner or on a dev machine.",
 )
 async def test_clean_removes_pruned_run_but_keeps_new_one(
-    cluster: str, remote: Remote, monkeypatch: pytest.MonkeyPatch, fake_scratch: Path
+    cluster: str,  # noqa
+    remote: Remote,  # noqa
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """End-to-end: an old, locally-pruned run is removed from the cluster; a brand-new,
     never-fetched run is left alone."""
@@ -317,19 +320,23 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
 
     monkeypatch.chdir("examples/pytorch-example")
     config = get_cluv_config()
-    results_path_on_cluster = await expandvars(
-        remote, config.get_cluster_config(cluster).results_path
-    )
-    assert False, results_path_on_cluster  # TODO: remove this assert after debugging
+    results_path_on_cluster = config.get_cluster_config(cluster).results_path
+    assert results_path_on_cluster == "$SCRATCH/logs/pytorch-example"  # sanity check
+    results_path_on_cluster = await expandvars(remote, results_path_on_cluster)
 
-    await remote.run(f"rm -rf {results_path_on_cluster}", warn=True, hide=True)
+    # Move the directory temporarily, instead of deleting it, so we can clean up after the test.
+    await remote.run(
+        f"mv {results_path_on_cluster} {results_path_on_cluster.with_suffix('.backup')}",
+        warn=True,
+        hide=False,
+    )
     await remote.run(f"mkdir -p {results_path_on_cluster}", hide=True)
 
     old_run = results_path_on_cluster / "old_run"
     await remote.run(f"mkdir -p {old_run}", hide=True)
     await remote.run(f"touch -d '2020-01-01' {old_run}", hide=True)
 
-    await sync([cluster], uv_sync_args=None)
+    await sync([cluster], sync_datasets=False)
 
     local_results_path = Path(os.path.expandvars(config.results_path))
     shutil.rmtree(local_results_path / "old_run")
@@ -340,7 +347,17 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
     await clean([cluster], force=True)
 
     remaining = (
-        (await remote.get_output(f"ls {results_path_on_cluster}", warn=True)).strip().splitlines()
+        (await remote.get_output(f"ls {results_path_on_cluster}", warn=True, hide=False))
+        .strip()
+        .splitlines()
     )
     assert "old_run" not in remaining
     assert "new_run" in remaining
+
+    # Cleanup after the test.
+    await remote.run(f"rmdir {results_path_on_cluster / 'new_run'}", hide=False)
+    await remote.run(f"rmdir {results_path_on_cluster}", hide=False)
+    await remote.run(
+        f"mv {results_path_on_cluster.with_suffix('.backup')} {results_path_on_cluster}",
+        hide=False,
+    )

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -367,7 +367,7 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
 
     remote_backup_dir = results_path_on_cluster.with_suffix(".backup")
     assert not (await remote_test("-d", remote_backup_dir, remote)), (
-        f"Stale backup already exists on {cluster} at {results_path_on_cluster}! "
+        f"Stale backup already exists on {cluster} at {remote_backup_dir}! "
         f"Some Manual cleanup will probably be needed."
     )
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -137,7 +137,10 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     Returns the list of (hostname, command) pairs passed to `Remote.run`."""
     config = CluvConfig(
         results_path=str(tmp_path / "results"),
-        clusters={"foo": PartialClusterConfig(), "bar": PartialClusterConfig()},
+        clusters={
+            "foo": PartialClusterConfig(results_path="/results"),
+            "bar": PartialClusterConfig(results_path="/results"),
+        },
     )
     monkeypatch.setattr(cluv.cli.clean, get_cluv_config.__name__, lambda: config)
 
@@ -237,7 +240,12 @@ async def test_one_cluster_failure_does_not_abort_the_others(
     await clean()  # must not raise
     mock_confirm.assert_called_once()
 
-    assert commands_run_during_test == [("bar", "rm -rf /results/bar_run_pruned")]
+    assert sorted(commands_run_during_test) == sorted(
+        [
+            ("foo", "rm -rf /results/foo_run_pruned"),
+            ("bar", "rm -rf /results/bar_run_pruned"),
+        ]
+    )
 
 
 @pytest.fixture

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -32,10 +32,6 @@ from tests.test_integration import IN_GITHUB_CLOUD_CI
 # `tests/test_init.py`) to get the actual module object for monkeypatching.
 sync_module = importlib.import_module("cluv.cli.sync")
 
-# Captured once, before any test monkeypatches `Remote.run` -- reading `Remote.run.__name__`
-# *after* a patch is applied would return the replacement's name instead of "run".
-_REMOTE_RUN_NAME = Remote.run.__name__
-
 
 async def test_fetch_results_updates_watermark(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     async def fake_list_remote_run_dirs(remote, path):
@@ -141,7 +137,7 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str
         run_calls.append((self.hostname, command))
         return mock.Mock(returncode=0, stderr="")
 
-    monkeypatch.setattr(Remote, _REMOTE_RUN_NAME, fake_remote_run)
+    monkeypatch.setattr(Remote, "run", fake_remote_run)
     return run_calls
 
 
@@ -200,7 +196,7 @@ async def test_one_cluster_failure_does_not_abort_the_others(
         clean_env.append((self.hostname, command))
         return mock.Mock(returncode=0, stderr="")
 
-    monkeypatch.setattr(Remote, _REMOTE_RUN_NAME, failing_remote_run)
+    monkeypatch.setattr(Remote, "run", failing_remote_run)
 
     await clean()  # must not raise
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
 import importlib
-import os
 import shutil
 import subprocess
 from datetime import datetime, timezone
@@ -16,11 +16,11 @@ import rich.prompt
 import cluv.__main__ as cluv_main
 import cluv.cache
 import cluv.cli.clean
+import cluv.config
 from cluv.cache import CacheContent, ProjectStateOnCluster, read_cache, write_cache
 from cluv.cli.clean import clean, compute_runs_to_delete
 from cluv.cli.sync import (
     create_results_dir_with_symlink_to_scratch,
-    expandvars,
     fetch_results,
     get_active_remotes,
     remote_test,
@@ -115,7 +115,6 @@ def expected_commands(
 @pytest.fixture
 def commands_run_during_test(
     monkeypatch: pytest.MonkeyPatch,
-    request: pytest.FixtureRequest,
     expected_commands: dict[tuple[str, str], str | subprocess.CalledProcessError],
 ) -> list[tuple[str, str]]:
     """Returns the list of (hostname, command) pairs passed to `Remote.run` during the test.
@@ -192,7 +191,8 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_dry_run_makes_no_delete_calls(
     clean_env, commands_run_during_test: list[tuple[str, str]]
 ):
-    await clean(dry_run=True)
+    to_be_removed = await clean(dry_run=True)
+    assert to_be_removed == {"foo": ["foo_run_pruned"], "bar": ["bar_run_pruned"]}
     assert (
         commands_run_during_test == []
     )  # no calls were made to Remote.run, so nothing was deleted
@@ -204,8 +204,20 @@ async def test_declining_confirmation_makes_no_delete_calls(
     monkeypatch.setattr(
         cluv.cli.clean.Confirm, cluv.cli.clean.Confirm.ask.__name__, lambda *a, **k: False
     )
-    await clean()
+    removed = await clean()
+    assert not removed
     assert commands_run_during_test == []
+
+
+@pytest.fixture
+def mock_confirm(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest):
+    value = getattr(request, "param", True)
+    monkeypatch.setattr(
+        cluv.cli.clean.Confirm,
+        cluv.cli.clean.Confirm.ask.__name__,
+        mock_confirm := mock.Mock(spec=rich.prompt.Confirm.ask, return_value=value),
+    )
+    return mock_confirm
 
 
 async def test_force_skips_confirmation_and_deletes(
@@ -213,8 +225,8 @@ async def test_force_skips_confirmation_and_deletes(
     commands_run_during_test: list[tuple[str, str]],
     mock_confirm: mock.Mock,
 ):
-    await clean(force=True)
-
+    removed = await clean(force=True)
+    assert removed == {"foo": ["foo_run_pruned"], "bar": ["bar_run_pruned"]}
     mock_confirm.assert_not_called()
     assert len(commands_run_during_test) == 2
     for hostname, command in commands_run_during_test:
@@ -228,7 +240,8 @@ async def test_confirming_deletes_pruned_run_on_every_cluster(
     monkeypatch: pytest.MonkeyPatch,
     mock_confirm: mock.Mock,
 ):
-    await clean()
+    removed = await clean()
+    assert removed == {"foo": ["foo_run_pruned"], "bar": ["bar_run_pruned"]}
     mock_confirm.assert_called_once()
     assert sorted(commands_run_during_test) == sorted(
         [
@@ -253,26 +266,15 @@ async def test_one_cluster_failure_does_not_abort_the_others(
         }
     )
 
-    await clean()  # must not raise
+    removed = await clean()  # must not raise
     mock_confirm.assert_called_once()
-
+    assert removed == {"bar": ["bar_run_pruned"]}  # only the successfully removed run is reported.
     assert sorted(commands_run_during_test) == sorted(
         [
             ("foo", "rm -rf /foo/results/foo_run_pruned"),
             ("bar", "rm -rf /bar/results/bar_run_pruned"),
         ]
     )
-
-
-@pytest.fixture
-def mock_confirm(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest):
-    value = getattr(request, "param", True)
-    monkeypatch.setattr(
-        cluv.cli.clean.Confirm,
-        cluv.cli.clean.Confirm.ask.__name__,
-        mock_confirm := mock.Mock(spec=rich.prompt.Confirm.ask, return_value=value),
-    )
-    return mock_confirm
 
 
 async def test_never_synced_cluster_is_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -348,80 +350,112 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
     remote: Remote,
     monkeypatch: pytest.MonkeyPatch,
     clear_cluv_cache: None,
+    tmp_path: Path,
 ):
-    """End-to-end: an old, locally-pruned run is removed from the cluster; a brand-new,
-    never-fetched run is left alone."""
+    """Integration test for `cluv clean`.
+
+    Sets up a local results dir along with a fake one on the remote. This requires quite a bit of patching.
+    Then, runs `cluv clean`, and checks that the right dirs were removed on the remote and fetched locally.
+    """
     assert not current_cluster(), "test needs to run locally for now."
-    assert cluv.cache.read_cache() == CacheContent(), "test assumes no previous cache content"
+    assert cluv.cache.read_cache() == CacheContent(), "Assuming a clean cache to begin with."
 
     monkeypatch.chdir("examples/pytorch-example")
     config = get_cluv_config()
     try:
-        results_path_on_cluster = config.get_cluster_config(cluster).results_path
+        cluster_config = config.get_cluster_config(cluster)
     except KeyError as err:
         pytest.skip(
             f"We have an existing connection to the {cluster!r} cluster, but it "
             f"is not configured in the cluv section of that example's pyproject.toml file. (err={err})"
         )
 
-    # sanity check
-    assert results_path_on_cluster == PurePosixPath("$SCRATCH/logs/pytorch_example")
-    results_path_on_cluster = await expandvars(remote, results_path_on_cluster)
+    real_results_path_on_cluster = cluster_config.results_path
 
-    local_results_path = Path(os.path.expandvars(config.results_path))
-    # Move the local results dir:
-    if local_results_path.exists():
-        local_results_path.rename(local_results_path.with_suffix(".backup"))
+    # Local "logs" directory.
+    fake_local_results_dir = tmp_path / real_results_path_on_cluster.name
 
-    remote_backup_dir = results_path_on_cluster.with_suffix(".backup")
-    assert not (await remote_test("-d", remote_backup_dir, remote)), (
-        f"Stale backup already exists on {cluster} at {remote_backup_dir}! "
-        f"Some Manual cleanup will probably be needed."
+    # Directory on the cluster containing the test runs.
+    fake_cluster_results_dir = real_results_path_on_cluster.with_name(
+        f"temp_{real_results_path_on_cluster.name}"
+    )
+    if await remote_test("-d", fake_cluster_results_dir, remote=remote):
+        # Remote test dir already exists, remove it.
+        await remote.run(f"rm -rf {fake_cluster_results_dir}", hide=False)
+    await remote.run(f"mkdir -p {fake_cluster_results_dir}", hide=True)
+    assert not (await remote.get_output(f"ls {fake_cluster_results_dir}", hide=True)), (
+        f"Sanity check: fake cluster results dir at {fake_cluster_results_dir} should be empty!"
     )
 
-    # Move the directory temporarily, instead of deleting it, so we can clean up after the test.
-    await remote.run(
-        f"mv {results_path_on_cluster} {remote_backup_dir}",
-        hide=False,
+    # Patch stuff so that `cluv clean` actually uses the fake local and remote results dirs instead of the real ones.
+    monkeypatch.setattr(config, "results_path", fake_local_results_dir)
+    cluster_config = dataclasses.replace(cluster_config, results_path=fake_cluster_results_dir)
+    monkeypatch.setitem(config.clusters, cluster, cluster_config)
+    monkeypatch.setattr(cluv.config, get_cluv_config.__name__, lambda: config)
+    monkeypatch.setattr(cluv.cli.clean, get_cluv_config.__name__, lambda: config)
+
+    # Setup the local "logs" directory with some fake runs.
+
+    # Setup the remote directory with some fake runs.
+    old_run_on_cluster = fake_cluster_results_dir / "old_run"
+    newer_run_on_cluster = fake_cluster_results_dir / "newer_run"
+    await remote.run(f"mkdir -p {old_run_on_cluster}", hide=True)
+    await remote.run(f"touch -d '2020-01-01' {old_run_on_cluster}", hide=True)
+
+    await remote.run(f"mkdir -p {newer_run_on_cluster}", hide=True)
+    await remote.run(f"touch -d '2026-01-01' {newer_run_on_cluster}", hide=True)
+
+    # Fetch all the runs from the cluster. This also updates the cluv cache with the last-fetch watermark.
+    await sync([cluster], sync_datasets=False)
+
+    last_fetch_watermark = cluv.cache.read_cache().project_states[cluster].last_fetch_watermark
+    assert last_fetch_watermark
+    assert last_fetch_watermark.replace(hour=0) == datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    # Delete the old run locally. We then expect `cluv clean` to remove that run on the cluster.
+    shutil.rmtree(fake_local_results_dir / "old_run")
+
+    # Create a new run directory on the remote after `sync` was run!
+    # NOTE: `cluv clean` doesn't sync results, so we don't expect this new run to be synced
+    # back to the local results dir directly. However, when running `cluv sync` near the end of this test,
+    # we do expect that directory to be synced back, since it is newer than the last-fetch watermark.
+    # We still expect the old run to be deleted on the remote, since it was pruned locally.
+    newest_run_on_cluster = fake_cluster_results_dir / "newest_run"
+    await remote.run(f"mkdir -p {newest_run_on_cluster}", hide=True)
+
+    removed = await clean([cluster], force=True)
+
+    assert removed == {cluster: [str(old_run_on_cluster.name)]}
+
+    runs_on_cluster = (
+        await remote.get_output(f"ls {fake_cluster_results_dir}", hide=True)
+    ).splitlines()
+    print(f"Runs on cluster after `cluv clean`: {runs_on_cluster}")
+    assert old_run_on_cluster.name not in runs_on_cluster, (
+        "Old run directory should have been removed on the cluster"
     )
-    try:
-        await remote.run(f"mkdir -p {results_path_on_cluster}", hide=True)
+    assert newer_run_on_cluster.name in runs_on_cluster, (
+        f"Newer run directory ({newer_run_on_cluster}) should still exist on the cluster!"
+    )
+    assert newest_run_on_cluster.name in runs_on_cluster, (
+        f"Newest run directory ({newest_run_on_cluster}) should still exist on the cluster!"
+    )
 
-        old_run = results_path_on_cluster / "old_run"
-        await remote.run(f"mkdir -p {old_run}", hide=True)
-        await remote.run(f"touch -d '2020-01-01' {old_run}", hide=True)
-        await sync([cluster], sync_datasets=False)
+    assert fake_local_results_dir.exists(), "Local results dir should still exist."
+    assert not (fake_local_results_dir / old_run_on_cluster.name).exists()
+    assert (fake_local_results_dir / newer_run_on_cluster.name).exists()
 
-        last_fetch_watermark = cluv.cache.read_cache().project_states[cluster].last_fetch_watermark
-        assert last_fetch_watermark
-        assert last_fetch_watermark.replace(hour=0) == datetime(2020, 1, 1, tzinfo=timezone.utc)
+    # This newest run directory will not exist locally, because `cluv clean` doesn't do the `sync` step.
+    assert not (fake_local_results_dir / newest_run_on_cluster.name).exists()
 
-        shutil.rmtree(local_results_path / "old_run")
+    # Fetch all the runs again.
+    await sync([cluster], sync_datasets=False)
 
-        new_run = results_path_on_cluster / "new_run"
-        await remote.run(f"mkdir -p {new_run}", hide=True)
+    assert fake_local_results_dir.exists(), "Local results dir should still exist."
+    assert not (fake_local_results_dir / old_run_on_cluster.name).exists()
+    assert (fake_local_results_dir / newer_run_on_cluster.name).exists()
+    # This time, the newest run gets synced back!
+    assert (fake_local_results_dir / newest_run_on_cluster.name).exists()
 
-        await clean([cluster], force=True)
-
-        remaining = (
-            (await remote.get_output(f"ls {results_path_on_cluster}", warn=True, hide=False))
-            .strip()
-            .splitlines()
-        )
-        assert "old_run" not in remaining
-        assert "new_run" in remaining
-    finally:
-        # Cleanup after the test.
-        print("Test cleanup.")
-        # Restore the local results dir, if it existed before the test.
-        shutil.rmtree(local_results_path)
-        if (local_results_dir_backup := local_results_path.with_suffix(".backup")).exists():
-            local_results_dir_backup.rename(local_results_path)
-
-        await remote.run(f"rmdir {results_path_on_cluster / 'old_run'}", hide=False, warn=True)
-        await remote.run(f"rmdir {results_path_on_cluster / 'new_run'}", hide=False, warn=True)
-        await remote.run(f"rmdir {results_path_on_cluster}", hide=False)
-        await remote.run(
-            f"mv {remote_backup_dir} {results_path_on_cluster}",
-            hide=False,
-        )
+    # Remove the temp results dir on the cluster to cleanup the test.
+    await remote.run(f"rm -rf --verbose {fake_cluster_results_dir}", hide=False)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -6,6 +6,7 @@ import dataclasses
 import importlib
 import shutil
 import subprocess
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from unittest import mock
@@ -339,18 +340,25 @@ def clear_cluv_cache(monkeypatch: pytest.MonkeyPatch):
     yield
 
 
+@pytest.fixture(scope="session")
+def unique_str_for_this_run() -> str:
+    """Return a random unique string for this test run, to avoid collisions with other test runs."""
+    return uuid.uuid4().hex[:8]  # 8 hex chars is enough to avoid collisions in practice.
+
+
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.skipif(
     IN_GITHUB_CLOUD_CI,
     reason="Integration tests are only run on a self-hosted github runner or on a dev machine.",
 )
-async def test_clean_removes_pruned_run_but_keeps_new_one(
+async def test_clean(
     cluster: str,
     remote: Remote,
     monkeypatch: pytest.MonkeyPatch,
     clear_cluv_cache: None,
     tmp_path: Path,
+    unique_str_for_this_run: str,
 ):
     """Integration test for `cluv clean`.
 
@@ -377,7 +385,7 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
 
     # Directory on the cluster containing the test runs.
     fake_cluster_results_dir = real_results_path_on_cluster.with_name(
-        f"temp_{real_results_path_on_cluster.name}"
+        f"temp_{unique_str_for_this_run}_{real_results_path_on_cluster.name}"
     )
     if await remote_test("-d", fake_cluster_results_dir, remote=remote):
         # Remote test dir already exists, remove it.

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -3,16 +3,23 @@
 from __future__ import annotations
 
 import importlib
+import os
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-from cluv.cache import ProjectStateOnCluster
-from cluv.cli.sync import fetch_results
-from cluv.config import CluvConfig, PartialClusterConfig
+import cluv.__main__ as cluv_main
+import cluv.cli.clean
+from cluv.cache import CacheContent, ProjectStateOnCluster
+from cluv.cli.clean import clean, compute_runs_to_delete
+from cluv.cli.sync import expandvars, fetch_results, sync
+from cluv.config import CluvConfig, PartialClusterConfig, get_cluv_config
 from cluv.remote import Remote
+from cluv.utils import current_cluster
+from tests.test_integration import IN_GITHUB_CLOUD_CI
 
 # `cluv/cli/__init__.py` does `from .sync import sync`, which shadows the `cluv.cli.sync`
 # submodule attribute with the `sync` function. Use `importlib.import_module` (same idiom as
@@ -43,3 +50,216 @@ async def test_fetch_results_updates_watermark(tmp_path: Path, monkeypatch: pyte
     await fetch_results(remote, config, project_state)
 
     assert project_state.last_fetch_watermark == datetime(2026, 7, 3, tzinfo=timezone.utc)
+
+
+def test_pruned_run_is_selected():
+    watermark = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    remote_runs = [("run_a", datetime(2026, 6, 30, tzinfo=timezone.utc))]
+    assert compute_runs_to_delete(set(), remote_runs, watermark) == ["run_a"]
+
+
+def test_run_present_locally_is_kept():
+    watermark = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    remote_runs = [("run_a", datetime(2026, 6, 30, tzinfo=timezone.utc))]
+    assert compute_runs_to_delete({"run_a"}, remote_runs, watermark) == []
+
+
+def test_never_synced_cluster_selects_nothing():
+    remote_runs = [("run_a", datetime(2026, 6, 30, tzinfo=timezone.utc))]
+    assert compute_runs_to_delete(set(), remote_runs, watermark=None) == []
+
+
+def test_new_run_not_the_newest_is_still_kept():
+    """Guards against re-deriving the watermark as max(remote mtimes) *inside* this
+    function instead of using the externally-supplied, previously-cached watermark --
+    the over-deletion bug found while designing this feature (see the design spec's
+    "Rejected alternative: sync-first" section)."""
+    watermark = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    remote_runs = [
+        ("new_run_1", datetime(2026, 7, 2, tzinfo=timezone.utc)),
+        ("new_run_2", datetime(2026, 7, 5, tzinfo=timezone.utc)),
+    ]
+    assert compute_runs_to_delete(set(), remote_runs, watermark) == []
+
+
+def _config(tmp_path: Path) -> CluvConfig:
+    return CluvConfig(
+        results_path=str(tmp_path / "results"),
+        clusters={"mila": PartialClusterConfig(), "tamia": PartialClusterConfig()},
+    )
+
+
+@pytest.fixture
+def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    """Two clusters, each reporting one prunable run ("run_pruned") and one kept run
+    ("run_kept", which exists locally). Returns the list of (hostname, command) pairs
+    passed to `Remote.run` -- i.e. the deletion calls actually made."""
+    config = _config(tmp_path)
+    monkeypatch.setattr(cluv.cli.clean, "get_cluv_config", lambda: config)
+
+    results_path_here = tmp_path / "results"
+    results_path_here.mkdir()
+    (results_path_here / "run_kept").mkdir()
+
+    remotes = [Remote(hostname="mila"), Remote(hostname="tamia")]
+    monkeypatch.setattr(cluv.cli.clean, "get_active_remotes", mock.AsyncMock(return_value=remotes))
+
+    watermark = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    cache = CacheContent(
+        project_states={
+            "mila": ProjectStateOnCluster(last_fetch_watermark=watermark),
+            "tamia": ProjectStateOnCluster(last_fetch_watermark=watermark),
+        }
+    )
+    monkeypatch.setattr(cluv.cli.clean, "read_cache", lambda: cache)
+
+    async def fake_list_remote_run_dirs(remote, path):
+        return [
+            ("run_kept", datetime(2026, 6, 20, tzinfo=timezone.utc)),
+            ("run_pruned", datetime(2026, 6, 20, tzinfo=timezone.utc)),
+        ]
+
+    monkeypatch.setattr(cluv.cli.clean, "list_remote_run_dirs", fake_list_remote_run_dirs)
+
+    run_calls: list[tuple[str, str]] = []
+
+    async def fake_remote_run(self, command: str, **kwargs):
+        run_calls.append((self.hostname, command))
+        return mock.Mock(returncode=0, stderr="")
+
+    monkeypatch.setattr(Remote, "run", fake_remote_run)
+    return run_calls
+
+
+async def test_dry_run_makes_no_delete_calls(clean_env: list[tuple[str, str]]):
+    await clean(dry_run=True)
+    assert clean_env == []
+
+
+async def test_declining_confirmation_makes_no_delete_calls(
+    clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(cluv.cli.clean.Confirm, "ask", lambda *a, **k: False)
+    await clean()
+    assert clean_env == []
+
+
+async def test_force_skips_confirmation_and_deletes(
+    clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+):
+    ask = mock.Mock()
+    monkeypatch.setattr(cluv.cli.clean.Confirm, "ask", ask)
+
+    await clean(force=True)
+
+    ask.assert_not_called()
+    assert len(clean_env) == 2
+    for _hostname, command in clean_env:
+        assert "run_pruned" in command
+        assert "run_kept" not in command
+
+
+async def test_confirming_deletes_pruned_run_on_every_cluster(
+    clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(cluv.cli.clean.Confirm, "ask", lambda *a, **k: True)
+
+    await clean()
+
+    assert {hostname for hostname, _ in clean_env} == {"mila", "tamia"}
+
+
+async def test_one_cluster_failure_does_not_abort_the_others(
+    clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(cluv.cli.clean.Confirm, "ask", lambda *a, **k: True)
+
+    async def failing_remote_run(self, command: str, **kwargs):
+        if self.hostname == "mila":
+            return mock.Mock(returncode=1, stderr="boom")
+        clean_env.append((self.hostname, command))
+        return mock.Mock(returncode=0, stderr="")
+
+    monkeypatch.setattr(Remote, "run", failing_remote_run)
+
+    await clean()  # must not raise
+
+    assert clean_env == [("tamia", mock.ANY)]
+
+
+async def test_never_synced_cluster_is_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    config = _config(tmp_path)
+    monkeypatch.setattr(cluv.cli.clean, "get_cluv_config", lambda: config)
+    (tmp_path / "results").mkdir()
+
+    remotes = [Remote(hostname="mila")]
+    monkeypatch.setattr(cluv.cli.clean, "get_active_remotes", mock.AsyncMock(return_value=remotes))
+    monkeypatch.setattr(cluv.cli.clean, "read_cache", lambda: CacheContent())
+
+    called = mock.AsyncMock()
+    monkeypatch.setattr(cluv.cli.clean, "list_remote_run_dirs", called)
+
+    await clean()
+
+    called.assert_not_called()
+
+
+def test_clean_cli_parses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cluv_main, "clean", mock_clean := mock.AsyncMock(spec=cluv_main.clean))
+
+    cluv_main.main(["clean"])
+
+    mock_clean.assert_called_once_with(clusters=[], force=False, dry_run=False)
+
+
+def test_clean_cli_parses_force_and_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cluv_main, "clean", mock_clean := mock.AsyncMock(spec=cluv_main.clean))
+
+    cluv_main.main(["clean", "rorqual", "narval", "--force", "--dry-run"])
+
+    mock_clean.assert_called_once_with(clusters=["rorqual", "narval"], force=True, dry_run=True)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.skipif(
+    IN_GITHUB_CLOUD_CI,
+    reason="Integration tests are only run on a self-hosted github runner or on a dev machine.",
+)
+async def test_clean_removes_pruned_run_but_keeps_new_one(
+    monkeypatch: pytest.MonkeyPatch, fake_scratch: Path
+):
+    """End-to-end: an old, locally-pruned run is removed from the cluster; a brand-new,
+    never-fetched run is left alone."""
+    assert not current_cluster(), "test needs to run locally for now."
+    cluster = "tamia"
+    remote = await Remote.connect(cluster)
+
+    monkeypatch.chdir("examples/pytorch-example")
+    config = get_cluv_config()
+    results_path_on_cluster = await expandvars(
+        remote, config.get_cluster_config(cluster).results_path
+    )
+
+    await remote.run(f"rm -rf {results_path_on_cluster}", warn=True, hide=True)
+    await remote.run(f"mkdir -p {results_path_on_cluster}", hide=True)
+
+    old_run = results_path_on_cluster / "old_run"
+    await remote.run(f"mkdir -p {old_run}", hide=True)
+    await remote.run(f"touch -d '2020-01-01' {old_run}", hide=True)
+
+    await sync([cluster], uv_sync_args=None)
+
+    local_results_path = Path(os.path.expandvars(config.results_path))
+    shutil.rmtree(local_results_path / "old_run")
+
+    new_run = results_path_on_cluster / "new_run"
+    await remote.run(f"mkdir -p {new_run}", hide=True)
+
+    await clean([cluster], force=True)
+
+    remaining = (
+        (await remote.get_output(f"ls {results_path_on_cluster}", warn=True)).strip().splitlines()
+    )
+    assert "old_run" not in remaining
+    assert "new_run" in remaining

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import subprocess
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from unittest import mock
 
 import pytest
@@ -321,7 +321,8 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
     monkeypatch.chdir("examples/pytorch-example")
     config = get_cluv_config()
     results_path_on_cluster = config.get_cluster_config(cluster).results_path
-    assert results_path_on_cluster == "$SCRATCH/logs/pytorch-example"  # sanity check
+    # sanity check
+    assert results_path_on_cluster == PurePosixPath("$SCRATCH/logs/pytorch_example")
     results_path_on_cluster = await expandvars(remote, results_path_on_cluster)
 
     # Move the directory temporarily, instead of deleting it, so we can clean up after the test.
@@ -330,34 +331,35 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
         warn=True,
         hide=False,
     )
-    await remote.run(f"mkdir -p {results_path_on_cluster}", hide=True)
+    try:
+        await remote.run(f"mkdir -p {results_path_on_cluster}", hide=True)
 
-    old_run = results_path_on_cluster / "old_run"
-    await remote.run(f"mkdir -p {old_run}", hide=True)
-    await remote.run(f"touch -d '2020-01-01' {old_run}", hide=True)
+        old_run = results_path_on_cluster / "old_run"
+        await remote.run(f"mkdir -p {old_run}", hide=True)
+        await remote.run(f"touch -d '2020-01-01' {old_run}", hide=True)
 
-    await sync([cluster], sync_datasets=False)
+        await sync([cluster], sync_datasets=False)
 
-    local_results_path = Path(os.path.expandvars(config.results_path))
-    shutil.rmtree(local_results_path / "old_run")
+        local_results_path = Path(os.path.expandvars(config.results_path))
+        shutil.rmtree(local_results_path / "old_run")
 
-    new_run = results_path_on_cluster / "new_run"
-    await remote.run(f"mkdir -p {new_run}", hide=True)
+        new_run = results_path_on_cluster / "new_run"
+        await remote.run(f"mkdir -p {new_run}", hide=True)
 
-    await clean([cluster], force=True)
+        await clean([cluster], force=True)
 
-    remaining = (
-        (await remote.get_output(f"ls {results_path_on_cluster}", warn=True, hide=False))
-        .strip()
-        .splitlines()
-    )
-    assert "old_run" not in remaining
-    assert "new_run" in remaining
-
-    # Cleanup after the test.
-    await remote.run(f"rmdir {results_path_on_cluster / 'new_run'}", hide=False)
-    await remote.run(f"rmdir {results_path_on_cluster}", hide=False)
-    await remote.run(
-        f"mv {results_path_on_cluster.with_suffix('.backup')} {results_path_on_cluster}",
-        hide=False,
-    )
+        remaining = (
+            (await remote.get_output(f"ls {results_path_on_cluster}", warn=True, hide=False))
+            .strip()
+            .splitlines()
+        )
+        assert "old_run" not in remaining
+        assert "new_run" in remaining
+    finally:
+        # Cleanup after the test.
+        await remote.run(f"rmdir {results_path_on_cluster / 'new_run'}", hide=False)
+        await remote.run(f"rmdir {results_path_on_cluster}", hide=False)
+        await remote.run(
+            f"mv {results_path_on_cluster.with_suffix('.backup')} {results_path_on_cluster}",
+            hide=False,
+        )

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import importlib
 import os
 import shutil
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest import mock
 
 import pytest
+import rich.prompt
 
 import cluv.__main__ as cluv_main
 import cluv.cli.clean
@@ -34,7 +36,7 @@ sync_module = importlib.import_module("cluv.cli.sync")
 
 
 async def test_fetch_results_updates_watermark(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    async def fake_list_remote_run_dirs(remote, path):
+    async def fake_list_remote_run_dirs(remote: Remote, path):
         return [
             ("run_a", datetime(2026, 7, 1, tzinfo=timezone.utc)),
             ("run_b", datetime(2026, 7, 3, tzinfo=timezone.utc)),
@@ -50,9 +52,9 @@ async def test_fetch_results_updates_watermark(tmp_path: Path, monkeypatch: pyte
 
     config = CluvConfig(
         results_path=str(tmp_path / "results"),
-        clusters={"mila": PartialClusterConfig(project_dir="/home/user/myproject")},
+        clusters={"foo": PartialClusterConfig(project_dir="/home/user/myproject")},
     )
-    remote = Remote(hostname="mila")
+    remote = Remote(hostname="foo")
     project_state = ProjectStateOnCluster()
 
     await fetch_results(remote, config, project_state)
@@ -77,11 +79,7 @@ def test_never_synced_cluster_selects_nothing():
     assert compute_runs_to_delete(set(), remote_runs, watermark=None) == []
 
 
-def test_new_run_not_the_newest_is_still_kept():
-    """Guards against re-deriving the watermark as max(remote mtimes) *inside* this
-    function instead of using the externally-supplied, previously-cached watermark --
-    the over-deletion bug found while designing this feature (see the design spec's
-    "Rejected alternative: sync-first" section)."""
+def test_new_runs_are_kept():
     watermark = datetime(2026, 7, 1, tzinfo=timezone.utc)
     remote_runs = [
         ("new_run_1", datetime(2026, 7, 2, tzinfo=timezone.utc)),
@@ -90,26 +88,51 @@ def test_new_run_not_the_newest_is_still_kept():
     assert compute_runs_to_delete(set(), remote_runs, watermark) == []
 
 
-def _config(tmp_path: Path) -> CluvConfig:
-    return CluvConfig(
-        results_path=str(tmp_path / "results"),
-        clusters={"mila": PartialClusterConfig(), "tamia": PartialClusterConfig()},
-    )
+@pytest.fixture
+def commands_run_during_test(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> list[tuple[str, str]]:
+    """Returns the list of (hostname, command) pairs passed to `Remote.run` during the test.
+
+    Can be indirectly parametrized with a dict mapping (hostname, command) to the desired stdout string
+    to return for that command. If a command is not in the dict, it will return an empty string.
+    This allows simulating different remote outputs for different commands.
+    """
+    run_calls: list[tuple[str, str]] = []
+    command_to_output: dict[tuple[str, str], str] = getattr(request, "param", {})
+
+    async def fake_remote_run(self: Remote, command: str, **kwargs):
+        run_calls.append((self.hostname, command))
+        if (self.hostname, command) in command_to_output:
+            stdout = command_to_output[self.hostname, command]
+            return mock.Mock(
+                spec=subprocess.CompletedProcess, returncode=0, stdout=stdout, stderr=""
+            )
+        return mock.Mock(spec=subprocess.CompletedProcess, returncode=0, stderr="")
+
+    monkeypatch.setattr(Remote, "run", fake_remote_run)
+    return run_calls  # return the list, which will be modified in-place during the test.
 
 
 @pytest.fixture
-def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Two clusters, each reporting one prunable run ("run_pruned") and one kept run
-    ("run_kept", which exists locally). Returns the list of (hostname, command) pairs
-    passed to `Remote.run` -- i.e. the deletion calls actually made."""
-    config = _config(tmp_path)
+    ("run_kept", which exists locally).
+
+    Returns the list of (hostname, command) pairs passed to `Remote.run`."""
+    config = CluvConfig(
+        results_path=str(tmp_path / "results"),
+        clusters={"foo": PartialClusterConfig(), "bar": PartialClusterConfig()},
+    )
     monkeypatch.setattr(cluv.cli.clean, get_cluv_config.__name__, lambda: config)
 
-    results_path_here = tmp_path / "results"
+    results_path_here = Path(config.results_path)
     results_path_here.mkdir()
-    (results_path_here / "run_kept").mkdir()
+    (results_path_here / "foo_run_kept").mkdir()
+    (results_path_here / "bar_run_kept").mkdir()
 
-    remotes = [Remote(hostname="mila"), Remote(hostname="tamia")]
+    remotes = [Remote(hostname="foo"), Remote(hostname="bar")]
     monkeypatch.setattr(
         cluv.cli.clean, get_active_remotes.__name__, mock.AsyncMock(return_value=remotes)
     )
@@ -117,47 +140,43 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str
     watermark = datetime(2026, 7, 1, tzinfo=timezone.utc)
     cache = CacheContent(
         project_states={
-            "mila": ProjectStateOnCluster(last_fetch_watermark=watermark),
-            "tamia": ProjectStateOnCluster(last_fetch_watermark=watermark),
+            "foo": ProjectStateOnCluster(last_fetch_watermark=watermark),
+            "bar": ProjectStateOnCluster(last_fetch_watermark=watermark),
         }
     )
     monkeypatch.setattr(cluv.cli.clean, read_cache.__name__, lambda: cache)
 
-    async def fake_list_remote_run_dirs(remote, path):
+    async def fake_list_remote_run_dirs(remote: Remote, path: str):
+        cluster = remote.hostname
         return [
-            ("run_kept", datetime(2026, 6, 20, tzinfo=timezone.utc)),
-            ("run_pruned", datetime(2026, 6, 20, tzinfo=timezone.utc)),
+            (f"{cluster}_run_kept", datetime(2026, 6, 20, tzinfo=timezone.utc)),
+            (f"{cluster}_run_pruned", datetime(2026, 6, 20, tzinfo=timezone.utc)),
         ]
 
     monkeypatch.setattr(cluv.cli.clean, list_remote_run_dirs.__name__, fake_list_remote_run_dirs)
 
-    run_calls: list[tuple[str, str]] = []
 
-    async def fake_remote_run(self, command: str, **kwargs):
-        run_calls.append((self.hostname, command))
-        return mock.Mock(returncode=0, stderr="")
-
-    monkeypatch.setattr(Remote, "run", fake_remote_run)
-    return run_calls
-
-
-async def test_dry_run_makes_no_delete_calls(clean_env: list[tuple[str, str]]):
+async def test_dry_run_makes_no_delete_calls(
+    clean_env, commands_run_during_test: list[tuple[str, str]]
+):
     await clean(dry_run=True)
-    assert clean_env == []
+    assert (
+        commands_run_during_test == []
+    )  # no calls were made to Remote.run, so nothing was deleted
 
 
 async def test_declining_confirmation_makes_no_delete_calls(
-    clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+    clean_env, commands_run_during_test: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setattr(
         cluv.cli.clean.Confirm, cluv.cli.clean.Confirm.ask.__name__, lambda *a, **k: False
     )
     await clean()
-    assert clean_env == []
+    assert commands_run_during_test == []
 
 
 async def test_force_skips_confirmation_and_deletes(
-    clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+    clean_env, commands_run_during_test: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
 ):
     ask = mock.Mock()
     monkeypatch.setattr(cluv.cli.clean.Confirm, cluv.cli.clean.Confirm.ask.__name__, ask)
@@ -165,29 +184,38 @@ async def test_force_skips_confirmation_and_deletes(
     await clean(force=True)
 
     ask.assert_not_called()
-    assert len(clean_env) == 2
-    for _hostname, command in clean_env:
+    assert len(commands_run_during_test) == 2
+    for _hostname, command in commands_run_during_test:
         assert "run_pruned" in command
         assert "run_kept" not in command
 
 
 async def test_confirming_deletes_pruned_run_on_every_cluster(
-    clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+    clean_env, commands_run_during_test: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setattr(
-        cluv.cli.clean.Confirm, cluv.cli.clean.Confirm.ask.__name__, lambda *a, **k: True
+        cluv.cli.clean.Confirm,
+        cluv.cli.clean.Confirm.ask.__name__,
+        mock_ask := mock.Mock(spec=cluv.cli.clean.Confirm.ask, side_effect=lambda *a, **k: True),
     )
 
     await clean()
+    mock_ask.assert_called_once()
+    assert {hostname for hostname, _ in commands_run_during_test} == {"foo", "bar"}
 
-    assert {hostname for hostname, _ in clean_env} == {"mila", "tamia"}
 
-
+@pytest.mark.parametrize(
+    commands_run_during_test.__name__,
+    [{("foo", "rm -rf /results/foo_run_pruned"): ""}],
+    indirect=True,
+)
 async def test_one_cluster_failure_does_not_abort_the_others(
-    clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+    clean_env, commands_run_during_test: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setattr(
-        cluv.cli.clean.Confirm, cluv.cli.clean.Confirm.ask.__name__, lambda *a, **k: True
+        cluv.cli.clean.Confirm,
+        cluv.cli.clean.Confirm.ask.__name__,
+        mock_confirm := mock.Mock(spec=rich.prompt.Confirm.ask, return_value=True),
     )
 
     async def failing_remote_run(self, command: str, **kwargs):
@@ -199,12 +227,16 @@ async def test_one_cluster_failure_does_not_abort_the_others(
     monkeypatch.setattr(Remote, "run", failing_remote_run)
 
     await clean()  # must not raise
+    mock_confirm.assert_called_once()
 
     assert clean_env == [("tamia", mock.ANY)]
 
 
 async def test_never_synced_cluster_is_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    config = _config(tmp_path)
+    config = CluvConfig(
+        results_path=str(tmp_path / "results"),
+        clusters={"mila": PartialClusterConfig(), "tamia": PartialClusterConfig()},
+    )
     monkeypatch.setattr(cluv.cli.clean, get_cluv_config.__name__, lambda: config)
     (tmp_path / "results").mkdir()
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -89,9 +89,21 @@ def test_new_runs_are_kept():
 
 
 @pytest.fixture
+def expected_commands(
+    request: pytest.FixtureRequest,
+) -> dict[tuple[str, str], str | subprocess.CalledProcessError]:
+    """Returns a dict mapping (hostname, command) to the desired stdout string or error.
+
+    If a command is not in the dict, it will return an empty string. This allows simulating different remote outputs for different commands.
+    """
+    return getattr(request, "param", {})
+
+
+@pytest.fixture
 def commands_run_during_test(
     monkeypatch: pytest.MonkeyPatch,
     request: pytest.FixtureRequest,
+    expected_commands: dict[tuple[str, str], str | subprocess.CalledProcessError],
 ) -> list[tuple[str, str]]:
     """Returns the list of (hostname, command) pairs passed to `Remote.run` during the test.
 
@@ -100,12 +112,14 @@ def commands_run_during_test(
     This allows simulating different remote outputs for different commands.
     """
     run_calls: list[tuple[str, str]] = []
-    command_to_output: dict[tuple[str, str], str] = getattr(request, "param", {})
 
     async def fake_remote_run(self: Remote, command: str, **kwargs):
         run_calls.append((self.hostname, command))
-        if (self.hostname, command) in command_to_output:
-            stdout = command_to_output[self.hostname, command]
+        if (self.hostname, command) in expected_commands:
+            stdout_or_error = expected_commands[self.hostname, command]
+            if isinstance(stdout_or_error, subprocess.CalledProcessError):
+                raise stdout_or_error
+            stdout = stdout_or_error
             return mock.Mock(
                 spec=subprocess.CompletedProcess, returncode=0, stdout=stdout, stderr=""
             )
@@ -176,60 +190,65 @@ async def test_declining_confirmation_makes_no_delete_calls(
 
 
 async def test_force_skips_confirmation_and_deletes(
-    clean_env, commands_run_during_test: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+    clean_env,
+    commands_run_during_test: list[tuple[str, str]],
+    mock_confirm: mock.Mock,
 ):
-    ask = mock.Mock()
-    monkeypatch.setattr(cluv.cli.clean.Confirm, cluv.cli.clean.Confirm.ask.__name__, ask)
-
     await clean(force=True)
 
-    ask.assert_not_called()
+    mock_confirm.assert_not_called()
     assert len(commands_run_during_test) == 2
-    for _hostname, command in commands_run_during_test:
-        assert "run_pruned" in command
-        assert "run_kept" not in command
+    for hostname, command in commands_run_during_test:
+        assert f"{hostname}_run_pruned" in command
+        assert f"{hostname}_run_kept" not in command
 
 
 async def test_confirming_deletes_pruned_run_on_every_cluster(
-    clean_env, commands_run_during_test: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+    clean_env,
+    commands_run_during_test: list[tuple[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+    mock_confirm: mock.Mock,
 ):
-    monkeypatch.setattr(
-        cluv.cli.clean.Confirm,
-        cluv.cli.clean.Confirm.ask.__name__,
-        mock_ask := mock.Mock(spec=cluv.cli.clean.Confirm.ask, side_effect=lambda *a, **k: True),
-    )
-
     await clean()
-    mock_ask.assert_called_once()
-    assert {hostname for hostname, _ in commands_run_during_test} == {"foo", "bar"}
-
-
-@pytest.mark.parametrize(
-    commands_run_during_test.__name__,
-    [{("foo", "rm -rf /results/foo_run_pruned"): ""}],
-    indirect=True,
-)
-async def test_one_cluster_failure_does_not_abort_the_others(
-    clean_env, commands_run_during_test: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
-):
-    monkeypatch.setattr(
-        cluv.cli.clean.Confirm,
-        cluv.cli.clean.Confirm.ask.__name__,
-        mock_confirm := mock.Mock(spec=rich.prompt.Confirm.ask, return_value=True),
+    mock_confirm.assert_called_once()
+    assert sorted(commands_run_during_test) == sorted(
+        [
+            ("foo", "rm -rf /results/foo_run_pruned"),
+            ("bar", "rm -rf /results/bar_run_pruned"),
+        ]
     )
 
-    async def failing_remote_run(self, command: str, **kwargs):
-        if self.hostname == "mila":
-            return mock.Mock(returncode=1, stderr="boom")
-        clean_env.append((self.hostname, command))
-        return mock.Mock(returncode=0, stderr="")
 
-    monkeypatch.setattr(Remote, "run", failing_remote_run)
+async def test_one_cluster_failure_does_not_abort_the_others(
+    clean_env,
+    commands_run_during_test: list[tuple[str, str]],
+    expected_commands: dict[tuple[str, str], str | subprocess.CalledProcessError],
+    mock_confirm: mock.Mock,
+):
+    expected_commands.update(
+        {
+            ("foo", "rm -rf /results/foo_run_pruned"): subprocess.CalledProcessError(
+                1, "rm -rf /results/foo_run_pruned", stderr="boom"
+            ),
+            ("bar", "rm -rf /results/bar_run_pruned"): "",
+        }
+    )
 
     await clean()  # must not raise
     mock_confirm.assert_called_once()
 
-    assert clean_env == [("tamia", mock.ANY)]
+    assert commands_run_during_test == [("bar", "rm -rf /results/bar_run_pruned")]
+
+
+@pytest.fixture
+def mock_confirm(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest):
+    value = getattr(request, "param", True)
+    monkeypatch.setattr(
+        cluv.cli.clean.Confirm,
+        cluv.cli.clean.Confirm.ask.__name__,
+        mock_confirm := mock.Mock(spec=rich.prompt.Confirm.ask, return_value=value),
+    )
+    return mock_confirm
 
 
 async def test_never_synced_cluster_is_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -274,6 +293,7 @@ def test_clean_cli_parses_force_and_dry_run(monkeypatch: pytest.MonkeyPatch) -> 
     mock_clean.assert_called_once_with(clusters=["rorqual", "narval"], force=True, dry_run=True)
 
 
+@pytest.mark.parametrize("cluster", "tamia", indirect=True)
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.skipif(
@@ -281,19 +301,18 @@ def test_clean_cli_parses_force_and_dry_run(monkeypatch: pytest.MonkeyPatch) -> 
     reason="Integration tests are only run on a self-hosted github runner or on a dev machine.",
 )
 async def test_clean_removes_pruned_run_but_keeps_new_one(
-    monkeypatch: pytest.MonkeyPatch, fake_scratch: Path
+    cluster: str, remote: Remote, monkeypatch: pytest.MonkeyPatch, fake_scratch: Path
 ):
     """End-to-end: an old, locally-pruned run is removed from the cluster; a brand-new,
     never-fetched run is left alone."""
     assert not current_cluster(), "test needs to run locally for now."
-    cluster = "tamia"
-    remote = await Remote.connect(cluster)
 
     monkeypatch.chdir("examples/pytorch-example")
     config = get_cluv_config()
     results_path_on_cluster = await expandvars(
         remote, config.get_cluster_config(cluster).results_path
     )
+    assert False, results_path_on_cluster  # TODO: remove this assert after debugging
 
     await remote.run(f"rm -rf {results_path_on_cluster}", warn=True, hide=True)
     await remote.run(f"mkdir -p {results_path_on_cluster}", hide=True)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -328,7 +328,6 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
     # Move the directory temporarily, instead of deleting it, so we can clean up after the test.
     await remote.run(
         f"mv {results_path_on_cluster} {results_path_on_cluster.with_suffix('.backup')}",
-        warn=True,
         hide=False,
     )
     try:
@@ -357,7 +356,8 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
         assert "new_run" in remaining
     finally:
         # Cleanup after the test.
-        await remote.run(f"rmdir {results_path_on_cluster / 'new_run'}", hide=False)
+        await remote.run(f"rmdir {results_path_on_cluster / 'old_run'}", hide=False, warn=True)
+        await remote.run(f"rmdir {results_path_on_cluster / 'new_run'}", hide=False, warn=True)
         await remote.run(f"rmdir {results_path_on_cluster}", hide=False)
         await remote.run(
             f"mv {results_path_on_cluster.with_suffix('.backup')} {results_path_on_cluster}",

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -13,11 +13,17 @@ import pytest
 
 import cluv.__main__ as cluv_main
 import cluv.cli.clean
-from cluv.cache import CacheContent, ProjectStateOnCluster
+from cluv.cache import CacheContent, ProjectStateOnCluster, read_cache
 from cluv.cli.clean import clean, compute_runs_to_delete
-from cluv.cli.sync import expandvars, fetch_results, sync
+from cluv.cli.sync import (
+    create_results_dir_with_symlink_to_scratch,
+    expandvars,
+    fetch_results,
+    get_active_remotes,
+    sync,
+)
 from cluv.config import CluvConfig, PartialClusterConfig, get_cluv_config
-from cluv.remote import Remote
+from cluv.remote import Remote, list_remote_run_dirs, run
 from cluv.utils import current_cluster
 from tests.test_integration import IN_GITHUB_CLOUD_CI
 
@@ -25,6 +31,10 @@ from tests.test_integration import IN_GITHUB_CLOUD_CI
 # submodule attribute with the `sync` function. Use `importlib.import_module` (same idiom as
 # `tests/test_init.py`) to get the actual module object for monkeypatching.
 sync_module = importlib.import_module("cluv.cli.sync")
+
+# Captured once, before any test monkeypatches `Remote.run` -- reading `Remote.run.__name__`
+# *after* a patch is applied would return the replacement's name instead of "run".
+_REMOTE_RUN_NAME = Remote.run.__name__
 
 
 async def test_fetch_results_updates_watermark(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -34,11 +44,13 @@ async def test_fetch_results_updates_watermark(tmp_path: Path, monkeypatch: pyte
             ("run_b", datetime(2026, 7, 3, tzinfo=timezone.utc)),
         ]
 
-    monkeypatch.setattr(sync_module, "list_remote_run_dirs", fake_list_remote_run_dirs)
+    monkeypatch.setattr(sync_module, list_remote_run_dirs.__name__, fake_list_remote_run_dirs)
     monkeypatch.setattr(
-        sync_module, "create_results_dir_with_symlink_to_scratch", mock.AsyncMock()
+        sync_module,
+        create_results_dir_with_symlink_to_scratch.__name__,
+        mock.AsyncMock(),
     )
-    monkeypatch.setattr(sync_module, "run", mock.AsyncMock())
+    monkeypatch.setattr(sync_module, run.__name__, mock.AsyncMock())
 
     config = CluvConfig(
         results_path=str(tmp_path / "results"),
@@ -95,14 +107,16 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str
     ("run_kept", which exists locally). Returns the list of (hostname, command) pairs
     passed to `Remote.run` -- i.e. the deletion calls actually made."""
     config = _config(tmp_path)
-    monkeypatch.setattr(cluv.cli.clean, "get_cluv_config", lambda: config)
+    monkeypatch.setattr(cluv.cli.clean, get_cluv_config.__name__, lambda: config)
 
     results_path_here = tmp_path / "results"
     results_path_here.mkdir()
     (results_path_here / "run_kept").mkdir()
 
     remotes = [Remote(hostname="mila"), Remote(hostname="tamia")]
-    monkeypatch.setattr(cluv.cli.clean, "get_active_remotes", mock.AsyncMock(return_value=remotes))
+    monkeypatch.setattr(
+        cluv.cli.clean, get_active_remotes.__name__, mock.AsyncMock(return_value=remotes)
+    )
 
     watermark = datetime(2026, 7, 1, tzinfo=timezone.utc)
     cache = CacheContent(
@@ -111,7 +125,7 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str
             "tamia": ProjectStateOnCluster(last_fetch_watermark=watermark),
         }
     )
-    monkeypatch.setattr(cluv.cli.clean, "read_cache", lambda: cache)
+    monkeypatch.setattr(cluv.cli.clean, read_cache.__name__, lambda: cache)
 
     async def fake_list_remote_run_dirs(remote, path):
         return [
@@ -119,7 +133,7 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str
             ("run_pruned", datetime(2026, 6, 20, tzinfo=timezone.utc)),
         ]
 
-    monkeypatch.setattr(cluv.cli.clean, "list_remote_run_dirs", fake_list_remote_run_dirs)
+    monkeypatch.setattr(cluv.cli.clean, list_remote_run_dirs.__name__, fake_list_remote_run_dirs)
 
     run_calls: list[tuple[str, str]] = []
 
@@ -127,7 +141,7 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str
         run_calls.append((self.hostname, command))
         return mock.Mock(returncode=0, stderr="")
 
-    monkeypatch.setattr(Remote, "run", fake_remote_run)
+    monkeypatch.setattr(Remote, _REMOTE_RUN_NAME, fake_remote_run)
     return run_calls
 
 
@@ -139,7 +153,9 @@ async def test_dry_run_makes_no_delete_calls(clean_env: list[tuple[str, str]]):
 async def test_declining_confirmation_makes_no_delete_calls(
     clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
 ):
-    monkeypatch.setattr(cluv.cli.clean.Confirm, "ask", lambda *a, **k: False)
+    monkeypatch.setattr(
+        cluv.cli.clean.Confirm, cluv.cli.clean.Confirm.ask.__name__, lambda *a, **k: False
+    )
     await clean()
     assert clean_env == []
 
@@ -148,7 +164,7 @@ async def test_force_skips_confirmation_and_deletes(
     clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
 ):
     ask = mock.Mock()
-    monkeypatch.setattr(cluv.cli.clean.Confirm, "ask", ask)
+    monkeypatch.setattr(cluv.cli.clean.Confirm, cluv.cli.clean.Confirm.ask.__name__, ask)
 
     await clean(force=True)
 
@@ -162,7 +178,9 @@ async def test_force_skips_confirmation_and_deletes(
 async def test_confirming_deletes_pruned_run_on_every_cluster(
     clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
 ):
-    monkeypatch.setattr(cluv.cli.clean.Confirm, "ask", lambda *a, **k: True)
+    monkeypatch.setattr(
+        cluv.cli.clean.Confirm, cluv.cli.clean.Confirm.ask.__name__, lambda *a, **k: True
+    )
 
     await clean()
 
@@ -172,7 +190,9 @@ async def test_confirming_deletes_pruned_run_on_every_cluster(
 async def test_one_cluster_failure_does_not_abort_the_others(
     clean_env: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
 ):
-    monkeypatch.setattr(cluv.cli.clean.Confirm, "ask", lambda *a, **k: True)
+    monkeypatch.setattr(
+        cluv.cli.clean.Confirm, cluv.cli.clean.Confirm.ask.__name__, lambda *a, **k: True
+    )
 
     async def failing_remote_run(self, command: str, **kwargs):
         if self.hostname == "mila":
@@ -180,7 +200,7 @@ async def test_one_cluster_failure_does_not_abort_the_others(
         clean_env.append((self.hostname, command))
         return mock.Mock(returncode=0, stderr="")
 
-    monkeypatch.setattr(Remote, "run", failing_remote_run)
+    monkeypatch.setattr(Remote, _REMOTE_RUN_NAME, failing_remote_run)
 
     await clean()  # must not raise
 
@@ -189,15 +209,17 @@ async def test_one_cluster_failure_does_not_abort_the_others(
 
 async def test_never_synced_cluster_is_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     config = _config(tmp_path)
-    monkeypatch.setattr(cluv.cli.clean, "get_cluv_config", lambda: config)
+    monkeypatch.setattr(cluv.cli.clean, get_cluv_config.__name__, lambda: config)
     (tmp_path / "results").mkdir()
 
     remotes = [Remote(hostname="mila")]
-    monkeypatch.setattr(cluv.cli.clean, "get_active_remotes", mock.AsyncMock(return_value=remotes))
-    monkeypatch.setattr(cluv.cli.clean, "read_cache", lambda: CacheContent())
+    monkeypatch.setattr(
+        cluv.cli.clean, get_active_remotes.__name__, mock.AsyncMock(return_value=remotes)
+    )
+    monkeypatch.setattr(cluv.cli.clean, read_cache.__name__, lambda: CacheContent())
 
     called = mock.AsyncMock()
-    monkeypatch.setattr(cluv.cli.clean, "list_remote_run_dirs", called)
+    monkeypatch.setattr(cluv.cli.clean, list_remote_run_dirs.__name__, called)
 
     await clean()
 
@@ -205,7 +227,9 @@ async def test_never_synced_cluster_is_skipped(tmp_path: Path, monkeypatch: pyte
 
 
 def test_clean_cli_parses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(cluv_main, "clean", mock_clean := mock.AsyncMock(spec=cluv_main.clean))
+    monkeypatch.setattr(
+        cluv_main, cluv_main.clean.__name__, mock_clean := mock.AsyncMock(spec=cluv_main.clean)
+    )
 
     cluv_main.main(["clean"])
 
@@ -213,7 +237,9 @@ def test_clean_cli_parses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_clean_cli_parses_force_and_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(cluv_main, "clean", mock_clean := mock.AsyncMock(spec=cluv_main.clean))
+    monkeypatch.setattr(
+        cluv_main, cluv_main.clean.__name__, mock_clean := mock.AsyncMock(spec=cluv_main.clean)
+    )
 
     cluv_main.main(["clean", "rorqual", "narval", "--force", "--dry-run"])
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -14,8 +14,9 @@ import pytest
 import rich.prompt
 
 import cluv.__main__ as cluv_main
+import cluv.cache
 import cluv.cli.clean
-from cluv.cache import CacheContent, ProjectStateOnCluster, read_cache
+from cluv.cache import CacheContent, ProjectStateOnCluster, read_cache, write_cache
 from cluv.cli.clean import clean, compute_runs_to_delete
 from cluv.cli.sync import (
     create_results_dir_with_symlink_to_scratch,
@@ -74,6 +75,15 @@ def test_run_present_locally_is_kept():
     watermark = datetime(2026, 7, 1, tzinfo=timezone.utc)
     remote_runs = [("run_a", datetime(2026, 6, 30, tzinfo=timezone.utc))]
     assert compute_runs_to_delete({"run_a"}, remote_runs, watermark) == []
+
+
+def test_pruned_run_equal_to_watermark_is_selected():
+    """A run that was itself the max-mtime run during the last sync sets the watermark to its own
+    mtime. Since it was seen (and thus is safe to prune once removed locally), it must be selected
+    even though its mtime is not *strictly* less than the watermark."""
+    watermark = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    remote_runs = [("old_run", datetime(2020, 1, 1, tzinfo=timezone.utc))]
+    assert compute_runs_to_delete(set(), remote_runs, watermark) == ["old_run"]
 
 
 def test_never_synced_cluster_selects_nothing():
@@ -303,6 +313,26 @@ def test_clean_cli_parses_force_and_dry_run(monkeypatch: pytest.MonkeyPatch) -> 
     mock_clean.assert_called_once_with(clusters=["rorqual", "narval"], force=True, dry_run=True)
 
 
+@pytest.fixture
+def clear_cluv_cache(monkeypatch: pytest.MonkeyPatch):
+    """Clear the cluv cache before each test to avoid state leakage."""
+    cache = CacheContent()
+
+    def _write_cache(content: CacheContent):
+        nonlocal cache
+        cache = content
+
+    monkeypatch.setattr(cluv.cache, read_cache.__name__, lambda: cache)
+    monkeypatch.setattr(cluv.cache, write_cache.__name__, _write_cache)
+    monkeypatch.setattr(sync_module, read_cache.__name__, lambda: cache)
+    monkeypatch.setattr(sync_module, write_cache.__name__, _write_cache)
+    # `cluv.cli.clean` does `from cluv.cache import read_cache`, a separate name binding that
+    # patching `cluv.cache.read_cache` above doesn't affect -- it must be patched directly too.
+    monkeypatch.setattr(cluv.cli.clean, read_cache.__name__, lambda: cache)
+
+    yield
+
+
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.skipif(
@@ -313,11 +343,12 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
     cluster: str,  # noqa
     remote: Remote,  # noqa
     monkeypatch: pytest.MonkeyPatch,
+    clear_cluv_cache: None,
 ):
     """End-to-end: an old, locally-pruned run is removed from the cluster; a brand-new,
     never-fetched run is left alone."""
     assert not current_cluster(), "test needs to run locally for now."
-
+    assert cluv.cache.read_cache() == CacheContent(), "test assumes no previous cache content"
     monkeypatch.chdir("examples/pytorch-example")
     config = get_cluv_config()
     results_path_on_cluster = config.get_cluster_config(cluster).results_path
@@ -325,6 +356,10 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
     assert results_path_on_cluster == PurePosixPath("$SCRATCH/logs/pytorch_example")
     results_path_on_cluster = await expandvars(remote, results_path_on_cluster)
 
+    local_results_path = Path(os.path.expandvars(config.results_path))
+    # Move the local results dir:
+    if local_results_path.exists():
+        local_results_path.rename(local_results_path.with_suffix(".backup"))
     # Move the directory temporarily, instead of deleting it, so we can clean up after the test.
     await remote.run(
         f"mv {results_path_on_cluster} {results_path_on_cluster.with_suffix('.backup')}",
@@ -336,10 +371,12 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
         old_run = results_path_on_cluster / "old_run"
         await remote.run(f"mkdir -p {old_run}", hide=True)
         await remote.run(f"touch -d '2020-01-01' {old_run}", hide=True)
-
         await sync([cluster], sync_datasets=False)
 
-        local_results_path = Path(os.path.expandvars(config.results_path))
+        last_fetch_watermark = cluv.cache.read_cache().project_states[cluster].last_fetch_watermark
+        assert last_fetch_watermark
+        assert last_fetch_watermark.replace(hour=0) == datetime(2020, 1, 1, tzinfo=timezone.utc)
+
         shutil.rmtree(local_results_path / "old_run")
 
         new_run = results_path_on_cluster / "new_run"
@@ -356,6 +393,12 @@ async def test_clean_removes_pruned_run_but_keeps_new_one(
         assert "new_run" in remaining
     finally:
         # Cleanup after the test.
+        print("Test cleanup.")
+        # Restore the local results dir, if it existed before the test.
+        shutil.rmtree(local_results_path)
+        if (local_results_dir_backup := local_results_path.with_suffix(".backup")).exists():
+            local_results_dir_backup.rename(local_results_path)
+
         await remote.run(f"rmdir {results_path_on_cluster / 'old_run'}", hide=False, warn=True)
         await remote.run(f"rmdir {results_path_on_cluster / 'new_run'}", hide=False, warn=True)
         await remote.run(f"rmdir {results_path_on_cluster}", hide=False)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -150,8 +150,8 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config = CluvConfig(
         results_path=str(tmp_path / "results"),
         clusters={
-            "foo": PartialClusterConfig(results_path="/results"),
-            "bar": PartialClusterConfig(results_path="/results"),
+            "foo": PartialClusterConfig(results_path="/foo/results"),
+            "bar": PartialClusterConfig(results_path="/bar/results"),
         },
     )
     monkeypatch.setattr(cluv.cli.clean, get_cluv_config.__name__, lambda: config)
@@ -175,8 +175,12 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(cluv.cli.clean, read_cache.__name__, lambda: cache)
 
-    async def fake_list_remote_run_dirs(remote: Remote):  # noqa
+    async def fake_list_remote_run_dirs(
+        remote: Remote,  # noqa
+        path: PurePosixPath,
+    ) -> list[tuple[str, datetime]]:
         cluster = remote.hostname  # noqa
+        assert path == PurePosixPath(f"/{cluster}/results")
         return [
             (f"{cluster}_run_kept", datetime(2026, 6, 20, tzinfo=timezone.utc)),
             (f"{cluster}_run_pruned", datetime(2026, 6, 20, tzinfo=timezone.utc)),
@@ -228,8 +232,8 @@ async def test_confirming_deletes_pruned_run_on_every_cluster(
     mock_confirm.assert_called_once()
     assert sorted(commands_run_during_test) == sorted(
         [
-            ("foo", "rm -rf /results/foo_run_pruned"),
-            ("bar", "rm -rf /results/bar_run_pruned"),
+            ("foo", "rm -rf /foo/results/foo_run_pruned"),
+            ("bar", "rm -rf /bar/results/bar_run_pruned"),
         ]
     )
 
@@ -242,10 +246,10 @@ async def test_one_cluster_failure_does_not_abort_the_others(
 ):
     expected_commands.update(
         {
-            ("foo", "rm -rf /results/foo_run_pruned"): subprocess.CalledProcessError(
-                1, "rm -rf /results/foo_run_pruned", stderr="boom"
+            ("foo", "rm -rf /foo/results/foo_run_pruned"): subprocess.CalledProcessError(
+                1, "rm -rf /foo/results/foo_run_pruned", stderr="boom"
             ),
-            ("bar", "rm -rf /results/bar_run_pruned"): "",
+            ("bar", "rm -rf /bar/results/bar_run_pruned"): "",
         }
     )
 
@@ -254,8 +258,8 @@ async def test_one_cluster_failure_does_not_abort_the_others(
 
     assert sorted(commands_run_during_test) == sorted(
         [
-            ("foo", "rm -rf /results/foo_run_pruned"),
-            ("bar", "rm -rf /results/bar_run_pruned"),
+            ("foo", "rm -rf /foo/results/foo_run_pruned"),
+            ("bar", "rm -rf /bar/results/bar_run_pruned"),
         ]
     )
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -30,7 +30,7 @@ from cluv.remote import Remote, list_remote_run_dirs, run
 from cluv.utils import current_cluster
 
 # Note: Need to import these fixtures for now. If they were moved to conftest, we wouldn't need to.
-from tests.test_integration import IN_GITHUB_CLOUD_CI, cluster, remote  # noqa
+from tests.test_integration import IN_GITHUB_CLOUD_CI
 
 # `cluv/cli/__init__.py` does `from .sync import sync`, which shadows the `cluv.cli.sync`
 # submodule attribute with the `sync` function. Use `importlib.import_module` (same idiom as
@@ -57,7 +57,7 @@ async def test_fetch_results_updates_watermark(tmp_path: Path, monkeypatch: pyte
         results_path=str(tmp_path / "results"),
         clusters={"foo": PartialClusterConfig(project_dir="/home/user/myproject")},
     )
-    remote = Remote(hostname="foo")  # noqa
+    remote = Remote(hostname="foo")
     project_state = ProjectStateOnCluster()
 
     await fetch_results(remote, config, project_state)
@@ -176,10 +176,9 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cluv.cli.clean, read_cache.__name__, lambda: cache)
 
     async def fake_list_remote_run_dirs(
-        remote: Remote,  # noqa
-        path: PurePosixPath,
+        remote: Remote, path: PurePosixPath
     ) -> list[tuple[str, datetime]]:
-        cluster = remote.hostname  # noqa
+        cluster = remote.hostname
         assert path == PurePosixPath(f"/{cluster}/results")
         return [
             (f"{cluster}_run_kept", datetime(2026, 6, 20, tzinfo=timezone.utc)),
@@ -344,8 +343,8 @@ def clear_cluv_cache(monkeypatch: pytest.MonkeyPatch):
     reason="Integration tests are only run on a self-hosted github runner or on a dev machine.",
 )
 async def test_clean_removes_pruned_run_but_keeps_new_one(
-    cluster: str,  # noqa
-    remote: Remote,  # noqa
+    cluster: str,
+    remote: Remote,
     monkeypatch: pytest.MonkeyPatch,
     clear_cluv_cache: None,
 ):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -25,7 +25,10 @@ async def test_list_remote_run_dirs_parses_find_output(monkeypatch: pytest.Monke
 
 
 async def test_list_remote_run_dirs_empty_when_path_missing(monkeypatch: pytest.MonkeyPatch):
+    calls = []
+
     async def fake_get_output(self, command: str, **kwargs) -> str:
+        calls.append(kwargs)
         return ""
 
     monkeypatch.setattr(Remote, "get_output", fake_get_output)
@@ -34,3 +37,4 @@ async def test_list_remote_run_dirs_empty_when_path_missing(monkeypatch: pytest.
     result = await list_remote_run_dirs(remote, PurePosixPath("/scratch/results"))
 
     assert result == []
+    assert calls[0].get("warn") is True

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -13,7 +13,7 @@ async def test_list_remote_run_dirs_parses_find_output(monkeypatch: pytest.Monke
         assert command.startswith("find ")
         return "1751328000.0 run_a\n1751414400.5 run_b\n"
 
-    monkeypatch.setattr(Remote, "get_output", fake_get_output)
+    monkeypatch.setattr(Remote, Remote.get_output.__name__, fake_get_output)
 
     remote = Remote(hostname="mila")
     result = await list_remote_run_dirs(remote, PurePosixPath("/scratch/results"))
@@ -31,7 +31,7 @@ async def test_list_remote_run_dirs_empty_when_path_missing(monkeypatch: pytest.
         calls.append(kwargs)
         return ""
 
-    monkeypatch.setattr(Remote, "get_output", fake_get_output)
+    monkeypatch.setattr(Remote, Remote.get_output.__name__, fake_get_output)
 
     remote = Remote(hostname="mila")
     result = await list_remote_run_dirs(remote, PurePosixPath("/scratch/results"))

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,36 @@
+"""Tests for cluv.remote helpers that don't require a real SSH connection."""
+
+from datetime import datetime, timezone
+from pathlib import PurePosixPath
+
+import pytest
+
+from cluv.remote import Remote, list_remote_run_dirs
+
+
+async def test_list_remote_run_dirs_parses_find_output(monkeypatch: pytest.MonkeyPatch):
+    async def fake_get_output(self, command: str, **kwargs) -> str:
+        assert command.startswith("find ")
+        return "1751328000.0 run_a\n1751414400.5 run_b\n"
+
+    monkeypatch.setattr(Remote, "get_output", fake_get_output)
+
+    remote = Remote(hostname="mila")
+    result = await list_remote_run_dirs(remote, PurePosixPath("/scratch/results"))
+
+    assert result == [
+        ("run_a", datetime.fromtimestamp(1751328000.0, tz=timezone.utc)),
+        ("run_b", datetime.fromtimestamp(1751414400.5, tz=timezone.utc)),
+    ]
+
+
+async def test_list_remote_run_dirs_empty_when_path_missing(monkeypatch: pytest.MonkeyPatch):
+    async def fake_get_output(self, command: str, **kwargs) -> str:
+        return ""
+
+    monkeypatch.setattr(Remote, "get_output", fake_get_output)
+
+    remote = Remote(hostname="mila")
+    result = await list_remote_run_dirs(remote, PurePosixPath("/scratch/results"))
+
+    assert result == []

--- a/tests/test_sync_cache.py
+++ b/tests/test_sync_cache.py
@@ -1,0 +1,69 @@
+"""Regression test for a cache-clobbering race in `sync_task_function`.
+
+Each cluster's `sync_task_function` call used to read the whole on-disk cache once at the
+start, then repeatedly write that same stale snapshot back after each step. Since `sync()`
+runs every cluster's task concurrently, whichever cluster's task saved last would overwrite
+every other cluster's just-written state -- including `last_fetch_watermark`, which is
+exactly what `cluv clean` depends on to avoid over-deleting.
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timezone
+from unittest import mock
+
+import pytest
+
+from cluv.cache import ProjectStateOnCluster, read_cache, write_cache
+from cluv.config import CluvConfig, PartialClusterConfig
+from cluv.remote import Remote
+
+sync_module = importlib.import_module("cluv.cli.sync")
+
+
+@pytest.fixture
+def fake_cache_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    import cluv.cache
+
+    monkeypatch.setattr(cluv.cache, cluv.cache._get_cache_dir.__name__, lambda: cache_dir)
+    return cache_dir
+
+
+async def test_save_does_not_clobber_a_concurrently_written_cluster(
+    tmp_path, fake_cache_dir, monkeypatch: pytest.MonkeyPatch
+):
+    config = CluvConfig(
+        results_path=str(tmp_path / "results"),
+        clusters={"foo": PartialClusterConfig(project_dir="/home/user/proj")},
+    )
+    monkeypatch.setattr(sync_module, sync_module.get_cluv_config.__name__, lambda: config)
+    monkeypatch.setattr(sync_module, sync_module.install_uv.__name__, mock.AsyncMock())
+    monkeypatch.setattr(sync_module, sync_module.clone_project.__name__, mock.AsyncMock())
+    monkeypatch.setattr(sync_module, sync_module.run_uv_sync.__name__, mock.AsyncMock())
+
+    bar_watermark = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    async def fake_fetch_results(remote, config, project_state):
+        # Simulate a sibling cluster's sync_task_function completing and writing its own
+        # state to disk while our own task is still in progress.
+        cache = read_cache()
+        cache.project_states["bar"] = ProjectStateOnCluster(last_fetch_watermark=bar_watermark)
+        write_cache(cache)
+
+        project_state.last_fetch_watermark = datetime(2026, 7, 1, tzinfo=timezone.utc)
+        return []
+
+    monkeypatch.setattr(sync_module, "fetch_results", fake_fetch_results)
+
+    await sync_module.sync_task_function(
+        report_progress=lambda **kwargs: None, remote=Remote(hostname="foo")
+    )
+
+    cache = read_cache()
+    assert cache.project_states["bar"].last_fetch_watermark == bar_watermark
+    assert cache.project_states["foo"].last_fetch_watermark == datetime(
+        2026, 7, 1, tzinfo=timezone.utc
+    )


### PR DESCRIPTION
## Summary

Implements `cluv clean` (#65): removes a run's result directory from a cluster once you've deleted your local copy of it, without ever deleting a run that hasn't been fetched yet.

- A per-cluster **fetch watermark** (max mtime among that cluster's remote run dirs, captured right after the last successful `sync`) is cached alongside the existing per-cluster sync state (`cluv/cache.py`).
- `cluv clean` diffs your local results dir against each cluster's remote listing and only deletes a remote run if it's **absent locally AND older than that cluster's cached watermark** — this can only ever under-delete, never over-delete, since a genuinely new run is always newer than the watermark that predates its creation. See `compute_runs_to_delete` in `cluv/cli/clean.py`.
- `clean` never runs `sync` first — it only reads state cached by the last successful sync of each cluster. Clusters that have never been synced are skipped.
- CLI: `cluv clean [<cluster> ...] [-f/--force] [--dry-run]`, mirroring `cluv sync`'s conventions.
- New user guide: `docs/guides/cleaning-runs.md`.

## Bonus fix

While testing `clean` end-to-end, found and fixed a pre-existing race in `sync_task_function`: each cluster's task read the whole on-disk cache once at the start and kept re-writing that stale snapshot after every step. Since `sync()` runs all connected clusters concurrently, whichever cluster's task saved last silently clobbered every other cluster's just-written state — including `last_fetch_watermark`, which `clean` depends on. Fixed by re-reading the cache immediately before each write and merging in only the current cluster's state (`cluv/cli/sync.py`).

## Test plan

- [x] `uv run pytest -m "not integration"` — 129 passed
- [x] `uv run mkdocs build --strict` — clean
- [x] Fix and run the real-SSH integration test against an actual cluster
- [x] Manually re-verify `cluv sync` → `cluv clean` end-to-end now that the cache race is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)