### PR TITLE
Format config files

### DIFF
--- a/examples/pytorch-example/pyproject.toml
+++ b/examples/pytorch-example/pyproject.toml
@@ -38,8 +38,8 @@ datasets_path = "$SCRATCH/datasets/cifar10"
 [tool.cluv.env]
 # Environment variables applied when using Slurm commands on all clusters.
 # Assume that compute nodes don't have internet access by default. Override below when they do.
-UV_OFFLINE="1"
-WANDB_MODE="offline"
+UV_OFFLINE = "1"
+WANDB_MODE = "offline"
 
 [tool.cluv.sbatch_args]
 # sbatch flags applied on all clusters. CLI-supplied flags take precedence.
@@ -52,7 +52,7 @@ mem = "16G"
 
 [tool.cluv.clusters.mila]
 # Overrides specific to the Mila cluster.
-env = {UV_OFFLINE="0", WANDB_MODE="online"}
+env = { UV_OFFLINE = "0", WANDB_MODE = "online" }
 
 [tool.cluv.clusters.tamia]
 
@@ -66,15 +66,15 @@ datasets_path = "$HOME/datasets/cifar10"
 results_path = "$HOME/logs/pytorch_example"
 
 [tool.cluv.clusters.rorqual]
-env = {SBATCH_ACCOUNT="rrg-bengioy-ad"}
+env = { SBATCH_ACCOUNT = "rrg-bengioy-ad" }
 
 [tool.cluv.clusters.fir]
-env = {UV_OFFLINE="0", WANDB_MODE="online"}
-sbatch_args = {account="rrg-bengioy-ad"}
+env = { UV_OFFLINE = "0", WANDB_MODE = "online" }
+sbatch_args = { account = "rrg-bengioy-ad" }
 
 [tool.cluv.clusters.nibi]
-env = {UV_OFFLINE="0", WANDB_MODE="online"}
-sbatch_args = {account="rrg-bengioy-ad"}
+env = { UV_OFFLINE = "0", WANDB_MODE = "online" }
+sbatch_args = { account = "rrg-bengioy-ad" }
 
 # TODO: There are issues with the job output script being created in $HOME. Once #87 is implemented,
 # uncomment these to also submit on Trillium and Trillium-gpu.
@@ -87,4 +87,4 @@ sbatch_args = {account="rrg-bengioy-ad"}
 
 [tool.cluv.clusters.narval]
 # Mila doesn't have an allocation on Narval anymore.
-sbatch_args = {account="def-bengioy"}
+sbatch_args = { account = "def-bengioy" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,10 @@ results_path = "$SCRATCH/logs/cluv"
 # On clusters, Cluv creates a symlink (a shortcut) in your project folder to the results_path dir.
 # This makes it easier to keep your project in $HOME and to see the results which are on $SCRATCH.
 results_symlink = "logs"
+# Where to read the data from when synchronizing data to all clusters.
+#data_source = "<cluster>:<dataset_path_on_the_cluster>"
+# Where the dataset should be replicated on all clusters.
+#datasets_path = <cloned_datasets_path>
 
 [tool.cluv.env]
 # Environment variables applied when using Slurm commands on all clusters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,7 @@ markers = [
 managed = true
 
 [tool.uv.workspace]
-members = [
-    "examples/pytorch-example",
-]
+members = ["examples/pytorch-example"]
 
 
 [tool.uv-dynamic-versioning]
@@ -86,64 +84,57 @@ show_missing = true
 ###  --------------   CLUV CONFIG   --------------  ###
 
 [tool.cluv]
-
 # Job script to use by default when one isn't passed to the `submit` command, on all clusters.
-# Can be overridden per cluster below. or per job submission.
+# Can be overridden per cluster below or per job submission.
 job_script_path = "scripts/job.sh"
 # Where to store job results by default. Can be overridden per cluster.
 results_path = "$SCRATCH/logs/cluv"
 # On clusters, Cluv creates a symlink (a shortcut) in your project folder to the results_path dir.
 # This makes it easier to keep your project in $HOME and to see the results which are on $SCRATCH.
 results_symlink = "logs"
-## Where to read the data from when synchronizing data to all clusters.
-#data_source = "mila:/network/datasets/cifar10.var/cifar10_torchvision"
-## Where the dataset should be replicated on all clusters.
-#datasets_path = "$SCRATCH/datasets/cifar10"
 
 [tool.cluv.env]
 # Environment variables applied when using Slurm commands on all clusters.
 # Assume that compute nodes don't have internet access by default. Override below when they do.
-UV_OFFLINE="1"
-WANDB_MODE="offline"
+UV_OFFLINE = "1"
+WANDB_MODE = "offline"
 
 [tool.cluv.sbatch_args]
 # sbatch flags applied on all clusters. CLI-supplied flags take precedence.
 time = "3:00:00"
 requeue = true
 
-
 ###  --------------   Clusters Config   --------------  ###
 
 [tool.cluv.clusters.mila]
 # Overrides specific to the Mila cluster.
-env = {UV_OFFLINE="0", WANDB_MODE="online"}
+env = { UV_OFFLINE = "0", WANDB_MODE = "online" }
 
 [tool.cluv.clusters.tamia]
 
 [tool.cluv.clusters.killarney]
 # For example, you might not have a $SCRATCH on Killarney. This can be overwritten here.
 results_path = "$HOME/logs/cluv"
-# datasets_path = "$HOME/datasets/cifar10"
 
 [tool.cluv.clusters.vulcan]
 
 [tool.cluv.clusters.rorqual]
-sbatch_args = {account="rrg-bengioy-ad"}
+sbatch_args = { account = "rrg-bengioy-ad" }
 
 [tool.cluv.clusters.fir]
-env = {UV_OFFLINE="0", WANDB_MODE="online"}
-sbatch_args = {account="rrg-bengioy-ad"}
+env = { UV_OFFLINE = "0", WANDB_MODE = "online" }
+sbatch_args = { account = "rrg-bengioy-ad" }
 
 [tool.cluv.clusters.nibi]
-env = {UV_OFFLINE="0", WANDB_MODE="online"}
-sbatch_args = {account="rrg-bengioy-ad"}
+env = { UV_OFFLINE = "0", WANDB_MODE = "online" }
+sbatch_args = { account = "rrg-bengioy-ad" }
 
 [tool.cluv.clusters.trillium]
-sbatch_args = {account="rrg-bengioy-ad"}
+sbatch_args = { account = "rrg-bengioy-ad" }
 
 [tool.cluv.clusters.trillium-gpu]
-sbatch_args = {account="rrg-bengioy-ad"}
+sbatch_args = { account = "rrg-bengioy-ad" }
 
 [tool.cluv.clusters.narval]
 # Mila doesn't have an allocation on Narval anymore.
-sbatch_args = {account="def-bengioy"}
+sbatch_args = { account = "def-bengioy" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ results_symlink = "logs"
 #data_source = "<cluster>:<dataset_path_on_the_cluster>"
 
 # Where the dataset should be replicated on all clusters.
-#datasets_path = "<cloned_datasets_path>"
+#datasets_path = "<path_to_copy_datasets_on_all_clusters>"
 
 [tool.cluv.env]
 # Environment variables applied when using Slurm commands on all clusters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,18 +84,24 @@ show_missing = true
 ###  --------------   CLUV CONFIG   --------------  ###
 
 [tool.cluv]
+# All variables below can be overridden per cluster (except data_source).
+
 # Job script to use by default when one isn't passed to the `submit` command, on all clusters.
-# Can be overridden per cluster below or per job submission.
+# Can also be overridden per job submission.
 job_script_path = "scripts/job.sh"
-# Where to store job results by default. Can be overridden per cluster.
+
+# Where to store job results by default.
 results_path = "$SCRATCH/logs/cluv"
+
 # On clusters, Cluv creates a symlink (a shortcut) in your project folder to the results_path dir.
 # This makes it easier to keep your project in $HOME and to see the results which are on $SCRATCH.
 results_symlink = "logs"
+
 # Where to read the data from when synchronizing data to all clusters.
 #data_source = "<cluster>:<dataset_path_on_the_cluster>"
+
 # Where the dataset should be replicated on all clusters.
-#datasets_path = <cloned_datasets_path>
+#datasets_path = "<cloned_datasets_path>"
 
 [tool.cluv.env]
 # Environment variables applied when using Slurm commands on all clusters.


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Format the `[tool.cluv]` section to follow the same formatting as the parts of the `.toml` files.
* Remove commented line for Killarney config.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/