### PR TITLE
Add a [tool.cluv.local] section for local env vars

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3
+  python: python3.13
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -202,7 +202,10 @@ def load_cluv_config(pyproject_path: Path) -> CluvConfig:
     if current_cluster() is None:
         for key, value in cluv.get("local", {}).get("env", {}).items():
             while "$" in value:
-                value = os.path.expandvars(value)
+                new_value = os.path.expandvars(value)
+                if new_value == value:
+                    break
+                value = new_value
             if key in os.environ:
                 logger.warning(
                     "Not overwriting local env var %s=%s with value from [tool.cluv.local.env] %s",

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -211,6 +211,7 @@ def load_cluv_config(pyproject_path: Path) -> CluvConfig:
                     value,
                 )
                 continue
+            logger.info("Setting local env var %s=%s from [tool.cluv.local.env]", key, value)
             os.environ[key] = value
     config = CluvConfig.model_validate(cluv, extra="forbid")
     return config

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -208,13 +208,13 @@ def load_cluv_config(pyproject_path: Path) -> CluvConfig:
                 value = new_value
             if key in os.environ:
                 logger.warning(
-                    "Not overwriting local env var %s=%s with value from [tool.cluv.local.env] %s",
+                    "Overwriting local env var %s=%s with value from [tool.cluv.local.env] %s",
                     key,
                     os.environ[key],
                     value,
                 )
-                continue
-            logger.info("Setting local env var %s=%s from [tool.cluv.local.env]", key, value)
+            else:
+                logger.info("Setting local env var %s=%s from [tool.cluv.local.env]", key, value)
             os.environ[key] = value
     config = CluvConfig.model_validate(cluv, extra="forbid")
     return config

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -195,21 +195,24 @@ def load_cluv_config(pyproject_path: Path) -> CluvConfig:
     with pyproject_path.open("rb") as handle:
         data = tomllib.load(handle)
 
-    cluv = data.get("tool", {}).get("cluv", {})
+    cluv: dict = data.get("tool", {}).get("cluv", {})
     if not cluv:
         raise RuntimeError(f"No cluv config in {pyproject_path} file.")
 
-    config = CluvConfig.model_validate(cluv, extra="forbid")
     if current_cluster() is None:
-        for key, value in config.local.env.items():
+        for key, value in cluv.get("local", {}).get("env", {}).items():
+            while "$" in value:
+                value = os.path.expandvars(value)
             if key in os.environ:
-                logger.debug(
-                    "Overriding local env var %s=%s with value from [tool.cluv.local.env] from pyproject.toml: %s",
+                logger.warning(
+                    "Not overwriting local env var %s=%s with value from [tool.cluv.local.env] %s",
                     key,
                     os.environ[key],
                     value,
                 )
+                continue
             os.environ[key] = value
+    config = CluvConfig.model_validate(cluv, extra="forbid")
     return config
 
 

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -85,6 +85,16 @@ class ClusterConfig[PathType: Path | PurePosixPath = PurePosixPath]:
     """Whether to ignore this cluster when running commands on all clusters."""
 
 
+@dataclass(frozen=True)
+class LocalConfig:
+    """Config for using cluv on a local machine (not on a Slurm cluster)."""
+
+    env: dict[str, str] = field(default_factory=dict)
+    """Environment variables to set when using cluv on a local machine (not on a Slurm cluster).
+    For example, this can be used to set a fake "$SCRATCH" directory to use when not on a Slurm cluster.
+    """
+
+
 class CluvConfig(BaseModel):
     """Configuration options for Cluv, loaded from the pyproject.toml file."""
 
@@ -137,6 +147,8 @@ class CluvConfig(BaseModel):
     The keys are cluster names, and values are configs that override options for that cluster.
     """
 
+    local: LocalConfig = LocalConfig()
+
     @property
     def clusters_names(self) -> list[str]:
         return [name for name, config in self.clusters.items() if not config.ignore]
@@ -187,7 +199,18 @@ def load_cluv_config(pyproject_path: Path) -> CluvConfig:
     if not cluv:
         raise RuntimeError(f"No cluv config in {pyproject_path} file.")
 
-    return CluvConfig.model_validate(cluv, extra="forbid")
+    config = CluvConfig.model_validate(cluv, extra="forbid")
+    if current_cluster() is None:
+        for key, value in config.local.env.items():
+            if key in os.environ:
+                logger.debug(
+                    "Overriding local env var %s=%s with value from [tool.cluv.local.env] from pyproject.toml: %s",
+                    key,
+                    os.environ[key],
+                    value,
+                )
+            os.environ[key] = value
+    return config
 
 
 def current_cluster_config() -> ClusterConfig[Path] | None:

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -191,6 +191,25 @@ def has_cluv_config(pyproject_path: Path) -> bool:
     return "cluv" in data.get("tool", {})
 
 
+def set_local_env_vars(env_vars: dict[str, str]) -> None:
+    for key, value in env_vars.items():
+        while "$" in value:
+            new_value = os.path.expandvars(value)
+            if new_value == value:
+                break
+            value = new_value
+        if key in os.environ:
+            logger.warning(
+                "Overwriting local env var %s=%s with value from [tool.cluv.local.env] %s",
+                key,
+                os.environ[key],
+                value,
+            )
+        else:
+            logger.info("Setting local env var %s=%s from [tool.cluv.local.env]", key, value)
+        os.environ[key] = value
+
+
 def load_cluv_config(pyproject_path: Path) -> CluvConfig:
     with pyproject_path.open("rb") as handle:
         data = tomllib.load(handle)
@@ -200,22 +219,7 @@ def load_cluv_config(pyproject_path: Path) -> CluvConfig:
         raise RuntimeError(f"No cluv config in {pyproject_path} file.")
 
     if current_cluster() is None:
-        for key, value in cluv.get("local", {}).get("env", {}).items():
-            while "$" in value:
-                new_value = os.path.expandvars(value)
-                if new_value == value:
-                    break
-                value = new_value
-            if key in os.environ:
-                logger.warning(
-                    "Overwriting local env var %s=%s with value from [tool.cluv.local.env] %s",
-                    key,
-                    os.environ[key],
-                    value,
-                )
-            else:
-                logger.info("Setting local env var %s=%s from [tool.cluv.local.env]", key, value)
-            os.environ[key] = value
+        set_local_env_vars(cluv.get("local", {}).get("env", {}))
     config = CluvConfig.model_validate(cluv, extra="forbid")
     return config
 

--- a/cluv/job.py
+++ b/cluv/job.py
@@ -1,8 +1,3 @@
-"""A script that reads something, and produces some output.
-
-This is a simplified job script, used to test the syncing of the 'dataset' across clusters.
-"""
-
 import dataclasses
 import functools
 import os

--- a/examples/hydra_example/pyproject.toml
+++ b/examples/hydra_example/pyproject.toml
@@ -3,9 +3,7 @@ name = "hydra-example"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-authors = [
-    { name = "Fabrice Normandin", email = "normandf@mila.quebec" }
-]
+authors = [{ name = "Fabrice Normandin", email = "normandf@mila.quebec" }]
 requires-python = ">=3.13"
 dependencies = [
     "cluv[dev,hydra]",
@@ -35,14 +33,19 @@ datasets_path = "$SCRATCH/datasets/cifar10"
 
 [tool.cluv.env]
 # Assume that compute nodes don't have internet access by default. Override below when they do.
-UV_OFFLINE="1"
-WANDB_MODE="offline"
+UV_OFFLINE = "1"
+WANDB_MODE = "offline"
 
 [tool.cluv.sbatch_args]
 # Environment variables applied when using Slurm commands on all clusters.
 time = "3:00:00"
 requeue = true
 
+[tool.cluv.local]
+## Settings (environment variables) applied when using cluv on a local machine (not on a Slurm cluster).
+# Fake "$SCRATCH" directory to use when not on a Slurm cluster.
+# (this makes the examples runnable either from a laptop or from a Slurm cluster.
+env = { SCRATCH = "$HOME/scratch" }
 
 ###  --------------   Clusters Config   --------------  ###
 
@@ -65,10 +68,10 @@ results_path = "$HOME/logs/hydra_example"
 account = "rrg-bengioy-ad"
 
 [tool.cluv.clusters.fir]
-env = {UV_OFFLINE="0", WANDB_MODE="online"}
+env = { UV_OFFLINE = "0", WANDB_MODE = "online" }
 
 [tool.cluv.clusters.nibi]
-env = {UV_OFFLINE="0", WANDB_MODE="online"}
+env = { UV_OFFLINE = "0", WANDB_MODE = "online" }
 [tool.cluv.clusters.nibi.sbatch_args]
 account = "rrg-bengioy-ad"
 

--- a/examples/pytorch-example/pyproject.toml
+++ b/examples/pytorch-example/pyproject.toml
@@ -47,6 +47,12 @@ time = "3:00:00"
 requeue = true
 mem = "16G"
 
+[tool.cluv.local]
+## Settings (environment variables) applied when using cluv on a local machine (not on a Slurm cluster).
+# Fake "$SCRATCH" directory to use when not on a Slurm cluster.
+# (this makes the examples runnable either from a laptop or from a Slurm cluster.
+env = { SCRATCH = "$HOME/scratch" }
+
 
 ###  --------------   Clusters Config   --------------  ###
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,13 @@ results_symlink = "logs"
 UV_OFFLINE = "1"
 WANDB_MODE = "offline"
 
+
+[tool.cluv.local]
+## Settings (environment variables) applied when using cluv on a local machine (not on a Slurm cluster).
+# Fake "$SCRATCH" directory to use when not on a Slurm cluster.
+# (this makes the examples runnable either from a laptop or from a Slurm cluster.
+env = { SCRATCH = "$HOME/scratch" }
+
 [tool.cluv.sbatch_args]
 # sbatch flags applied on all clusters. CLI-supplied flags take precedence.
 time = "3:00:00"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,6 @@ results_symlink = "logs"
 UV_OFFLINE = "1"
 WANDB_MODE = "offline"
 
-
 [tool.cluv.local]
 ## Settings (environment variables) applied when using cluv on a local machine (not on a Slurm cluster).
 # Fake "$SCRATCH" directory to use when not on a Slurm cluster.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,9 @@ def fake_scratch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     from cluv.config import set_local_env_vars
 
     def _mock_set_local_env_vars(env_vars: dict[str, str]) -> None:
-        """Mock function to disable setting local env vars during tests."""
+        """Mock function swap our the $SCRATCH value from the pyproject.toml
+        for the fake_scratch value during tests.
+        """
         new_items = {
             key: str(fake_scratch) if key == "SCRATCH" else value
             for key, value in env_vars.items()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,11 +22,10 @@ def fake_scratch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Mock function swap our the $SCRATCH value from the pyproject.toml
         for the fake_scratch value during tests.
         """
-        new_items = {
-            key: str(fake_scratch) if key == "SCRATCH" else value
-            for key, value in env_vars.items()
-        }
-        set_local_env_vars(new_items)
+        new_env_vars = env_vars.copy()
+        if "SCRATCH" in env_vars:
+            new_env_vars["SCRATCH"] = str(fake_scratch)
+        set_local_env_vars(new_env_vars)
 
     # Patch this, so that the SCRATCH environment variable is always set as we expect it to be.
     monkeypatch.setattr(cluv.config, set_local_env_vars.__name__, _mock_set_local_env_vars)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 
+import cluv.config
 from cluv.cli.login import get_remote_without_2fa_prompt
 from cluv.remote import control_socket_is_running
 from tests.test_integration import ALL_CLUSTERS, IN_SELF_HOSTED_GITHUB_CI, REQUIRED_CLUSTERS
@@ -14,6 +15,18 @@ def fake_scratch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     fake_scratch = tmp_path / "scratch"
     fake_scratch.mkdir()
     monkeypatch.setenv("SCRATCH", str(fake_scratch))
+    from cluv.config import set_local_env_vars
+
+    def _mock_set_local_env_vars(env_vars: dict[str, str]) -> None:
+        """Mock function to disable setting local env vars during tests."""
+        new_items = {
+            key: str(fake_scratch) if key == "SCRATCH" else value
+            for key, value in env_vars.items()
+        }
+        set_local_env_vars(new_items)
+
+    # Patch this, so that the SCRATCH environment variable is always set as we expect it to be.
+    monkeypatch.setattr(cluv.config, set_local_env_vars.__name__, _mock_set_local_env_vars)
     return fake_scratch
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest_asyncio
 
 import cluv.config
 from cluv.cli.login import get_remote_without_2fa_prompt
-from cluv.config import find_pyproject
+from cluv.config import find_pyproject, get_cluv_config, set_local_env_vars
 from cluv.remote import control_socket_is_running
 from tests.test_integration import ALL_CLUSTERS, IN_SELF_HOSTED_GITHUB_CI, REQUIRED_CLUSTERS
 
@@ -16,7 +16,6 @@ def fake_scratch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     fake_scratch = tmp_path / "scratch"
     fake_scratch.mkdir()
     monkeypatch.setenv("SCRATCH", str(fake_scratch))
-    from cluv.config import set_local_env_vars
 
     def _mock_set_local_env_vars(env_vars: dict[str, str]) -> None:
         """Mock function swap our the $SCRATCH value from the pyproject.toml
@@ -53,7 +52,6 @@ def use_normal_project_dir_on_cluster_instead_of_action_runners_path(
     As a consequence of this, the ~/repos/cluv path on the clusters might be changed by the test runners.
     This is kind-of to be expected though, and is not different than doing a `cluv sync` ourselves.
     """
-    from cluv.config import get_cluv_config
 
     def mock_get_cluv_config() -> cluv.config.CluvConfig:
         config = get_cluv_config()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest_asyncio
 
 import cluv.config
 from cluv.cli.login import get_remote_without_2fa_prompt
+from cluv.config import find_pyproject
 from cluv.remote import control_socket_is_running
 from tests.test_integration import ALL_CLUSTERS, IN_SELF_HOSTED_GITHUB_CI, REQUIRED_CLUSTERS
 
@@ -36,6 +37,37 @@ def reset_cluv_config():
     from cluv.config import get_cluv_config
 
     get_cluv_config.cache_clear()
+
+
+@pytest.fixture(autouse=IN_SELF_HOSTED_GITHUB_CI)
+def use_normal_project_dir_on_cluster_instead_of_action_runners_path(
+    monkeypatch: pytest.MonkeyPatch, reset_cluv_config: None
+):
+    """The self-hosted runner is running from ~/action-runners/.../_work/cluv/cluv.
+
+    Patch the output of `get_cluv_config` while in the tests, so that it always uses a project_dir that is
+    "normal", like ~/repos/cluv and ~/repos/cluv/examples/<example_name> instead of replicating entire
+    action-runners/.../_work/cluv on the cluster.
+
+    As a consequence of this, the ~/repos/cluv path on the clusters might be changed by the test runners.
+    This is kind-of to be expected though, and is not different than doing a `cluv sync` ourselves.
+    """
+    from cluv.config import get_cluv_config
+
+    def mock_get_cluv_config() -> cluv.config.CluvConfig:
+        config = get_cluv_config()
+        if config.project_dir is None:
+            project_dir = find_pyproject().parent
+            if project_dir.name == "cluv":
+                monkeypatch.setattr(config, "project_dir", "$HOME/repos/cluv")
+            else:
+                assert project_dir.parent.name == "examples"
+                monkeypatch.setattr(
+                    config, "project_dir", f"$HOME/repos/cluv/examples/{project_dir.name}"
+                )
+        return config
+
+    monkeypatch.setattr(cluv.config, get_cluv_config.__name__, mock_get_cluv_config)
 
 
 @pytest_asyncio.fixture(scope="session", params=ALL_CLUSTERS)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Unit tests for cluv/config.py — pure, no I/O beyond tmp_path."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -332,3 +333,24 @@ class TestRealProjectConfig:
         cfg = load_cluv_config(root_dir / "pyproject.toml")
         assert cfg is not None
         assert set(cfg.clusters_names) == set(DRAC_CLUSTERS + ["mila"])
+
+
+def test_cluv_local_env_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Prevent any modifications to `os.environ` between tests.
+    monkeypatch.setattr(os, "environ", os.environ.copy())
+
+    p = write_pyproject(
+        tmp_path,
+        """[tool.cluv]
+results_path = "logs"
+[tool.cluv.local.env]
+FOO = "$BAR/baz"
+ALREADY_IN_ENV = "new-value"
+""",
+    )
+    os.environ["ALREADY_IN_ENV"] = "old-value"
+    assert "FOO" not in os.environ
+    cfg = load_cluv_config(p)
+    assert cfg.local.env == {"FOO": "$BAR/baz", "ALREADY_IN_ENV": "new-value"}
+    assert os.environ["FOO"] == "$BAR/baz"
+    assert os.environ["ALREADY_IN_ENV"] == "new-value"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -304,12 +304,12 @@ def test_init(
     monkeypatch.chdir(project_dir)
 
     pyproject_file = project_dir / "pyproject.toml"
-    content = pyproject_file.read_text()
-    if scratch:
+    if pyproject_file.exists() and scratch:
+        content = pyproject_file.read_text()
         content = content.replace(
             "SCRATCH = $HOME/scratch", f"SCRATCH = {scratch}" if scratch else ""
         )
-    pyproject_file.write_text(content)
+        pyproject_file.write_text(content)
     monkeypatch.setenv("SCRATCH", str(scratch) if scratch else "")
 
     init()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -303,9 +303,19 @@ def test_init(
 ) -> None:
     monkeypatch.chdir(project_dir)
 
+    pyproject_file = project_dir / "pyproject.toml"
+    content = pyproject_file.read_text()
+    if scratch:
+        content = content.replace(
+            "SCRATCH = $HOME/scratch", f"SCRATCH = {scratch}" if scratch else ""
+        )
+    pyproject_file.write_text(content)
+    monkeypatch.setenv("SCRATCH", str(scratch) if scratch else "")
+
     init()
 
     generated_config = load_cluv_config(project_dir / "pyproject.toml")
+
     assert generated_config.results_path == DEFAULT_RESULTS_PATH
     assert (project_dir / "scripts").is_dir()
     assert (project_dir / "scripts" / "job.sh").is_file()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -246,14 +246,12 @@ def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 @pytest.fixture(params=[True, False], ids=["with_scratch", "without_scratch"])
 def scratch(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest, fake_scratch: Path
 ) -> Path | None:
     """Fixture that sets up a fake SCRATCH directory if requested, or pretends that SCRATCH doesn't exist otherwise."""
     use_scratch = request.param
     if use_scratch:
-        fake_scratch_dir = tmp_path / "fake_scratch"
-        monkeypatch.setenv("SCRATCH", str(fake_scratch_dir))  # Set the SCRATCH env var to tmp_path
-        return fake_scratch_dir
+        return fake_scratch
     if "SCRATCH" in os.environ:
         # Remove the SCRATCH environment variable
         monkeypatch.delenv("SCRATCH")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,12 +1,15 @@
 """Tests for `cluv sync`"""
 
+import importlib
 import subprocess
+import unittest
+import unittest.mock
 from pathlib import Path
 
 import pytest
 
-from cluv.cli.sync import expandvars, sync
-from cluv.config import get_cluv_config
+from cluv.cli.sync import expandvars, fetch_results, sync
+from cluv.config import LocalConfig, get_cluv_config
 from cluv.job import get_datasets_path
 from cluv.remote import Remote
 from cluv.utils import current_cluster
@@ -22,6 +25,12 @@ pytestmark = [
 ]
 
 
+# `cluv/cli/__init__.py` does `from .sync import sync`, which shadows the `cluv.cli.sync`
+# submodule attribute with the `sync` function. Use `importlib.import_module` (same idiom as
+# `tests/test_init.py`) to get the actual module object for monkeypatching.
+sync_module = importlib.import_module("cluv.cli.sync")
+
+
 @pytest.mark.slow
 @pytest.mark.asyncio
 async def test_cluv_sync_with_data_path(monkeypatch: pytest.MonkeyPatch, fake_scratch: Path):
@@ -35,9 +44,17 @@ async def test_cluv_sync_with_data_path(monkeypatch: pytest.MonkeyPatch, fake_sc
     other_cluster_remote = await Remote.connect(other_cluster)
 
     monkeypatch.chdir("examples/pytorch-example")
-
+    # We need to change the "tool.cluv.local.env.SCRATCH" to point to the fake scratch path.
     config = get_cluv_config()
-    assert config
+    monkeypatch.setattr(config, "local", LocalConfig(env={"SCRATCH": str(fake_scratch)}))
+    monkeypatch.setenv("SCRATCH", str(fake_scratch))
+    monkeypatch.setattr(sync_module, get_cluv_config.__name__, lambda: config)
+
+    # Avoid re-fetching results to this fake_scratch directory.
+    monkeypatch.setattr(
+        sync_module, fetch_results.__name__, unittest.mock.AsyncMock(return_value=[])
+    )
+
     assert config.datasets_path
 
     here_datasets_path = get_datasets_path()
@@ -76,7 +93,7 @@ async def test_cluv_sync_with_data_path(monkeypatch: pytest.MonkeyPatch, fake_sc
     this_cluster_files = subprocess.getoutput(f"ls {here_datasets_path}").strip().splitlines()
     assert this_cluster_files != other_cluster_files
 
-    await sync([other_cluster], uv_sync_args=None)
+    await sync([other_cluster])
 
     # Check that we now have the files for that dataset in the datasets_path on this machine.
     from torchvision.datasets import CIFAR10
@@ -84,10 +101,16 @@ async def test_cluv_sync_with_data_path(monkeypatch: pytest.MonkeyPatch, fake_sc
     print(CIFAR10(here_datasets_path))
 
     # Dataset is synced on the remote as well.
-    this_cluster_files = subprocess.getoutput(f"ls {here_datasets_path}").strip().splitlines()
-    other_cluster_files = (
-        (await other_cluster_remote.get_output(f"ls {other_cluster_datasets_path}"))
-        .strip()
-        .splitlines()
+    this_cluster_files = list(
+        sorted(subprocess.getoutput(f"ls {here_datasets_path}").strip().splitlines())
+    )
+    other_cluster_files = list(
+        sorted(
+            (
+                (await other_cluster_remote.get_output(f"ls {other_cluster_datasets_path}"))
+                .strip()
+                .splitlines()
+            )
+        )
     )
     assert this_cluster_files == other_cluster_files


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->

Issue: The examples that use datasets (the Pytorch example, as well as the incoming Hydra example) use `$SCRATCH/data/...` for the dataset location.

This adds a new section to pyproject.toml, like this:

```toml
[tool.cluv.local]
## Settings (environment variables) applied when using cluv on a local machine (not on a Slurm cluster).
# Fake "$SCRATCH" directory to use when not on a Slurm cluster.
# (this makes the examples runnable either from a laptop or from a Slurm cluster.
env = { SCRATCH = "$HOME/scratch" }
```



## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
