### PR TITLE
Show if a cluster is disable in `cluv status`

### DIFF
--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -400,7 +400,7 @@ def _build_cluster_table(
 def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobInfo]) -> Table:
     """Build the jobs overview table with one row per cached job, enriched with live status info."""
     table = Table(
-        title="Jobs Overview",
+        title="Cluv Jobs Overview",
         box=box.SIMPLE_HEAVY,
         header_style="bold white on #1a1a2e",
         title_style="bold cyan",

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -121,7 +121,9 @@ _MILA_CLUSTERS = {"mila"}
 
 
 async def fetch_live_job_info(
-    cluster: str, job_ids: list[int], disabled_clusters: list[str]
+    cluster: str,
+    job_ids: list[int],
+    disabled_clusters: dict[str, DisabledCluster],
 ) -> dict[int, LiveJobInfo]:
     """Batch-fetch Slurm state, elapsed, and wait-time for a list of job IDs."""
     start_time = datetime.now()
@@ -201,7 +203,10 @@ async def fetch_live_job_info(
     return jobs
 
 
-async def get_cluster_status(cluster: str, disabled_clusters: list[str]) -> ClusterStatus:
+async def get_cluster_status(
+    cluster: str,
+    disabled_clusters: dict[str, DisabledCluster],
+) -> ClusterStatus:
     """Fetch live Slurm data from a remote cluster and return a ClusterStatus.
 
     Uses a single SSH round-trip. Falls back gracefully when commands are
@@ -485,7 +490,9 @@ def _build_legend() -> Panel:
 
 
 async def get_job_infos(
-    cached_jobs: list[Job], clusters: list[str], disabled_clusters: list[str]
+    cached_jobs: list[Job],
+    clusters: list[str],
+    disabled_clusters: dict[str, DisabledCluster],
 ) -> tuple[dict[int, LiveJobInfo], dict[str, ClusterJobStats]]:
     """Fetch live job info for all cached jobs, and count job statuses per cluster."""
     # Reverse the cached jobs so the most recent ones are shown first in the jobs table.
@@ -554,13 +561,14 @@ async def status(table: str) -> None:
 
     clusters = get_cluv_config().clusters_names
     disabled_clusters = get_disabled_clusters()
-    disabled_keys = list(disabled_clusters.keys())
 
     # Load cached jobs
     cached_jobs = load_jobs()
 
     with console.status("Fetching jobs status..."):
-        jobs_status, clusters_job_stats = await get_job_infos(cached_jobs, clusters, disabled_keys)
+        jobs_status, clusters_job_stats = await get_job_infos(
+            cached_jobs, clusters, disabled_clusters
+        )
 
     if table in ("clusters", "all"):
         # Query clusters in parallel
@@ -568,7 +576,7 @@ async def status(table: str) -> None:
             clusters_status: list[ClusterStatus] = [
                 d
                 for d in await asyncio.gather(
-                    *(get_cluster_status(c, disabled_keys) for c in clusters)
+                    *(get_cluster_status(c, disabled_clusters) for c in clusters)
                 )
             ]
 

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -120,9 +120,15 @@ disk-quota 2>/dev/null; echo {_SEP}
 _MILA_CLUSTERS = {"mila"}
 
 
-async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, LiveJobInfo]:
+async def fetch_live_job_info(
+    cluster: str, job_ids: list[int], disabled_clusters: list[str]
+) -> dict[int, LiveJobInfo]:
     """Batch-fetch Slurm state, elapsed, and wait-time for a list of job IDs."""
     start_time = datetime.now()
+
+    if cluster in disabled_clusters:
+        logger.info(f"[bold]{cluster}[/bold] is disabled; skipping jobs")
+        return {}
 
     remote = await get_remote_without_2fa_prompt(cluster)
     if remote is None and cluster != current_cluster():
@@ -204,7 +210,7 @@ async def get_cluster_status(cluster: str, disabled_clusters: list[str]) -> Clus
     start_time = datetime.now()
 
     if cluster in disabled_clusters:
-        logger.info(f"Skipping [bold]{cluster}[/bold]; returning empty status")
+        logger.info(f"[bold]{cluster}[/bold] is disabled; returning empty status")
         return get_default_cluster_status(cluster)
 
     # Use get_remote_without_2fa_prompt directly so we never filter out the
@@ -366,10 +372,10 @@ def _build_cluster_table(
             disabled_clusters_info = disabled_clusters.get(c.name)
             if disabled_clusters_info and disabled_clusters_info.disabled_until:
                 cluster_status += Text(
-                    f"Disabled ({format_remaining(disabled_clusters_info.disabled_until)} remaining)"
+                    f"Disabled\n({format_remaining(disabled_clusters_info.disabled_until)})"
                 )
             else:
-                cluster_status += Text("Disabled (indefinitely)")
+                cluster_status += Text("Disabled")
 
         job_stats = clusters_job_stats.get(
             c.name, ClusterJobStats(running=0, cancelled=0, completed=0, pending=0)
@@ -480,8 +486,7 @@ def _build_legend() -> Panel:
 
 
 async def get_job_infos(
-    cached_jobs: list[Job],
-    clusters: list[str],  # , disabled_clusters: list[str]
+    cached_jobs: list[Job], clusters: list[str], disabled_clusters: list[str]
 ) -> tuple[dict[int, LiveJobInfo], dict[str, ClusterJobStats]]:
     """Fetch live job info for all cached jobs, and count job statuses per cluster."""
     # Reverse the cached jobs so the most recent ones are shown first in the jobs table.
@@ -495,7 +500,7 @@ async def get_job_infos(
 
     # Fetch live job info for all cached jobs
     results = await asyncio.gather(
-        *(fetch_live_job_info(c, ids) for c, ids in cluster_jobs.items())
+        *(fetch_live_job_info(c, ids, disabled_clusters) for c, ids in cluster_jobs.items())
     )
     live_info = {jid: info for cluster_result in results for jid, info in cluster_result.items()}
 
@@ -550,12 +555,13 @@ async def status(table: str) -> None:
 
     clusters = get_cluv_config().clusters_names
     disabled_clusters = get_disabled_clusters()
+    disabled_keys = list(disabled_clusters.keys())
 
     # Load cached jobs
     cached_jobs = load_jobs()
 
     with console.status("Fetching jobs status..."):
-        jobs_status, clusters_job_stats = await get_job_infos(cached_jobs, clusters)
+        jobs_status, clusters_job_stats = await get_job_infos(cached_jobs, clusters, disabled_keys)
 
     if table in ("clusters", "all"):
         # Query clusters in parallel
@@ -563,7 +569,7 @@ async def status(table: str) -> None:
             clusters_status: list[ClusterStatus] = [
                 d
                 for d in await asyncio.gather(
-                    *(get_cluster_status(c, disabled_clusters.keys()) for c in clusters)
+                    *(get_cluster_status(c, disabled_keys) for c in clusters)
                 )
             ]
 

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -368,9 +368,8 @@ def _build_cluster_table(
         cluster_name = Text(c.name, style="bold magenta" if c.online else "bold bright_black")
         cluster_status = status + cluster_name + "\n"
 
-        if c.name in disabled_clusters:
-            disabled_clusters_info = disabled_clusters.get(c.name)
-            if disabled_clusters_info and disabled_clusters_info.disabled_until:
+        if disabled_clusters_info := disabled_clusters.get(c.name):
+            if disabled_clusters_info.disabled_until:
                 cluster_status += Text(
                     f"Disabled\n({format_remaining(disabled_clusters_info.disabled_until)})"
                 )

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -12,7 +12,7 @@ from rich.table import Table
 from rich.text import Text
 
 from cluv.cache import Job, get_disabled_clusters, load_jobs
-from cluv.cli.disable import print_disabled_clusters
+from cluv.cli.disable import DisabledCluster, format_remaining
 from cluv.cli.login import get_remote_without_2fa_prompt
 from cluv.config import get_cluv_config
 from cluv.remote import run
@@ -195,13 +195,17 @@ async def fetch_live_job_info(cluster: str, job_ids: list[int]) -> dict[int, Liv
     return jobs
 
 
-async def get_cluster_status(cluster: str) -> ClusterStatus:
+async def get_cluster_status(cluster: str, disabled_clusters: list[str]) -> ClusterStatus:
     """Fetch live Slurm data from a remote cluster and return a ClusterStatus.
 
     Uses a single SSH round-trip. Falls back gracefully when commands are
     unavailable (e.g. partition-stats is DRAC-only).
     """
     start_time = datetime.now()
+
+    if cluster in disabled_clusters:
+        logger.info(f"Skipping [bold]{cluster}[/bold]; returning empty status")
+        return get_default_cluster_status(cluster)
 
     # Use get_remote_without_2fa_prompt directly so we never filter out the
     # "current" cluster the way login() does. A working socket for mila is
@@ -333,7 +337,9 @@ def _gpu_bar(idle: int, total: int, width: int = 10) -> Text:
 # Main display
 # ---------------------------------------------------------------------------
 def _build_cluster_table(
-    data: list[ClusterStatus], clusters_job_stats: dict[str, ClusterJobStats]
+    data: list[ClusterStatus],
+    clusters_job_stats: dict[str, ClusterJobStats],
+    disabled_clusters: dict[str, DisabledCluster],
 ) -> Table:
     """Build the cluster overview table with live status info and job counts."""
     table = Table(
@@ -353,6 +359,18 @@ def _build_cluster_table(
 
     for c in data:
         status = Text("● ", style="bold green") if c.online else Text("⚠ ", style="bold red")
+        cluster_name = Text(c.name, style="bold magenta" if c.online else "bold bright_black")
+        cluster_status = status + cluster_name + "\n"
+
+        if c.name in disabled_clusters:
+            disabled_clusters_info = disabled_clusters.get(c.name)
+            if disabled_clusters_info and disabled_clusters_info.disabled_until:
+                cluster_status += Text(
+                    f"Disabled ({format_remaining(disabled_clusters_info.disabled_until)} remaining)"
+                )
+            else:
+                cluster_status += Text("Disabled (indefinitely)")
+
         job_stats = clusters_job_stats.get(
             c.name, ClusterJobStats(running=0, cancelled=0, completed=0, pending=0)
         )
@@ -368,16 +386,12 @@ def _build_cluster_table(
             c.storage.scratch_used, c.storage.scratch_quota
         )
 
-        # Dim the whole row if the cluster is offline
-        row_style = "dim" if not c.online else ""
-
         table.add_row(
-            status + Text(c.name, style="bold magenta" if c.online else "bold bright_black"),
+            cluster_status,
             Text(c.gpu_model, style="bright_blue") if c.online else "-",
             _gpu_bar(c.gpu_idle, c.gpu_total) if c.online else "-",
             my_jobs if c.online else "-",
             home_bar + "\n" + scratch_bar if c.online else "-",
-            style=row_style,
         )
 
     return table
@@ -466,7 +480,8 @@ def _build_legend() -> Panel:
 
 
 async def get_job_infos(
-    cached_jobs: list[Job], clusters: list[str]
+    cached_jobs: list[Job],
+    clusters: list[str],  # , disabled_clusters: list[str]
 ) -> tuple[dict[int, LiveJobInfo], dict[str, ClusterJobStats]]:
     """Fetch live job info for all cached jobs, and count job statuses per cluster."""
     # Reverse the cached jobs so the most recent ones are shown first in the jobs table.
@@ -533,9 +548,8 @@ async def status(table: str) -> None:
     console.rule("[bold cyan]cluv status[/bold cyan]")
     console.print()
 
-    disabled = get_disabled_clusters()
-    print_disabled_clusters(disabled)
-    clusters = [c for c in get_cluv_config().clusters_names if c not in disabled]
+    clusters = get_cluv_config().clusters_names
+    disabled_clusters = get_disabled_clusters()
 
     # Load cached jobs
     cached_jobs = load_jobs()
@@ -547,7 +561,10 @@ async def status(table: str) -> None:
         # Query clusters in parallel
         with console.status("Fetching clusters status..."):
             clusters_status: list[ClusterStatus] = [
-                d for d in await asyncio.gather(*(get_cluster_status(c) for c in clusters))
+                d
+                for d in await asyncio.gather(
+                    *(get_cluster_status(c, disabled_clusters.keys()) for c in clusters)
+                )
             ]
 
         # Show a tip message if all clusters are offline.
@@ -559,7 +576,7 @@ async def status(table: str) -> None:
                 )
             )
 
-        console.print(_build_cluster_table(clusters_status, clusters_job_stats))
+        console.print(_build_cluster_table(clusters_status, clusters_job_stats, disabled_clusters))
         console.print(_build_legend())
         console.print()
 

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -45,9 +45,6 @@ class PartialClusterConfig:
     project_dir: str | None = None
     """Path where the project should be cloned on this cluster."""
 
-    ignore: bool = False
-    """Whether to ignore this cluster when running commands on all clusters."""
-
 
 @dataclass(frozen=True)
 class ClusterConfig[PathType: Path | PurePosixPath = PurePosixPath]:
@@ -80,9 +77,6 @@ class ClusterConfig[PathType: Path | PurePosixPath = PurePosixPath]:
 
     project_dir: PathType | None
     """Path where the project should be cloned on this cluster."""
-
-    ignore: bool
-    """Whether to ignore this cluster when running commands on all clusters."""
 
 
 @dataclass(frozen=True)
@@ -151,7 +145,7 @@ class CluvConfig(BaseModel):
 
     @property
     def clusters_names(self) -> list[str]:
-        return [name for name, config in self.clusters.items() if not config.ignore]
+        return list(self.clusters.keys())
 
     def get_cluster_config(self, cluster: str) -> ClusterConfig:
         """Returns the cluster config for a specific cluster.
@@ -174,7 +168,6 @@ class CluvConfig(BaseModel):
             datasets_path=PurePosixPath(datasets_path) if datasets_path else None,
             job_script_path=PurePosixPath(job_script_path) if job_script_path else None,
             project_dir=PurePosixPath(project_dir) if project_dir else None,
-            ignore=cluster_config.ignore,
         )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,21 +85,6 @@ SBATCH_ACCOUNT = "def-bengioy"
         assert cfg.clusters["mila"].env == {}
         assert cfg.clusters["rorqual"].env == {"SBATCH_ACCOUNT": "def-bengioy"}
 
-    def test_clusters_names_should_not_returned_ignored_clusters(self, tmp_path: Path) -> None:
-        p = write_pyproject(
-            tmp_path,
-            """
-    [tool.cluv]
-    results_path = "logs"
-    [tool.cluv.clusters.mila]
-    [tool.cluv.clusters.rorqual]
-    [tool.cluv.clusters.narval]
-    ignore = true
-    """,
-        )
-        cfg = load_cluv_config(p)
-        assert cfg.clusters_names == ["mila", "rorqual"]
-
 
 # ---------------------------------------------------------------------------
 # [tool.cluv.env] — global SBATCH_* defaults


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Now show directly in the "Clusters Overview" table if a cluster is disable in the "Cluster" column.
* Rename the table `Jobs Overview` to `Cluv Jobs Overview`.
* Remove the `ignore` field in the config to avoid duplicate with `cluv disable/enable`.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/

## Example
<img width="962" height="569" alt="Capture d’écran, le 2026-07-16 à 12 30 08" src="https://github.com/user-attachments/assets/7aa1b356-f5f1-46dc-951f-5021e332b1f9" />

