### PR TITLE
Fix logging when setting local environment variable

### DIFF
--- a/cluv/config.py
+++ b/cluv/config.py
@@ -200,13 +200,11 @@ def set_local_env_vars(env_vars: dict[str, str]) -> None:
             value = new_value
         if key in os.environ:
             logger.warning(
-                "Overwriting local env var %s=%s with value from [tool.cluv.local.env] %s",
-                key,
-                os.environ[key],
-                value,
+                f"Overwriting local env var {key}={os.environ[key]} "
+                rf"with value from \[tool.cluv.local.env] {value}"
             )
         else:
-            logger.info("Setting local env var %s=%s from [tool.cluv.local.env]", key, value)
+            logger.info(rf"Setting local env var {key}={value} from \[tool.cluv.local.env]")
         os.environ[key] = value
 
 


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->

Before :
```console
[07/16/26 12:36:06] INFO     Setting local env var SCRATCH=my_path/scratch from    
```

After :
```console
[07/16/26 12:36:06] INFO     Setting local env var SCRATCH=my_path/scratch from [tool.cluv.local.env]
```

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/