### PR TITLE
fix(init): preserve existing results directory

### DIFF
--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -189,6 +189,11 @@ def check_symlink_to_scratch(project_root: Path, results_path: str, results_syml
                 f"[yellow]⚠️  Warning: Symlink from {symlink_path} points to an other path ({symlink_path.resolve()}) than the expected scratch path.[/yellow]"
             )
             return
+    elif symlink_path.exists():
+        console.print(
+            f"[yellow]⚠️  Warning: {symlink_path} already exists and is not a symlink.[/yellow]"
+        )
+        return
     else:
         console.print(f"Creating symlink from {symlink_path} to {scratch_path}")
         scratch_path.mkdir(parents=True, exist_ok=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -131,6 +131,21 @@ class TestSymlinkCheck:
         assert expected_results_symlink.resolve() == (tmp_path / "some_other_folder").resolve()
         assert not expected_results_scratch_path.exists()
 
+    def test_keep_existing_results_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """check_symlink_to_scratch() should not replace an existing results directory."""
+        scratch_path = tmp_path / "scratch"
+        monkeypatch.setenv("SCRATCH", str(scratch_path))
+        results_directory = tmp_path / DEFAULT_RESULTS_LINKNAME
+        results_directory.mkdir()
+
+        check_symlink_to_scratch(tmp_path, DEFAULT_RESULTS_PATH, DEFAULT_RESULTS_LINKNAME)
+
+        assert results_directory.is_dir()
+        assert not results_directory.is_symlink()
+        assert not Path(os.path.expandvars(DEFAULT_RESULTS_PATH)).exists()
+
 
 class TestJobScriptCheck:
     def test_keep_existing_job_script(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Keep an existing `logs` directory intact when `cluv init` validates the results symlink, rather than raising `FileExistsError` while trying to replace it.

## Issues

Fixes #139
