### PR TITLE
Adapt the `results_path` of the default config when creating a new config with `cluv init`

### DIFF
--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -134,7 +134,8 @@ def check_cluv_config(pyproject_path: Path) -> None:
     )
     console.print("Adding config for cluv tool :")
 
-    cluv_config = _load_cluv_config_template(pyproject_path.parent.name)
+    cluv_config_template = _load_cluv_config_template()
+    cluv_config = _update_clug_config_template(cluv_config_template, pyproject_path.parent.name)
     add_cluv_config_section(pyproject_path, cluv_config)
 
 
@@ -300,11 +301,12 @@ def _load_cluv_config_template(project_name: str) -> str:
         ),
         len(pyproject_lines),
     )
-    template = "\n".join(pyproject_lines[start:end]).strip() + "\n"
-    return template.replace(
-        f'results_path = "{DEFAULT_RESULTS_PATH}"',
-        f'results_path = "$SCRATCH/logs/{project_name}"',
-    )
+    return "\n".join(pyproject_lines[start:end]).strip() + "\n"
+
+
+def _update_clug_config_template(template_config: str, project_name: str) -> str:
+    # Replace the results_path
+    return template_config.replace(DEFAULT_RESULTS_PATH, f"$SCRATCH/logs/{project_name}")
 
 
 def _get_script_templates_path() -> Path:

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -25,6 +25,7 @@ def init(path: Path | None = None) -> None:
     * Runs `uv init --package --build-backend hatch --python 3.13` to initialize a new uv project
       in the current directory (if there isn't one already).
     * Adds a default configuration for Cluv in the `[tool.cluv]` section of pyproject.toml.
+    * Adds job script templates in the `scripts/` directory of the project.
     """
     console.print()
     console.rule("[bold cyan]cluv init[/bold cyan]")
@@ -86,7 +87,7 @@ def init(path: Path | None = None) -> None:
 
 def check_home_dir() -> None:
     """
-    Check if the current directory is under the home directory. If not, raise an error and exit.
+    Check if the current directory is under the home directory. If not, raise an error.
     """
     if Path.cwd().is_relative_to(Path.home()):
         console.print("✅ Current directory is under home directory.", style="green")
@@ -169,10 +170,12 @@ def check_git() -> None:
         raise RuntimeError("Error when checking git remote: ", git_remote.stderr)
 
 
-def check_symlink_to_scratch(project_root: Path, results_path: str, results_symlink: str) -> None:
+def check_symlink_to_scratch(project_path: Path, results_path: str, results_symlink: str) -> None:
     """
-    Check if a symlink from the results_path in the project in $HOME to the corresponding path in $SCRATCH already exists. If not, create it.
-    The symlink should be like : $HOME/<project>/<results_symlink> -> $SCRATCH/<results_path>/<project_name>
+    Check if a symlink from the results_path in the project in $HOME to the corresponding path in
+    $SCRATCH already exists. If not, create it.
+
+    The symlink should be : <project_path>/<results_symlink> -> <results_path>
     """
     if "SCRATCH" not in os.environ:
         console.print(
@@ -182,7 +185,7 @@ def check_symlink_to_scratch(project_root: Path, results_path: str, results_syml
 
     # Generate the expected scratch and symlink path
     scratch_path = Path(os.path.expandvars(results_path))
-    symlink_path = project_root / results_symlink
+    symlink_path = project_path / results_symlink
 
     if symlink_path.is_symlink():
         if symlink_path.resolve() == scratch_path.resolve():
@@ -205,7 +208,8 @@ def check_symlink_to_scratch(project_root: Path, results_path: str, results_syml
 
 def check_ssh_hostnames(clusters: list[str]) -> None:
     """
-    Check if the names of the clusters in the cluv config are present in the SSH config file. If not, print a warning.
+    Check if the names of the clusters in the cluv config are present in the SSH config file.
+    If not, print a warning.
     """
     ssh_hostnames = get_ssh_hostnames()
     missing_clusters = set(clusters).difference(ssh_hostnames)
@@ -282,7 +286,7 @@ def check_job_script(project_root: Path, results_path: str) -> None:
         console.print(f"Adding job template script at '{script_path}'.")
 
 
-def _load_cluv_config_template(project_name: str) -> str:
+def _load_cluv_config_template() -> str:
     pyproject_template_path = _get_pyproject_template_path()
     pyproject_lines = pyproject_template_path.read_text().splitlines()
     start = next(
@@ -305,7 +309,6 @@ def _load_cluv_config_template(project_name: str) -> str:
 
 
 def _update_clug_config_template(template_config: str, project_name: str) -> str:
-    # Replace the results_path
     return template_config.replace(DEFAULT_RESULTS_PATH, f"$SCRATCH/logs/{project_name}")
 
 

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -89,10 +89,10 @@ def check_home_dir() -> None:
     Check if the current directory is under the home directory. If not, raise an error and exit.
     """
     if Path.cwd().is_relative_to(Path.home()):
-        console.print("[green]✅ Current directory is under home directory.[/green]")
+        console.print("✅ Current directory is under home directory.", style="green")
     else:
         console.print(
-            "[red]❌ cluv init should be run in a directory under your home directory.[/red]"
+            "❌ cluv init should be run in a directory under your home directory.", style="red"
         )
         raise RuntimeError("cluv init should be run in a directory under your home directory.")
 
@@ -126,7 +126,7 @@ def check_cluv_config(pyproject_path: Path) -> None:
     If not, add a default config section with the default clusters and settings.
     """
     if has_cluv_config(pyproject_path):
-        console.print("[green]✅ Project already have a cluv config in pyproject.toml.[/green]")
+        console.print("✅ Project already have a cluv config in pyproject.toml.", style="green")
         return
 
     console.print(
@@ -155,14 +155,16 @@ def check_git() -> None:
     if git_remote.returncode == 0:
         if git_remote.stdout.strip() == "":
             console.print(
-                "[yellow]⚠️  Warning: No git remote found. You won't be able to use some features (like syncing or submitting jobs). Consider adding a remote repository to your git config.[/yellow]"
+                "⚠️  Warning: No git remote found. You won't be able to use some features "
+                "(like syncing or submitting jobs). Consider adding a remote repository to your git config.",
+                style="yellow",
             )
         else:
             console.print(
-                f"[green]✅ Git remote repository found: {git_remote.stdout.strip()}[/green]"
+                f"✅ Git remote repository found: {git_remote.stdout.strip()}", style="green"
             )
     else:
-        console.print("[red]❌ Invalid git repository found.[/red]")
+        console.print("❌ Invalid git repository found.", style="red")
         raise RuntimeError("Error when checking git remote: ", git_remote.stderr)
 
 
@@ -173,7 +175,7 @@ def check_symlink_to_scratch(project_root: Path, results_path: str, results_syml
     """
     if "SCRATCH" not in os.environ:
         console.print(
-            "[yellow]⚠️  Warning: $SCRATCH variable not set. Skipping symlink creation.[/yellow]"
+            "⚠️  Warning: $SCRATCH variable not set. Skipping symlink creation.", style="yellow"
         )
         return
 
@@ -184,12 +186,14 @@ def check_symlink_to_scratch(project_root: Path, results_path: str, results_syml
     if symlink_path.is_symlink():
         if symlink_path.resolve() == scratch_path.resolve():
             console.print(
-                "[green]✅ Symlink from $HOME results_path to $SCRATCH already exists.[/green]"
+                "✅ Symlink from $HOME results_path to $SCRATCH already exists.", style="green"
             )
             return
         else:
             console.print(
-                f"[yellow]⚠️  Warning: Symlink from {symlink_path} points to an other path ({symlink_path.resolve()}) than the expected scratch path.[/yellow]"
+                f"⚠️  Warning: Symlink from {symlink_path} points to an other path "
+                f"({symlink_path.resolve()}) than the expected scratch path.",
+                style="yellow",
             )
             return
     else:
@@ -207,13 +211,15 @@ def check_ssh_hostnames(clusters: list[str]) -> None:
 
     if len(missing_clusters) > 0:
         console.print(
-            f"[yellow]⚠️  Warning: Missing SSH config for {len(missing_clusters)} clusters. Try to run [bold]mila init[/bold] to add all available clusters.[/yellow]"
+            f"⚠️  Warning: Missing SSH config for {len(missing_clusters)} clusters. "
+            "Try to run [bold]mila init[/bold] to add all available clusters.",
+            style="yellow",
         )
         for cluster in missing_clusters:
-            console.print(f"[yellow]    - {cluster}[/yellow]")
+            console.print(f"    - {cluster}", style="yellow")
     else:
         console.print(
-            "[green]✅ All clusters in the cluv config are present in your SSH config.[/green]"
+            "✅ All clusters in the cluv config are present in your SSH config.", style="green"
         )
 
 
@@ -232,7 +238,7 @@ def check_job_script(project_root: Path, results_path: str) -> None:
     script_templates = sorted(script_templates_path.glob("*.sh"))
 
     if not script_templates:
-        console.print("[yellow]⚠️  Warning: No script templates found.[/yellow]")
+        console.print("⚠️  Warning: No script templates found.", style="yellow")
         return
 
     scripts_dir.mkdir(parents=True, exist_ok=True)
@@ -240,7 +246,7 @@ def check_job_script(project_root: Path, results_path: str) -> None:
         script_path = scripts_dir / script_template.name
         if script_path.exists():
             console.print(
-                f"[green]✅ Job template script already exists at '{script_path}'.[/green]"
+                f"✅ Job template script already exists at '{script_path}'.", style="green"
             )
             continue
         script_content = script_template.read_text()

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -40,7 +40,6 @@ def init(path: Path | None = None) -> None:
     # Try to run "uv init" to create a new project
     console.print()
     console.print("Initializing uv project: running [bold]uv init[/bold]...")
-    console.log("uv init --package --build-backend hatch --python 3.13")
     run_uv_init()
 
     # Check status of the git repository
@@ -99,22 +98,26 @@ def check_home_dir() -> None:
 
 
 def run_uv_init() -> None:
-    uv_init = subprocess.run(
-        ["uv", "init", "--package", "--build-backend", "hatch", "--python", "3.13"],
-        capture_output=True,
-        text=True,
-    )
+    """
+    Try to run the uv init command. If the command fails because a pyproject.toml file
+    already exists,continue. Otherwise, raise an error.
+    """
+    command = ["uv", "init", "--package", "--build-backend", "hatch", "--python", "3.13"]
+    console.log(" ".join(command))
+
+    uv_init = subprocess.run(command, capture_output=True, text=True)
 
     # An expected error is that uv fails if a pyproject.toml file already exists
     if uv_init.returncode == 2:
         if uv_init.stderr.endswith("(`pyproject.toml` file exists)\n"):
             console.print(
-                "[green]✅ uv: a project already exists (see pyproject.toml file). Skipping initialization.[/green]"
+                "✅ uv: a project already exists (see pyproject.toml file). Skipping initialization.",
+                style="green",
             )
         else:
             raise RuntimeError("Error occurred while initializing uv project: ", uv_init.stderr)
     else:
-        console.print("[green]✅ uv: project initialized.[/green]")
+        console.print("✅ uv: project initialized.", style="green")
 
 
 def check_cluv_config(pyproject_path: Path) -> None:

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -101,7 +101,7 @@ def check_home_dir() -> None:
 def run_uv_init() -> None:
     """
     Try to run the uv init command. If the command fails because a pyproject.toml file
-    already exists,continue. Otherwise, raise an error.
+    already exists, continue. Otherwise, raise an error.
     """
     command = ["uv", "init", "--package", "--build-backend", "hatch", "--python", "3.13"]
     console.log(" ".join(command))
@@ -202,7 +202,7 @@ def check_symlink_to_scratch(project_path: Path, results_path: str, results_syml
             return
     elif symlink_path.exists():
         console.print(
-            f"[yellow]⚠️  Warning: {symlink_path} already exists and is not a symlink.[/yellow]"
+            f"⚠️  Warning: {symlink_path} already exists and is not a symlink.", style="yellow"
         )
         return
     else:
@@ -292,6 +292,9 @@ def check_job_script(project_root: Path, results_path: str) -> None:
 
 
 def _load_cluv_config_template() -> str:
+    """
+    Load the [tool.cluv] section from the pyproject.toml template file.
+    """
     pyproject_template_path = _get_pyproject_template_path()
     pyproject_lines = pyproject_template_path.read_text().splitlines()
     start = next(
@@ -314,10 +317,17 @@ def _load_cluv_config_template() -> str:
 
 
 def _update_clug_config_template(template_config: str, project_name: str) -> str:
+    """
+    Update the template cluv config with the project info.
+    """
     return template_config.replace(DEFAULT_RESULTS_PATH, f"$SCRATCH/logs/{project_name}")
 
 
 def _get_script_templates_path() -> Path:
+    """
+    Get the path to the folder with the job script templates for cluv init, either from the source
+    repository or from the installed package.
+    """
     checked_paths = [REPO_ROOT / "scripts", PACKAGE_ROOT / "templates" / "scripts"]
     for script_templates_path in checked_paths:
         if script_templates_path.exists():
@@ -329,6 +339,10 @@ def _get_script_templates_path() -> Path:
 
 
 def _get_pyproject_template_path() -> Path:
+    """
+    Get the path to the pyproject.toml template file for cluv init, either from the source
+    repository or from the installed package.
+    """
     checked_paths = [REPO_ROOT / "pyproject.toml", PACKAGE_ROOT / "templates" / "pyproject.toml"]
     for pyproject_template_path in checked_paths:
         if pyproject_template_path.exists():

--- a/cluv/cli/init.py
+++ b/cluv/cli/init.py
@@ -134,7 +134,7 @@ def check_cluv_config(pyproject_path: Path) -> None:
     )
     console.print("Adding config for cluv tool :")
 
-    cluv_config = _load_cluv_config_template()
+    cluv_config = _load_cluv_config_template(pyproject_path.parent.name)
     add_cluv_config_section(pyproject_path, cluv_config)
 
 
@@ -281,7 +281,7 @@ def check_job_script(project_root: Path, results_path: str) -> None:
         console.print(f"Adding job template script at '{script_path}'.")
 
 
-def _load_cluv_config_template() -> str:
+def _load_cluv_config_template(project_name: str) -> str:
     pyproject_template_path = _get_pyproject_template_path()
     pyproject_lines = pyproject_template_path.read_text().splitlines()
     start = next(
@@ -300,7 +300,11 @@ def _load_cluv_config_template() -> str:
         ),
         len(pyproject_lines),
     )
-    return "\n".join(pyproject_lines[start:end]).strip() + "\n"
+    template = "\n".join(pyproject_lines[start:end]).strip() + "\n"
+    return template.replace(
+        f'results_path = "{DEFAULT_RESULTS_PATH}"',
+        f'results_path = "$SCRATCH/logs/{project_name}"',
+    )
 
 
 def _get_script_templates_path() -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ WANDB_MODE = "offline"
 [tool.cluv.local]
 ## Settings (environment variables) applied when using cluv on a local machine (not on a Slurm cluster).
 # Fake "$SCRATCH" directory to use when not on a Slurm cluster.
-# (this makes the examples runnable either from a laptop or from a Slurm cluster.
+# This makes the examples runnable either from a laptop or from a Slurm cluster.
 env = { SCRATCH = "$HOME/scratch" }
 
 [tool.cluv.sbatch_args]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -58,8 +58,9 @@ class TestCheckCluvConfig:
         check_cluv_config(p)
         config = load_cluv_config(p)
         expected_config = load_cluv_config(REPO_ROOT / "pyproject.toml")
+        expected_results_path = f"$SCRATCH/logs/{tmp_path.name}"
 
-        assert config.results_path == expected_config.results_path
+        assert config.results_path == expected_results_path
         assert config.env == expected_config.env
         assert config.clusters_names == expected_config.clusters_names
         assert config.clusters == expected_config.clusters
@@ -103,7 +104,7 @@ class TestSymlinkCheck:
         expected_results_scratch_path = Path(os.path.expandvars(DEFAULT_RESULTS_PATH))
 
         check_symlink_to_scratch(
-            project_root=fake_project_root,
+            project_path=fake_project_root,
             results_path=DEFAULT_RESULTS_PATH,
             results_symlink=DEFAULT_RESULTS_LINKNAME,
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,7 +18,7 @@ import pytest
 import pytest_asyncio
 
 from cluv.cache import Job
-from cluv.cli.init import DEFAULT_RESULTS_PATH, init
+from cluv.cli.init import init
 from cluv.cli.login import login
 from cluv.cli.status import ClusterStatus, get_cluster_status
 from cluv.cli.submit import submit
@@ -83,7 +83,7 @@ async def test_login(remote: Remote):
 
 @pytest_asyncio.fixture(scope="session")
 async def cluster_status(cluster: str) -> ClusterStatus:
-    return await get_cluster_status(cluster)
+    return await get_cluster_status(cluster, {})
 
 
 @pytest.mark.slow
@@ -114,20 +114,6 @@ async def test_status_gpu_model(cluster_status: ClusterStatus, cluster: str):
     if cluster not in STATUS_SUPPORTED_CLUSTERS:
         pytest.xfail(f"Status integration test not supported on cluster {cluster}.")
     assert cluster_status.gpu_model != "?", f"GPU model not detected: {cluster_status.gpu_model!r}"
-
-
-@pytest.mark.slow
-@pytest.mark.timeout(30)
-@pytest.mark.xfail(reason="Status integration tests are flaky and will be reworked soon.")
-@pytest.mark.asyncio
-async def test_status_jobs(cluster_status: ClusterStatus, cluster: str):
-    if cluster not in STATUS_SUPPORTED_CLUSTERS:
-        pytest.xfail(f"Status integration test not supported on cluster {cluster}.")
-    # Job counts must be non-negative integers (tamia is a busy cluster)
-    assert cluster_status.jobs.running >= 0
-    assert cluster_status.jobs.pending >= 0
-    assert cluster_status.jobs.my_running >= 0
-    assert cluster_status.jobs.my_pending >= 0
 
 
 @pytest.mark.slow
@@ -314,7 +300,7 @@ def test_init(
 
     generated_config = load_cluv_config(project_dir / "pyproject.toml")
 
-    assert generated_config.results_path == DEFAULT_RESULTS_PATH
+    assert generated_config.results_path == f"$SCRATCH/logs/{project_dir.name}"
     assert (project_dir / "scripts").is_dir()
     assert (project_dir / "scripts" / "job.sh").is_file()
 
@@ -351,7 +337,7 @@ def test_init_at_path(fake_home: Path) -> None:
     init(project_path)
 
     generated_config = load_cluv_config(project_path / "pyproject.toml")
-    assert generated_config.results_path == DEFAULT_RESULTS_PATH
+    assert generated_config.results_path == f"$SCRATCH/logs/{project_path.name}"
     assert (project_path / "scripts").is_dir()
     assert (project_path / "scripts" / "job.sh").is_file()
     assert (project_path / "scripts" / "safe_job.sh").is_file()


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* The `results_path` is now set at `$SCRATCH/logs/<project_name>` instead of the default `$SCRATCH/logs/cluv`.
* Rework console printing  and functions documentation in `init.py`.
* Remove outdated `test_status_jobs` in `test_integration.py`.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
* Close #130 