### PR TITLE
Add `cluv --version` command

### DIFF
--- a/cluv/__init__.py
+++ b/cluv/__init__.py
@@ -1,0 +1,8 @@
+"""CLUV: Tool to use UV with multiple clusters."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("cluster-uv")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"

--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -20,6 +20,7 @@ import rich.logging
 import rich_argparse
 import simple_parsing
 
+from . import __version__
 from .cli.clean import clean
 from .cli.init import init
 from .cli.login import login
@@ -56,6 +57,11 @@ def main(argv: list[str] | None = None) -> None:
         epilog="For more information, see the documentation. You rock.",
     )
     _add_v_arg(parser, _root=True)  # add -v/--verbose on the top-level parser.
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"cluv {__version__}",
+    )
 
     subparsers = parser.add_subparsers(dest="<command>", required=True)
 


### PR DESCRIPTION
## Summary
- Adds `cluv --version` / prints `cluv <version>` and exits, using argparse's built-in `action="version"`.
- Version is read via `importlib.metadata.version("cluster-uv")` (the distribution name from `pyproject.toml`), with a `"0.0.0+unknown"` fallback for `PackageNotFoundError`.

## Notes on `uv-dynamic-versioning`
- The distribution name (`cluster-uv`) differs from the import name (`cluv`), but `importlib.metadata` resolves by distribution name (PEP 503 normalized), so this isn't a source of breakage across install methods.
- For editable/dev installs (`uv sync`), the version is computed live at sync time and can go stale relative to `HEAD` until the next `uv sync` — expected `uv-dynamic-versioning` behavior, not a bug.
- For installs from a built wheel/sdist (e.g. PyPI), the version is frozen into static `METADATA`/`PKG-INFO` at build/publish time — verified via `uv build` that the sdist has no `.git` directory and reads a fixed version string, so PyPI installs never touch git at install time.

## Test plan
- [x] `uv run cluv --version` prints `cluv <version>`
- [x] `uv run cluv --help` shows `--version` in usage/options
- [x] `uv run cluv` (no subcommand) still errors with "the following arguments are required: <command>"
- [x] `uv run pytest -k "main or version"` passes
- [x] Built wheel/sdist via `uv build` and confirmed frozen version in `METADATA`/`PKG-INFO`

🤖 Generated with [Claude Code](https://claude.com/claude-code)