### PR TITLE
Reduce the number of displayed jobs with `cluv status`

### DIFF
--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -190,10 +190,9 @@ def add_status_args(subparsers: Subparsers):
         help="Which table to display: cluster overview, jobs overview, or both (default: all).",
     )
     status_parser.add_argument(
-        "--max-jobs",
-        default=10,
-        type=int,
-        help="How many jobs to display.",
+        "--all-jobs",
+        action="store_true",
+        help="Show all jobs instead of only the 10 most recent.",
     )
     status_parser.set_defaults(func=status)
     return status_parser

--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -22,13 +22,13 @@ import simple_parsing
 
 from . import __version__
 from .cli.clean import clean
+from .cli.disable import disable, enable
 from .cli.init import init
 from .cli.login import login
 from .cli.run import run
 from .cli.status import status
 from .cli.submit import submit
 from .cli.sync import sync
-from .cli.disable import disable, enable
 from .utils import console
 
 logger = logging.getLogger("cluv")
@@ -188,6 +188,12 @@ def add_status_args(subparsers: Subparsers):
         default="all",
         metavar="<table>",
         help="Which table to display: cluster overview, jobs overview, or both (default: all).",
+    )
+    status_parser.add_argument(
+        "--show_n_jobs",
+        default=10,
+        type=int,
+        help="How many jobs to display.",
     )
     status_parser.set_defaults(func=status)
     return status_parser

--- a/cluv/__main__.py
+++ b/cluv/__main__.py
@@ -190,7 +190,7 @@ def add_status_args(subparsers: Subparsers):
         help="Which table to display: cluster overview, jobs overview, or both (default: all).",
     )
     status_parser.add_argument(
-        "--show_n_jobs",
+        "--max-jobs",
         default=10,
         type=int,
         help="How many jobs to display.",

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -408,7 +408,9 @@ def _build_cluster_table(
     return table
 
 
-def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobInfo]) -> Table:
+def _build_cluv_jobs_table(
+    cached_jobs: list[Job], live_info: dict[int, LiveJobInfo], show_n_jobs: int
+) -> Table:
     """Build the jobs overview table with one row per cached job, enriched with live status info."""
     table = Table(
         title="Cluv Jobs Overview",
@@ -426,7 +428,8 @@ def _build_cluv_jobs_table(cached_jobs: list[Job], live_info: dict[int, LiveJobI
     table.add_column("Waiting time")
     table.add_column("Elapsed time")
 
-    for job in cached_jobs:
+    # Reverse the cached jobs so the most recent ones are shown first in the jobs table.
+    for job in list(reversed(cached_jobs))[:show_n_jobs]:
         info = live_info.get(job.job_id)
 
         try:
@@ -496,9 +499,6 @@ async def get_job_infos(
     disabled_clusters: dict[str, DisabledCluster],
 ) -> tuple[dict[int, LiveJobInfo], dict[str, ClusterJobStats]]:
     """Fetch live job info for all cached jobs, and count job statuses per cluster."""
-    # Reverse the cached jobs so the most recent ones are shown first in the jobs table.
-    cached_jobs = list(reversed(cached_jobs))
-
     # Regroup jobs by cluster
     cluster_jobs: dict[str, list[int]] = {}
     for job in cached_jobs:
@@ -541,7 +541,7 @@ async def get_job_infos(
     return live_info, clusters_job_stats
 
 
-async def status(table: Literal["clusters", "jobs", "all"]) -> None:
+async def status(table: Literal["clusters", "jobs", "all"], show_n_jobs: int) -> None:
     """Show status of clusters and jobs.
 
     Parameters:
@@ -595,5 +595,11 @@ async def status(table: Literal["clusters", "jobs", "all"]) -> None:
         console.print()
 
     if table in ("jobs", "all"):
-        console.print(_build_cluv_jobs_table(cached_jobs, jobs_status))
+        console.print(_build_cluv_jobs_table(cached_jobs, jobs_status, show_n_jobs))
+        console.print(
+            Panel(
+                f"Showing the last {show_n_jobs} jobs on {len(cached_jobs)} cluv jobs",
+                border_style="dim",
+            )
+        )
         console.print()

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -36,6 +36,9 @@ logger = logging.getLogger(__name__)
 __all__ = ["status"]
 
 
+DEFAULT_SHOW_JOBS = 10
+
+
 @dataclass
 class ClusterJobStats:
     running: int
@@ -409,7 +412,7 @@ def _build_cluster_table(
 
 
 def _build_cluv_jobs_table(
-    cached_jobs: list[Job], live_info: dict[int, LiveJobInfo], max_jobs: int
+    cached_jobs: list[Job], live_info: dict[int, LiveJobInfo], max_jobs: int | None
 ) -> Table:
     """Build the jobs overview table with one row per cached job, enriched with live status info."""
     table = Table(
@@ -493,11 +496,12 @@ def _build_cluster_table_legend() -> Panel:
     return Panel(legend, title="Legend", border_style="dim", padding=(0, 1))
 
 
-def _build_job_table_legend(max_jobs: int, total_jobs: int) -> Panel:
-    shown_jobs = min(max_jobs, total_jobs)
+def _build_job_table_legend(max_jobs: int | None, total_jobs: int) -> Panel:
+    if max_jobs is None or max_jobs >= total_jobs:
+        return Panel(f"Showing {total_jobs} / {total_jobs} cluv jobs.", border_style="dim")
 
     return Panel(
-        f"Showing {shown_jobs} / {total_jobs} cluv jobs",
+        f"Showing {max_jobs} / {total_jobs} cluv jobs. Use --all-jobs to show all jobs.",
         border_style="dim",
     )
 
@@ -550,7 +554,7 @@ async def get_job_infos(
     return live_info, clusters_job_stats
 
 
-async def status(table: Literal["clusters", "jobs", "all"], max_jobs: int) -> None:
+async def status(table: Literal["clusters", "jobs", "all"], all_jobs: bool) -> None:
     """Show status of clusters and jobs.
 
     Parameters:
@@ -605,6 +609,7 @@ async def status(table: Literal["clusters", "jobs", "all"], max_jobs: int) -> No
         console.print()
 
     if table in ("jobs", "all"):
+        max_jobs = None if all_jobs else DEFAULT_SHOW_JOBS
         console.print(_build_cluv_jobs_table(cached_jobs, jobs_status, max_jobs))
         console.print(_build_job_table_legend(max_jobs, len(cached_jobs)))
         console.print()

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -409,7 +409,7 @@ def _build_cluster_table(
 
 
 def _build_cluv_jobs_table(
-    cached_jobs: list[Job], live_info: dict[int, LiveJobInfo], show_n_jobs: int
+    cached_jobs: list[Job], live_info: dict[int, LiveJobInfo], max_jobs: int
 ) -> Table:
     """Build the jobs overview table with one row per cached job, enriched with live status info."""
     table = Table(
@@ -429,7 +429,7 @@ def _build_cluv_jobs_table(
     table.add_column("Elapsed time")
 
     # Reverse the cached jobs so the most recent ones are shown first in the jobs table.
-    for job in list(reversed(cached_jobs))[:show_n_jobs]:
+    for job in list(reversed(cached_jobs))[:max_jobs]:
         info = live_info.get(job.job_id)
 
         try:
@@ -493,8 +493,8 @@ def _build_cluster_table_legend() -> Panel:
     return Panel(legend, title="Legend", border_style="dim", padding=(0, 1))
 
 
-def _build_job_table_legend(show_jobs: int, total_jobs: int) -> Panel:
-    shown_jobs = min(show_jobs, total_jobs)
+def _build_job_table_legend(max_jobs: int, total_jobs: int) -> Panel:
+    shown_jobs = min(max_jobs, total_jobs)
 
     return Panel(
         f"Showing {shown_jobs} / {total_jobs} cluv jobs",
@@ -550,7 +550,7 @@ async def get_job_infos(
     return live_info, clusters_job_stats
 
 
-async def status(table: Literal["clusters", "jobs", "all"], show_n_jobs: int) -> None:
+async def status(table: Literal["clusters", "jobs", "all"], max_jobs: int) -> None:
     """Show status of clusters and jobs.
 
     Parameters:
@@ -605,6 +605,6 @@ async def status(table: Literal["clusters", "jobs", "all"], show_n_jobs: int) ->
         console.print()
 
     if table in ("jobs", "all"):
-        console.print(_build_cluv_jobs_table(cached_jobs, jobs_status, show_n_jobs))
-        console.print(_build_job_table_legend(show_n_jobs, len(cached_jobs)))
+        console.print(_build_cluv_jobs_table(cached_jobs, jobs_status, max_jobs))
+        console.print(_build_job_table_legend(max_jobs, len(cached_jobs)))
         console.print()

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -482,7 +482,7 @@ def _count_states(tasks: list[ArrayTaskInfo]) -> Text:
     return total
 
 
-def _build_legend() -> Panel:
+def _build_cluster_table_legend() -> Panel:
     legend = (
         "[green]●[/green] connected  "
         "[red]⚠[/red] disconnected  "
@@ -491,6 +491,15 @@ def _build_legend() -> Panel:
         "[green]▰[/green]/[yellow]▰[/yellow]/[red]▰[/red] disk usage (low/med/high)"
     )
     return Panel(legend, title="Legend", border_style="dim", padding=(0, 1))
+
+
+def _build_job_table_legend(show_jobs: int, total_jobs: int) -> Panel:
+    shown_jobs = min(show_jobs, total_jobs)
+
+    return Panel(
+        f"Showing {shown_jobs} / {total_jobs} cluv jobs",
+        border_style="dim",
+    )
 
 
 async def get_job_infos(
@@ -585,21 +594,17 @@ async def status(table: Literal["clusters", "jobs", "all"], show_n_jobs: int) ->
         if clusters_status and all(not c.online for c in clusters_status):
             console.print(
                 (
-                    "[yellow]No active connections to any clusters found. "
-                    "Run [bold]cluv login[/bold] first.[/yellow]"
-                )
+                    "No active connections to any clusters found. "
+                    "Run [bold]cluv login[/bold] first."
+                ),
+                style="yellow",
             )
 
         console.print(_build_cluster_table(clusters_status, clusters_job_stats, disabled_clusters))
-        console.print(_build_legend())
+        console.print(_build_cluster_table_legend())
         console.print()
 
     if table in ("jobs", "all"):
         console.print(_build_cluv_jobs_table(cached_jobs, jobs_status, show_n_jobs))
-        console.print(
-            Panel(
-                f"Showing the last {show_n_jobs} jobs on {len(cached_jobs)} cluv jobs",
-                border_style="dim",
-            )
-        )
+        console.print(_build_job_table_legend(show_n_jobs, len(cached_jobs)))
         console.print()

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -219,13 +219,18 @@ Requires an active connection (see [`cluv login`](#cluv-login)) to fetch live da
 
 **Usage**
 ```console
-cluv status [table]
+cluv status [table] [options]
 ```
 
 **Arguments**
 
 `table`
 :   Which table to display in the status output. Can be one of `jobs`, `clusters`, or `all`. Defaults to `all`.
+
+**Options**
+
+`--show_n_jobs`
+:   Number of jobs to show in the `jobs` table. Default to 10.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -229,8 +229,8 @@ cluv status [table] [options]
 
 **Options**
 
-`--show_n_jobs`
-:   Number of jobs to show in the `jobs` table. Default to 10.
+`--max-jobs`
+:   Maximum number of jobs to show in the `jobs` table. Default to 10.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -229,8 +229,8 @@ cluv status [table] [options]
 
 **Options**
 
-`--max-jobs`
-:   Maximum number of jobs to show in the `jobs` table. Default to 10.
+`--all-jobs`
+:   Show all jobs instead of only the 10 most recent. By default, only the 10 most recent jobs are shown.
 
 ---
 


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* The `jobs` table now only show the last 10 jobs instead of all the cluv jobs. The number of jobs to display can be set with `--max-jobs`.
* Now correctly show the last submitted jobs first.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/