### PR TITLE
Remove duplicate print for disabled clusters

### DIFF
--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -77,7 +77,6 @@ async def sync(
 
     # Show disabled clusters early so the user is aware.
     disabled = get_disabled_clusters()
-    print_disabled_clusters(disabled)
 
     # When no cluster is passed, sync with clusters for which we have an active SSH connection.
     all_remotes = await get_active_remotes()
@@ -87,11 +86,13 @@ async def sync(
         # Pass the already-fetched disabled dict so login does not print the warning a second time.
         remotes = await login(enabled_clusters, disabled=disabled) if enabled_clusters else []
     elif not all_remotes:
+        print_disabled_clusters(disabled)
         raise RuntimeError(
             "[red]Not currently connected to any Slurm cluster.[/red] "
             "Use `cluv login` to login and create reusable connections."
         )
     else:
+        print_disabled_clusters(disabled)
         remotes = all_remotes.copy()
         clusters = [remote.hostname for remote in all_remotes]
 


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Fix duplicate print showing disabled clusters when using `cluv sync`:

```
cluv sync mila
Skipping disabled cluster(s): fir (indefinitely). Run cluv enable <cluster> to re-enable.
Skipping disabled cluster(s): fir (indefinitely). Run cluv enable <cluster> to re-enable.
```

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/