### PR TITLE
Show the number of available GPUs per type in `cluv status`

### DIFF
--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -342,7 +342,10 @@ def _gpu_bars(gpu_stats: dict[str, tuple[int, int]], name_width: int) -> Text:
     for i, (model, (idle, total)) in enumerate(gpu_stats.items()):
         if i:
             bars += Text("\n")
-        bars += Text(f"{model:<{name_width}} ", style="bright_blue") + _gpu_bar(idle, total)
+        if total == 0:
+            bars += Text("N/A", style="dim")
+        else:
+            bars += Text(f"{model:<{name_width}} ", style="bright_blue") + _gpu_bar(idle, total)
     return bars
 
 

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -78,9 +78,7 @@ class LiveJobInfo:
 class ClusterStatus:
     name: str
     online: bool
-    gpu_idle: int
-    gpu_total: int
-    gpu_model: str
+    gpu_stats: dict[str, tuple[int, int]]  # model -> (idle, total)
     storage: StorageStats
 
 
@@ -88,9 +86,7 @@ def get_default_cluster_status(cluster: str) -> ClusterStatus:
     return ClusterStatus(
         name=cluster,
         online=False,
-        gpu_idle=0,
-        gpu_total=0,
-        gpu_model="?",
+        gpu_stats={},
         storage=StorageStats(home_used=0, home_quota=0, scratch_used=0, scratch_quota=0),
     )
 
@@ -243,12 +239,7 @@ async def get_cluster_status(
     partition_stats_out, sinfo_out, diskusage_out, savail_out, disk_quota_out = parts[:5]
 
     # --- GPU info: prefer savail (Mila) over sinfo (DRAC) ---
-    savail_idle, savail_total, savail_models = parse_savail(savail_out)
-    if savail_total > 0:
-        gpu_idle, gpu_total, models = savail_idle, savail_total, savail_models
-    else:
-        gpu_idle, gpu_total, models = parse_sinfo_nodes(sinfo_out)
-    gpu_model = ", ".join(models) if models else "?"
+    gpu_stats = parse_savail(savail_out) or parse_sinfo_nodes(sinfo_out)
 
     # --- Partition stats can give us node counts which are a useful
     #     fallback when GPU counts aren't available --
@@ -257,9 +248,8 @@ async def get_cluster_status(
         ps = parse_partition_stats(partition_stats_out)
         # If neither savail nor sinfo gave us GPU counts, fall back to
         # partition-stats node counts (less precise but better than nothing).
-        if gpu_total == 0:
-            gpu_idle = ps["gpu_idle_nodes"]
-            gpu_total = ps["gpu_total_nodes"]
+        if not gpu_stats:
+            gpu_stats = {"GPU": (ps["gpu_idle_nodes"], ps["gpu_total_nodes"])}
 
     # --- Storage: prefer diskusage_report (DRAC, per-user quotas);
     #     fall back to disk-quota (Mila: lfs for $HOME, beegfs for $SCRATCH) ---
@@ -275,9 +265,7 @@ async def get_cluster_status(
     return ClusterStatus(
         name=cluster,
         online=True,
-        gpu_idle=gpu_idle,
-        gpu_total=gpu_total,
-        gpu_model=gpu_model,
+        gpu_stats=gpu_stats,
         storage=storage,
     )
 
@@ -345,6 +333,20 @@ def _gpu_bar(idle: int, total: int, width: int = 10) -> Text:
     return Text(f"{bar_str} {idle:>5}/{total}", style=colour)
 
 
+def _gpu_bars(gpu_stats: dict[str, tuple[int, int]]) -> Text:
+    """Return one free-GPU bar per model, stacked vertically and labelled."""
+    if not gpu_stats:
+        return Text("-")
+
+    name_width = max(len(model) for model in gpu_stats)
+    bars = Text()
+    for i, (model, (idle, total)) in enumerate(gpu_stats.items()):
+        if i:
+            bars += Text("\n")
+        bars += Text(f"{model:<{name_width}} ", style="bright_blue") + _gpu_bar(idle, total)
+    return bars
+
+
 # ---------------------------------------------------------------------------
 # Main display
 # ---------------------------------------------------------------------------
@@ -364,8 +366,7 @@ def _build_cluster_table(
     )
 
     table.add_column("Cluster", style="bold", ratio=1)
-    table.add_column("GPU model", justify="center", ratio=2)
-    table.add_column("Free GPUs", justify="left", ratio=1)
+    table.add_column("Free GPUs (by type)", justify="left", ratio=2)
     table.add_column("My jobs\nrun / pend / fail / comp", justify="center", ratio=2)
     table.add_column("Storage used", justify="left", ratio=2)
 
@@ -399,8 +400,7 @@ def _build_cluster_table(
 
         table.add_row(
             cluster_status,
-            Text(c.gpu_model, style="bright_blue") if c.online else "-",
-            _gpu_bar(c.gpu_idle, c.gpu_total) if c.online else "-",
+            _gpu_bars(c.gpu_stats) if c.online else "-",
             my_jobs if c.online else "-",
             home_bar + "\n" + scratch_bar if c.online else "-",
         )

--- a/cluv/cli/status.py
+++ b/cluv/cli/status.py
@@ -330,15 +330,14 @@ def _gpu_bar(idle: int, total: int, width: int = 10) -> Text:
         colour = "yellow"
     else:
         colour = "red"
-    return Text(f"{bar_str} {idle:>5}/{total}", style=colour)
+    return Text(f"{bar_str} {idle:>4}/{total}", style=colour)
 
 
-def _gpu_bars(gpu_stats: dict[str, tuple[int, int]]) -> Text:
+def _gpu_bars(gpu_stats: dict[str, tuple[int, int]], name_width: int) -> Text:
     """Return one free-GPU bar per model, stacked vertically and labelled."""
     if not gpu_stats:
         return Text("-")
 
-    name_width = max(len(model) for model in gpu_stats)
     bars = Text()
     for i, (model, (idle, total)) in enumerate(gpu_stats.items()):
         if i:
@@ -365,10 +364,12 @@ def _build_cluster_table(
         expand=True,
     )
 
-    table.add_column("Cluster", style="bold", ratio=1)
-    table.add_column("Free GPUs (by type)", justify="left", ratio=2)
-    table.add_column("My jobs\nrun / pend / fail / comp", justify="center", ratio=2)
-    table.add_column("Storage used", justify="left", ratio=2)
+    table.add_column("Cluster", style="bold")
+    table.add_column("Available GPUs (by type)", justify="left")
+    table.add_column("My jobs\nrun / pend / fail / comp", justify="center")
+    table.add_column("Storage used", justify="left")
+
+    max_gpu_name_width = max((len(model) for c in data for model in c.gpu_stats), default=0)
 
     for c in data:
         status = Text("● ", style="bold green") if c.online else Text("⚠ ", style="bold red")
@@ -400,7 +401,7 @@ def _build_cluster_table(
 
         table.add_row(
             cluster_status,
-            _gpu_bars(c.gpu_stats) if c.online else "-",
+            _gpu_bars(c.gpu_stats, max_gpu_name_width) if c.online else "-",
             my_jobs if c.online else "-",
             home_bar + "\n" + scratch_bar if c.online else "-",
         )
@@ -483,7 +484,7 @@ def _build_legend() -> Panel:
     legend = (
         "[green]●[/green] connected  "
         "[red]⚠[/red] disconnected  "
-        "[green]▰[/green] free GPU  "
+        "[green]▰[/green] idle GPU  "
         "[red]▱[/red] busy GPU   "
         "[green]▰[/green]/[yellow]▰[/yellow]/[red]▰[/red] disk usage (low/med/high)"
     )

--- a/cluv/slurm.py
+++ b/cluv/slurm.py
@@ -197,34 +197,24 @@ _IDLE_STATES = {"idle", "idle~", "idle+"}
 def _normalize_gpu_model(raw: str) -> str:
     """Normalize a raw GRES GPU model name to a short human-readable form.
 
+    MIG slices are kept as their own distinct GPU type (suffixed with their
+    profile) rather than folded back into the base model, since a MIG slice
+    is not interchangeable with a full physical GPU.
+
     Examples:
         "h100"                              → "H100"
         "a100"                              → "A100"
-        "nvidia_h100_80gb_hbm3_3g.40gb"    → "H100"
+        "nvidia_h100_80gb_hbm3_3g.40gb"     → "H100-3g.40gb"
     """
     # Strip optional "nvidia_" vendor prefix
     clean = re.sub(r"^nvidia_", "", raw, flags=re.IGNORECASE)
     m = _MODEL_TOKEN_RE.search(clean)
-    return m.group(1).upper() if m else raw.upper()
+    base = m.group(1).upper() if m else raw.upper()
 
-
-def _mig_physical_gpus(entries: list[tuple[str, int]]) -> int | None:
-    """Return the number of physical GPUs represented by a list of MIG GRES entries.
-
-    MIG profile names embed the compute slice fraction as ``<g_val>g.<mem>gb``
-    (e.g. ``3g.40gb``).  An H100 has 7 compute slices, so:
-
-        physical_gpus = sum(g_val * count) // 7
-
-    Returns *None* if any entry lacks a parseable MIG profile (not a pure MIG node).
-    """
-    total_compute = 0
-    for model, count in entries:
-        m = _MIG_PROFILE_RE.search(model)
-        if not m:
-            return None  # mixed or non-MIG node
-        total_compute += int(m.group(1)) * count
-    return total_compute // 7
+    mig = _MIG_PROFILE_RE.search(clean)
+    if mig:
+        return f"{base}-{mig.group(0).lower()}"
+    return base
 
 
 def parse_sinfo_nodes(output: str) -> dict[str, tuple[int, int]]:
@@ -240,13 +230,13 @@ def parse_sinfo_nodes(output: str) -> dict[str, tuple[int, int]]:
     unique, so nodes that belong to multiple Slurm partitions are not counted
     more than once.
 
-    MIG nodes are handled by reconstructing the physical GPU count from the
-    per-slice g-values (``sum(g_val * count) // 7`` for H100), grouped by
-    the model they belong to.
+    MIG slices are reported as their own GPU type (e.g. ``"H100-3g.40gb"``)
+    rather than reconstructed into a physical GPU count, since a MIG slice
+    can't be scheduled interchangeably with a full GPU.
 
     Returns:
-        A dict mapping each GPU model name (e.g. ``"H100"``) to a
-        ``(idle, total)`` tuple of physical GPU counts, sorted by model name.
+        A dict mapping each GPU model/MIG-profile name to a ``(idle, total)``
+        tuple of GRES counts, sorted by name.
     """
     per_model: dict[str, list[int]] = {}
 
@@ -263,24 +253,14 @@ def parse_sinfo_nodes(output: str) -> dict[str, tuple[int, int]]:
         if not matches:
             continue
 
-        entries: list[tuple[str, int]] = [(model, int(count_str)) for model, count_str in matches]
-
-        model_groups: dict[str, list[tuple[str, int]]] = {}
-        for model, count in entries:
-            model_groups.setdefault(_normalize_gpu_model(model), []).append((model, count))
-
-        for model, group_entries in model_groups.items():
-            # Compute physical GPU count for this model on this node.
-            # If all GRES entries are MIG slices, reconstruct the physical count.
-            # Otherwise sum only the non-MIG GRES entries.
-            node_gpus = _mig_physical_gpus(group_entries)
-            if node_gpus is None:
-                node_gpus = sum(c for m, c in group_entries if not _MIG_PROFILE_RE.search(m))
+        for raw_model, count_str in matches:
+            model = _normalize_gpu_model(raw_model)
+            count = int(count_str)
 
             idle_total = per_model.setdefault(model, [0, 0])
-            idle_total[1] += node_gpus
+            idle_total[1] += count
             if state in _IDLE_STATES:
-                idle_total[0] += node_gpus
+                idle_total[0] += count
 
     return {model: (idle, total) for model, (idle, total) in sorted(per_model.items())}
 

--- a/cluv/slurm.py
+++ b/cluv/slurm.py
@@ -36,18 +36,55 @@ def parse_timestamp(timestamp: str) -> datetime:
 
 
 def parse_slurm_time(time: str) -> timedelta:
-    """Parse a time value from the sbatch format to a timedelta object."""
-    # The SLURM time format is days-hours:minutes:seconds, with the days part optional.
-    match = re.match(r"(?:(\d+)-)?(\d{1,2}):(\d{2}):(\d{2})", time.strip())
-    if not match:
+    """Parse a time value from the sbatch format to a timedelta object.
+
+    The SLURM time format (https://slurm.schedmd.com/sbatch.html#OPT_time) can be:
+        1. days-hours:minutes:seconds
+        2. days-hours:minutes
+        3. days-hours
+        4. hours:minutes:seconds
+        5. minutes:seconds
+        6. minutes
+    """
+    value = time.strip()
+    if not value:
         raise ValueError(f"Could not parse time value: {time}")
 
-    return timedelta(
-        days=int(match.group(1) or 0),
-        hours=int(match.group(2)),
-        minutes=int(match.group(3)),
-        seconds=int(match.group(4)),
-    )
+    days, hours, minutes, seconds = 0, 0, 0, 0
+    has_days = "-" in value
+    if has_days:
+        day_part, value = value.split("-", 1)
+        if not day_part.isdigit():
+            raise ValueError(f"Could not parse time value: {time}")
+        days = int(day_part)
+
+    parts = value.split(":")
+    if len(parts) == 1:
+        if not parts[0].isdigit():
+            raise ValueError(f"Could not parse time value: {time}")
+        if has_days:
+            hours = int(parts[0])
+        else:
+            minutes = int(parts[0])
+    elif len(parts) == 2:
+        if not all(part.isdigit() for part in parts):
+            raise ValueError(f"Could not parse time value: {time}")
+        if has_days:
+            hours = int(parts[0])
+            minutes = int(parts[1])
+        else:
+            minutes = int(parts[0])
+            seconds = int(parts[1])
+    elif len(parts) == 3:
+        if not all(part.isdigit() for part in parts):
+            raise ValueError(f"Could not parse time value: {time}")
+        hours = int(parts[0])
+        minutes = int(parts[1])
+        seconds = int(parts[2])
+    else:
+        raise ValueError(f"Could not parse time value: {time}")
+
+    return timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
 
 
 async def run_sacct(
@@ -190,7 +227,7 @@ def _mig_physical_gpus(entries: list[tuple[str, int]]) -> int | None:
     return total_compute // 7
 
 
-def parse_sinfo_nodes(output: str) -> tuple[int, int, list[str]]:
+def parse_sinfo_nodes(output: str) -> dict[str, tuple[int, int]]:
     """Parse ``sinfo --noheader -N -o '%N %t %G' | sort -u | grep gpu`` output.
 
     Each line has the form ``<nodename> <state> <gres_field>`` where the GRES
@@ -204,16 +241,14 @@ def parse_sinfo_nodes(output: str) -> tuple[int, int, list[str]]:
     more than once.
 
     MIG nodes are handled by reconstructing the physical GPU count from the
-    per-slice g-values (``sum(g_val * count) // 7`` for H100).
+    per-slice g-values (``sum(g_val * count) // 7`` for H100), grouped by
+    the model they belong to.
 
     Returns:
-        gpu_idle  – total idle physical GPUs
-        gpu_total – total physical GPUs across all nodes
-        models    – sorted unique GPU model names (e.g. ``["H100", "A100"]``)
+        A dict mapping each GPU model name (e.g. ``"H100"``) to a
+        ``(idle, total)`` tuple of physical GPU counts, sorted by model name.
     """
-    gpu_idle = 0
-    gpu_total = 0
-    models: set[str] = set()
+    per_model: dict[str, list[int]] = {}
 
     for line in output.splitlines():
         line = line.strip()
@@ -230,21 +265,24 @@ def parse_sinfo_nodes(output: str) -> tuple[int, int, list[str]]:
 
         entries: list[tuple[str, int]] = [(model, int(count_str)) for model, count_str in matches]
 
-        for model, _ in entries:
-            models.add(_normalize_gpu_model(model))
+        model_groups: dict[str, list[tuple[str, int]]] = {}
+        for model, count in entries:
+            model_groups.setdefault(_normalize_gpu_model(model), []).append((model, count))
 
-        # Compute physical GPU count for this node.
-        # If all GRES entries are MIG slices, reconstruct the physical count.
-        # Otherwise sum only the non-MIG GRES entries.
-        node_gpus = _mig_physical_gpus(entries)
-        if node_gpus is None:
-            node_gpus = sum(c for m, c in entries if not _MIG_PROFILE_RE.search(m))
+        for model, group_entries in model_groups.items():
+            # Compute physical GPU count for this model on this node.
+            # If all GRES entries are MIG slices, reconstruct the physical count.
+            # Otherwise sum only the non-MIG GRES entries.
+            node_gpus = _mig_physical_gpus(group_entries)
+            if node_gpus is None:
+                node_gpus = sum(c for m, c in group_entries if not _MIG_PROFILE_RE.search(m))
 
-        gpu_total += node_gpus
-        if state in _IDLE_STATES:
-            gpu_idle += node_gpus
+            idle_total = per_model.setdefault(model, [0, 0])
+            idle_total[1] += node_gpus
+            if state in _IDLE_STATES:
+                idle_total[0] += node_gpus
 
-    return gpu_idle, gpu_total, sorted(models)
+    return {model: (idle, total) for model, (idle, total) in sorted(per_model.items())}
 
 
 # ---------------------------------------------------------------------------
@@ -257,28 +295,23 @@ def parse_sinfo_nodes(output: str) -> tuple[int, int, list[str]]:
 _SAVAIL_LINE_RE = re.compile(r"^(\w+)\s+(\d+)\s*/\s*(\d+)")
 
 
-def parse_savail(output: str) -> tuple[int, int, list[str]]:
+def parse_savail(output: str) -> dict[str, tuple[int, int]]:
     """Parse the output of the Mila-specific ``savail`` command.
 
     Returns:
-        gpu_idle  – total available (idle) GPUs across all types
-        gpu_total – total GPUs across all types
-        models    – sorted list of GPU model names in upper-case
+        A dict mapping each GPU model name (e.g. ``"A100"``) to a
+        ``(idle, total)`` tuple of GPU counts, sorted by model name.
     """
-    gpu_idle = 0
-    gpu_total = 0
-    models: list[str] = []
+    per_model: dict[str, tuple[int, int]] = {}
 
     for line in output.splitlines():
         m = _SAVAIL_LINE_RE.match(line.strip())
         if not m:
             continue
         model, avail, total = m.group(1), int(m.group(2)), int(m.group(3))
-        gpu_idle += avail
-        gpu_total += total
-        models.append(model.upper())
+        per_model[model.upper()] = (avail, total)
 
-    return gpu_idle, gpu_total, sorted(models)
+    return dict(sorted(per_model.items()))
 
 
 # ---------------------------------------------------------------------------

--- a/cluv/slurm.py
+++ b/cluv/slurm.py
@@ -36,55 +36,18 @@ def parse_timestamp(timestamp: str) -> datetime:
 
 
 def parse_slurm_time(time: str) -> timedelta:
-    """Parse a time value from the sbatch format to a timedelta object.
-
-    The SLURM time format (https://slurm.schedmd.com/sbatch.html#OPT_time) can be:
-        1. days-hours:minutes:seconds
-        2. days-hours:minutes
-        3. days-hours
-        4. hours:minutes:seconds
-        5. minutes:seconds
-        6. minutes
-    """
-    value = time.strip()
-    if not value:
+    """Parse a time value from the sbatch format to a timedelta object."""
+    # The SLURM time format is days-hours:minutes:seconds, with the days part optional.
+    match = re.match(r"(?:(\d+)-)?(\d{1,2}):(\d{2}):(\d{2})", time.strip())
+    if not match:
         raise ValueError(f"Could not parse time value: {time}")
 
-    days, hours, minutes, seconds = 0, 0, 0, 0
-    has_days = "-" in value
-    if has_days:
-        day_part, value = value.split("-", 1)
-        if not day_part.isdigit():
-            raise ValueError(f"Could not parse time value: {time}")
-        days = int(day_part)
-
-    parts = value.split(":")
-    if len(parts) == 1:
-        if not parts[0].isdigit():
-            raise ValueError(f"Could not parse time value: {time}")
-        if has_days:
-            hours = int(parts[0])
-        else:
-            minutes = int(parts[0])
-    elif len(parts) == 2:
-        if not all(part.isdigit() for part in parts):
-            raise ValueError(f"Could not parse time value: {time}")
-        if has_days:
-            hours = int(parts[0])
-            minutes = int(parts[1])
-        else:
-            minutes = int(parts[0])
-            seconds = int(parts[1])
-    elif len(parts) == 3:
-        if not all(part.isdigit() for part in parts):
-            raise ValueError(f"Could not parse time value: {time}")
-        hours = int(parts[0])
-        minutes = int(parts[1])
-        seconds = int(parts[2])
-    else:
-        raise ValueError(f"Could not parse time value: {time}")
-
-    return timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+    return timedelta(
+        days=int(match.group(1) or 0),
+        hours=int(match.group(2)),
+        minutes=int(match.group(3)),
+        seconds=int(match.group(4)),
+    )
 
 
 async def run_sacct(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -103,7 +103,8 @@ async def test_status_online(cluster_status: ClusterStatus, cluster: str):
 async def test_status_has_gpus(cluster_status: ClusterStatus, cluster: str):
     if cluster not in STATUS_SUPPORTED_CLUSTERS:
         pytest.xfail(f"Status integration test not supported on cluster {cluster}.")
-    assert cluster_status.gpu_total > 0, "Expected cluster to report GPU nodes"
+    total_gpus = sum(total for _, total in cluster_status.gpu_stats.values())
+    assert total_gpus > 0, "Expected cluster to report GPU nodes"
 
 
 @pytest.mark.slow
@@ -113,7 +114,8 @@ async def test_status_has_gpus(cluster_status: ClusterStatus, cluster: str):
 async def test_status_gpu_model(cluster_status: ClusterStatus, cluster: str):
     if cluster not in STATUS_SUPPORTED_CLUSTERS:
         pytest.xfail(f"Status integration test not supported on cluster {cluster}.")
-    assert cluster_status.gpu_model != "?", f"GPU model not detected: {cluster_status.gpu_model!r}"
+    assert cluster_status.gpu_stats, "GPU model not detected"
+    assert "?" not in cluster_status.gpu_stats
 
 
 @pytest.mark.slow
@@ -145,7 +147,7 @@ TEST_SUBMIT_TIMEOUT_SECONDS = 180
 )
 @pytest.mark.slow
 @pytest.mark.timeout(TEST_SUBMIT_TIMEOUT_SECONDS)
-async def test_submit(remote: Remote, fake_scratch: Path):
+async def test_submit(remote: Remote):
     """End-to-end: actually submit scripts/job.sh to a slurm cluster via sbatch.
 
     Requires an active SSH connection to the cluster and a clean git tree.

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -177,10 +177,8 @@ class TestParsePartitionStats:
 class TestParseSinfoNodes:
     def test_all_alloc(self):
         output = "node01 alloc gpu:h100:4(S:0-1)\nnode02 alloc gpu:h100:4(S:0-1)\n"
-        idle, total, models = parse_sinfo_nodes(output)
-        assert idle == 0
-        assert total == 8
-        assert models == ["H100"]
+        result = parse_sinfo_nodes(output)
+        assert result == {"H100": (0, 8)}
 
     def test_mixed_states(self):
         output = (
@@ -188,51 +186,39 @@ class TestParseSinfoNodes:
             "node02 alloc gpu:h200:8(S:0-1)\n"
             "node03 mix   gpu:h100:4(S:0-1)\n"
         )
-        idle, total, models = parse_sinfo_nodes(output)
-        assert idle == 4  # only the idle node
-        assert total == 4 + 8 + 4  # all three nodes
-        assert models == ["H100", "H200"]
+        result = parse_sinfo_nodes(output)
+        assert result == {"H100": (4, 8), "H200": (0, 8)}
 
     def test_idle_tilde_state(self):
         # sinfo sometimes reports "idle~" for draining idle nodes
         output = "node01 idle~ gpu:a100:8\n"
-        idle, total, models = parse_sinfo_nodes(output)
-        assert idle == 8
-        assert total == 8
+        result = parse_sinfo_nodes(output)
+        assert result == {"A100": (8, 8)}
 
     def test_multiple_models_sorted(self):
         output = "node01 idle gpu:v100:2\nnode02 idle gpu:a100:4\nnode03 idle gpu:h100:8\n"
-        _, _, models = parse_sinfo_nodes(output)
-        assert models == ["A100", "H100", "V100"]
+        result = parse_sinfo_nodes(output)
+        assert list(result.keys()) == ["A100", "H100", "V100"]
 
     def test_gres_without_socket_spec(self):
         # Some nodes report GRES without the (S:...) suffix
         output = "node01 idle gpu:h100:4\n"
-        idle, total, models = parse_sinfo_nodes(output)
-        assert idle == 4
-        assert total == 4
-        assert models == ["H100"]
+        result = parse_sinfo_nodes(output)
+        assert result == {"H100": (4, 4)}
 
     def test_empty_output(self):
-        idle, total, models = parse_sinfo_nodes("")
-        assert idle == 0
-        assert total == 0
-        assert models == []
+        assert parse_sinfo_nodes("") == {}
 
     def test_no_gpu_gres(self):
         # Lines without gpu: in GRES should be skipped
         output = "node01 idle cpu:32\nnode02 idle (null)\n"
-        idle, total, models = parse_sinfo_nodes(output)
-        assert idle == 0
-        assert total == 0
-        assert models == []
+        assert parse_sinfo_nodes(output) == {}
 
     def test_nvidia_prefix_normalized(self):
         # Full GRES name with nvidia_ prefix → model name is just the base
         output = "node01 idle gpu:nvidia_a100:8\n"
-        idle, total, models = parse_sinfo_nodes(output)
-        assert models == ["A100"]
-        assert total == 8
+        result = parse_sinfo_nodes(output)
+        assert result == {"A100": (8, 8)}
 
     def test_mig_node_physical_gpu_count(self):
         # Rorqual-style MIG node: 3 MIG profiles from 4 physical H100s
@@ -243,10 +229,8 @@ class TestParseSinfoNodes:
             "gpu:nvidia_h100_80gb_hbm3_2g.20gb:4(S:0-3),"
             "gpu:nvidia_h100_80gb_hbm3_1g.10gb:8(S:0-3)\n"
         )
-        idle, total, models = parse_sinfo_nodes(output)
-        assert total == 4, f"Expected 4 physical GPUs, got {total}"
-        assert idle == 4
-        assert models == ["H100"]
+        result = parse_sinfo_nodes(output)
+        assert result == {"H100": (4, 4)}
 
     def test_mig_model_normalization(self):
         # MIG GRES name should normalize to the base model (H100)
@@ -256,8 +240,8 @@ class TestParseSinfoNodes:
             "gpu:nvidia_h100_80gb_hbm3_2g.20gb:4(S:0-3),"
             "gpu:nvidia_h100_80gb_hbm3_1g.10gb:8(S:0-3)\n"
         )
-        _, _, models = parse_sinfo_nodes(output)
-        assert models == ["H100"]
+        result = parse_sinfo_nodes(output)
+        assert list(result.keys()) == ["H100"]
 
     def test_mixed_regular_and_mig_nodes(self):
         # Mix of regular H100 nodes and MIG nodes (rorqual-like)
@@ -269,10 +253,8 @@ class TestParseSinfoNodes:
             "gpu:nvidia_h100_80gb_hbm3_2g.20gb:4(S:0-3),"
             "gpu:nvidia_h100_80gb_hbm3_1g.10gb:8(S:0-3)\n"
         )
-        idle, total, models = parse_sinfo_nodes(output)
-        assert total == 8  # 4 + 4
-        assert idle == 8
-        assert models == ["H100"]
+        result = parse_sinfo_nodes(output)
+        assert result == {"H100": (8, 8)}  # 4 + 4
 
     def test_deduplication_via_sort_u(self):
         # Same node appearing multiple times (once per Slurm partition) should
@@ -286,9 +268,8 @@ class TestParseSinfoNodes:
         # contract that sort -u must be done upstream (in _REMOTE_SCRIPT).
         # Here we just verify the format is parsed correctly for one entry.
         output_deduped = "node01 idle gpu:h100:4\n"
-        idle, total, models = parse_sinfo_nodes(output_deduped)
-        assert total == 4
-        assert idle == 4
+        result = parse_sinfo_nodes(output_deduped)
+        assert result == {"H100": (4, 4)}
 
 
 # ---------------------------------------------------------------------------
@@ -298,37 +279,40 @@ class TestParseSinfoNodes:
 
 class TestParseSavail:
     def test_total_gpus(self):
-        _, total, _ = parse_savail(MILA_SAVAIL)
+        result = parse_savail(MILA_SAVAIL)
         # 32+136+8+16+352+376+56 = 976
-        assert total == 976
+        assert sum(total for _, total in result.values()) == 976
 
     def test_idle_gpus(self):
-        idle, _, _ = parse_savail(MILA_SAVAIL)
+        result = parse_savail(MILA_SAVAIL)
         # 15+13+0+0+10+130+5 = 173
-        assert idle == 173
+        assert sum(idle for idle, _ in result.values()) == 173
 
     def test_models_sorted(self):
-        _, _, models = parse_savail(MILA_SAVAIL)
-        assert models == ["A100", "A100L", "A6000", "H100", "L40S", "RTX8000", "V100"]
+        result = parse_savail(MILA_SAVAIL)
+        assert list(result.keys()) == [
+            "A100",
+            "A100L",
+            "A6000",
+            "H100",
+            "L40S",
+            "RTX8000",
+            "V100",
+        ]
 
     def test_header_and_separator_skipped(self):
         # The "GPU  Avail / Total" header and "===" separator must not be parsed as data
-        _, _, models = parse_savail(MILA_SAVAIL)
-        assert "GPU" not in models
-        assert "AVAIL" not in models
+        result = parse_savail(MILA_SAVAIL)
+        assert "GPU" not in result
+        assert "AVAIL" not in result
 
     def test_zero_available_still_counts_total(self):
         output = "a6000   0 / 8\nh100    0 / 16\n"
-        idle, total, models = parse_savail(output)
-        assert idle == 0
-        assert total == 24
-        assert models == ["A6000", "H100"]
+        result = parse_savail(output)
+        assert result == {"A6000": (0, 8), "H100": (0, 16)}
 
     def test_empty_output(self):
-        idle, total, models = parse_savail("")
-        assert idle == 0
-        assert total == 0
-        assert models == []
+        assert parse_savail("") == {}
 
 
 class TestParseDiskQuota:
@@ -415,10 +399,16 @@ class TestParseDiskusageReport:
 
 
 class TestParseTime:
-    def test_parse_slurm_time(self) -> None:
-        td = parse_slurm_time("12:28:45")
-        assert td == timedelta(hours=12, minutes=28, seconds=45)
-
-    def test_parse_slurm_time_with_day(self) -> None:
-        td = parse_slurm_time("07-12:28:45")
-        assert td == timedelta(days=7, hours=12, minutes=28, seconds=45)
+    @pytest.mark.parametrize(
+        ("input", "expected"),
+        [
+            ("12:28:45", timedelta(hours=12, minutes=28, seconds=45)),
+            ("07-12:28:45", timedelta(days=7, hours=12, minutes=28, seconds=45)),
+            ("07-12", timedelta(days=7, hours=12)),
+            ("07-12:28", timedelta(days=7, hours=12, minutes=28)),
+            ("28:12", timedelta(minutes=28, seconds=12)),
+            ("28", timedelta(minutes=28)),
+        ],
+    )
+    def test_parse_slurm_time(self, input: str, expected: timedelta) -> None:
+        assert parse_slurm_time(input) == expected

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -220,9 +220,9 @@ class TestParseSinfoNodes:
         result = parse_sinfo_nodes(output)
         assert result == {"A100": (8, 8)}
 
-    def test_mig_node_physical_gpu_count(self):
-        # Rorqual-style MIG node: 3 MIG profiles from 4 physical H100s
-        # sum(g_val * count) = 3*4 + 2*4 + 1*8 = 28; 28 // 7 = 4 physical GPUs
+    def test_mig_node_reports_each_profile_as_its_own_type(self):
+        # Rorqual-style MIG node: each MIG profile is its own GPU type, counted
+        # in slices (not reconstructed into a physical GPU count).
         output = (
             "rg12501 idle "
             "gpu:nvidia_h100_80gb_hbm3_3g.40gb:4(S:0-3),"
@@ -230,10 +230,14 @@ class TestParseSinfoNodes:
             "gpu:nvidia_h100_80gb_hbm3_1g.10gb:8(S:0-3)\n"
         )
         result = parse_sinfo_nodes(output)
-        assert result == {"H100": (4, 4)}
+        assert result == {
+            "H100-1g.10gb": (8, 8),
+            "H100-2g.20gb": (4, 4),
+            "H100-3g.40gb": (4, 4),
+        }
 
     def test_mig_model_normalization(self):
-        # MIG GRES name should normalize to the base model (H100)
+        # MIG GRES names should normalize to "<base>-<profile>", one type per profile
         output = (
             "rg01 alloc "
             "gpu:nvidia_h100_80gb_hbm3_3g.40gb:4(S:0-3),"
@@ -241,11 +245,11 @@ class TestParseSinfoNodes:
             "gpu:nvidia_h100_80gb_hbm3_1g.10gb:8(S:0-3)\n"
         )
         result = parse_sinfo_nodes(output)
-        assert list(result.keys()) == ["H100"]
+        assert list(result.keys()) == ["H100-1g.10gb", "H100-2g.20gb", "H100-3g.40gb"]
 
     def test_mixed_regular_and_mig_nodes(self):
-        # Mix of regular H100 nodes and MIG nodes (rorqual-like)
-        # Regular node: 4 GPUs; MIG node: 4 physical GPUs
+        # Mix of regular H100 nodes and MIG nodes (rorqual-like): the regular
+        # node counts as "H100", MIG slices count as their own profile types.
         output = (
             "rg00 idle gpu:h100:4(S:0-3)\n"
             "rg01 idle "
@@ -254,7 +258,12 @@ class TestParseSinfoNodes:
             "gpu:nvidia_h100_80gb_hbm3_1g.10gb:8(S:0-3)\n"
         )
         result = parse_sinfo_nodes(output)
-        assert result == {"H100": (8, 8)}  # 4 + 4
+        assert result == {
+            "H100": (4, 4),
+            "H100-1g.10gb": (8, 8),
+            "H100-2g.20gb": (4, 4),
+            "H100-3g.40gb": (4, 4),
+        }
 
     def test_deduplication_via_sort_u(self):
         # Same node appearing multiple times (once per Slurm partition) should

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -408,16 +408,10 @@ class TestParseDiskusageReport:
 
 
 class TestParseTime:
-    @pytest.mark.parametrize(
-        ("input", "expected"),
-        [
-            ("12:28:45", timedelta(hours=12, minutes=28, seconds=45)),
-            ("07-12:28:45", timedelta(days=7, hours=12, minutes=28, seconds=45)),
-            ("07-12", timedelta(days=7, hours=12)),
-            ("07-12:28", timedelta(days=7, hours=12, minutes=28)),
-            ("28:12", timedelta(minutes=28, seconds=12)),
-            ("28", timedelta(minutes=28)),
-        ],
-    )
-    def test_parse_slurm_time(self, input: str, expected: timedelta) -> None:
-        assert parse_slurm_time(input) == expected
+    def test_parse_slurm_time(self) -> None:
+        td = parse_slurm_time("12:28:45")
+        assert td == timedelta(hours=12, minutes=28, seconds=45)
+
+    def test_parse_slurm_time_with_day(self) -> None:
+        td = parse_slurm_time("07-12:28:45")
+        assert td == timedelta(days=7, hours=12, minutes=28, seconds=45)


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Merge the "GPU model" and "Free GPUs" columns in "Available GPUs (by type)" and show the number of GPUs available for each type.
* Show [MIG GPUs](https://docs.alliancecan.ca/wiki/Multi-Instance_GPU) as a type instead of trying to regroup the instances by physical GPU.
* Show `N/A` instead of bar with 0 GPU for clusters with no GPUs (like trillium).

### Example
<img width="1379" height="770" alt="Capture d’écran, le 2026-08-05 à 11 46 51" src="https://github.com/user-attachments/assets/4aa0e928-91ed-4c5f-bd71-c289a5ae9a4d" />

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/