### PR TITLE
Add documentation on job scripts used by `cluv submit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cluv submit mila job.sh
 
 ## Documentation
 
-* Cluv is documented at https://mila-iqia.github.io/cluv/.
+* **Full documentation** : See https://mila-iqia.github.io/cluv/.
 * **Command line help** : Use `cluv --help` or `cluv <command> --help`.
 * **Examples** : See the [examples](examples) folder for sample projects using cluv. Each example includes a README with instructions specific to that project.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # cluv
 
-cluv — sync UV-based Python projects across HPC clusters.
-
-## Status
-
-In early development. Commands are functional, but expect bugs or missing features.
+cluv — sync and submit UV-based Python projects across HPC clusters.
 
 ## Requirements
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -151,7 +151,7 @@ Enforces a clean git working tree, syncs the project to the target cluster (equi
 [`cluv sync`](#cluv-sync)), then runs `sbatch` on the remote, merging the global and per-cluster
 arguments from the config with the args from the command line.
 
-See the ["Configuring job submission"](guides/submit-config.md) guide for more information.
+See the ["Configuring job submission"](guides/submit/config.md) guide for more information.
 
 **Usage**
 ```console

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,7 +47,8 @@ Available for all commands.
 
 
 `-v`, `--verbose`
-:   Increase logging verbosity. Can be repeated: `-v` shows info-level logs, `-vv` (or more) shows debug-level logs. Defaults to warning-level logs only.
+:   Increase logging verbosity. Can be repeated: `-v` shows info-level logs, `-vv` (or more)
+    shows debug-level logs. Defaults to warning-level logs only.
 
 `-q`, `--quiet`
 :   Disable command output. Has no effect on `cluv status`.
@@ -61,13 +62,16 @@ Initialize a cluv project.
 
 If the project already have a `pyproject.toml` file, it will add a `[tool.cluv]` section to the file.
 
-If the project does not have a `pyproject.toml` file, it will create one with a `[tool.cluv]` section.
+If the project does not have a `pyproject.toml` file, it will create one with [`uv init`](https://docs.astral.sh/uv/reference/cli/#uv-init)
+and add a `[tool.cluv]` section.
 
-Default project structure after `cluv init`:
+Also tries to add a `scripts/` directory with template job scripts and a `logs/` symlink to `$SCRATCH/logs/<project_name>`.
+
+Default project structure after [`cluv init`](#cluv-init) (if the project didn't already exist):
 ```
 my_project/
 ├── README.md
-├── logs -> $SCRATCH/logs/my_project   # symlink to $SCRATCH
+├── logs -> $SCRATCH/logs/<project_name>   # symlink to cluster logs at `results_path`
 ├── pyproject.toml        # includes [tool.cluv] config
 ├── scripts/
 │   ├── job.sh            # Slurm job script template
@@ -144,7 +148,8 @@ cluv sync [clusters] [--sync-datasets | --no-sync-datasets]
 Submit a Slurm job on a remote cluster.
 
 Enforces a clean git working tree, syncs the project to the target cluster (equivalent to running
-[`cluv sync`](#cluv-sync)), then runs `sbatch` on the remote, merging the global and per-cluster arguments from the config with the args from the command line.
+[`cluv sync`](#cluv-sync)), then runs `sbatch` on the remote, merging the global and per-cluster
+arguments from the config with the args from the command line.
 
 See the ["Configuring job submission"](guides/submit-config.md) guide for more information.
 
@@ -193,7 +198,8 @@ cluv clean [clusters] [-f | --force] [--dry-run]
 **Arguments**
 
 `clusters`
-:   One or more cluster hostnames to clean. If omitted, cleans every cluster you currently have an active SSH connection to and that has been synced before.
+:   One or more cluster hostnames to clean. If omitted, cleans every cluster you currently have an
+    active SSH connection to and that has been synced before.
 
 **Options**
 
@@ -212,10 +218,11 @@ Show the status of clusters and jobs.
 The `clusters` table shows each cluster's live GPU availability and storage usage, along with
 counts of your running/pending/failed/completed cluv jobs on that cluster.
 
-The `jobs` table shows jobs submitted with `cluv submit` (from the local job cache), enriched with live Slurm
-status, wait time, and elapsed time.
+The `jobs` table shows jobs submitted with [`cluv submit`](#cluv-submit) (from the local job cache),
+enriched with live Slurm status, wait time, and elapsed time.
 
-Requires an active connection (see [`cluv login`](#cluv-login)) to fetch live data for a cluster; otherwise it is shown as disconnected.
+Requires an active connection (see [`cluv login`](#cluv-login)) to fetch live data for a cluster;
+otherwise it is shown as disconnected.
 
 **Usage**
 ```console

--- a/docs/guides/submit/config.md
+++ b/docs/guides/submit/config.md
@@ -2,6 +2,7 @@
 
 [`cluv submit`](../commands.md#cluv-submit) reads your `pyproject.toml` to build the final `sbatch` command.
 This guide explains which config fields are used, how global and per-cluster values are merged, and what is injected automatically.
+For what your job script itself should look like, see ["Writing a job script"](job-scripts.md).
 
 ## Config fields used by `cluv submit`
 

--- a/docs/guides/submit/config.md
+++ b/docs/guides/submit/config.md
@@ -1,8 +1,7 @@
 # Configuring job submission
 
-[`cluv submit`](../commands.md#cluv-submit) reads your `pyproject.toml` to build the final `sbatch` command.
+[`cluv submit`](../../commands.md#cluv-submit) reads your `pyproject.toml` to build the final `sbatch` command.
 This guide explains which config fields are used, how global and per-cluster values are merged, and what is injected automatically.
-For what your job script itself should look like, see ["Writing a job script"](job-scripts.md).
 
 ## Config fields used by `cluv submit`
 
@@ -104,5 +103,6 @@ cluv submit narval              # uses scripts/job_narval.sh
 cluv submit narval new_job.sh   # uses new_job.sh, ignoring config
 ```
 
-If neither a CLI script nor a configured `job_script_path` exists for the target cluster, `cluv
-submit` exits with an error.
+If neither a CLI script nor a configured `job_script_path` exists for the target cluster, [`cluv
+submit`](../../commands.md) exits with an error. See the page ["Writing a job script"](job-scripts.md) for what the
+script should contain.

--- a/docs/guides/submit/job-scripts.md
+++ b/docs/guides/submit/job-scripts.md
@@ -1,0 +1,60 @@
+# Writing a job script
+
+[`cluv submit`](../commands.md#cluv-submit) doesn't have a special format for job scripts: it's a
+plain `sbatch` script, with a few conventions that let `cluv` fill in cluster-specific details.
+
+## The basics
+
+A job script is a normal bash script with `#SBATCH` directives, submitted with `sbatch`:
+
+```bash title="scripts/job.sh"
+--8<-- "scripts/job.sh"
+```
+
+`cluv` invokes it roughly as:
+
+```console
+sbatch --chdir=<remote_project_dir> [sbatch-args] <job_script> [program_args...]
+```
+
+- The script runs with its working directory set to the project root on the target cluster
+  (`--chdir`), so relative paths inside the script resolve from there.
+- Anything passed after `--` on the `cluv submit` command line is forwarded as positional
+  arguments (`$@`) to the script. The script above just forwards them to `uv run`, so
+  `cluv submit mila scripts/job.sh -- python main.py --lr 0.01` runs
+  `uv run python main.py --lr 0.01` on the cluster.
+
+## Where the script needs to exist
+
+The path you pass to `cluv submit` (or configure via `job_script_path`) must exist **locally**,
+relative to the project root — `cluv` reads it locally to check for a conflicting `--output`
+directive (see below) before submitting. The remote `sbatch` call then references the same
+relative path under the project's remote directory, so the script must also be present there,
+which `cluv sync` takes care of as part of `cluv submit`.
+
+## Guarding against the project changing under a queued job
+
+The simple script above runs directly out of the synced project directory. That's fine for
+short, immediate jobs, but if the job sits in the Slurm queue for a while, a later `cluv sync` (or
+another `cluv submit`) could change the checked-out commit before the job actually starts
+running.
+
+The safer pattern is to clone the project into `$SLURM_TMPDIR` and explicitly check out
+`$GIT_COMMIT`, so the job always runs the exact commit it was submitted with, independent of
+what's currently synced in the project root:
+
+```bash title="scripts/safe_job.sh"
+--8<-- "scripts/safe_job.sh"
+```
+
+This variant also copies any existing results for `$SLURM_JOB_ID` into `$SLURM_TMPDIR` before
+running (in case of requeue) and rsyncs them back to `results_path` afterwards, matching the
+`{results_path}/{cluster}_%j/` layout that `SBATCH_OUTPUT` uses.
+
+## Summary
+
+- It's a regular `sbatch` script — no special cluv syntax.
+- Forward `"$@"` to your program so arguments after `--` reach it.
+- Don't set `#SBATCH --output`; `cluv` manages it via `results_path`.
+- Use `$GIT_COMMIT` if you want the job to check out a specific commit, which matters most for
+  jobs that might spend a while queued.

--- a/docs/guides/submit/job-scripts.md
+++ b/docs/guides/submit/job-scripts.md
@@ -1,43 +1,51 @@
 # Writing a job script
 
-[`cluv submit`](../commands.md#cluv-submit) doesn't have a special format for job scripts: it's a
-plain `sbatch` script, with a few conventions that let `cluv` fill in cluster-specific details.
+[`cluv submit`](../../commands.md#cluv-submit) doesn't have a special format for job scripts:
+it's a plain bash script, with `#SBATCH` directives, submitted as-is via
+[`sbatch`](https://slurm.schedmd.com/sbatch.html). `cluv` just adds a few conventions on top so it
+can fill in cluster-specific details.
 
-## The basics
+## Job script conventions
 
-A job script is a normal bash script with `#SBATCH` directives, submitted with `sbatch`:
-
-```bash title="scripts/job.sh"
---8<-- "scripts/job.sh"
-```
-
-`cluv` invokes it roughly as:
+On the remote cluster, [`cluv submit`](../../commands.md#cluv-submit) invokes the job script roughly
+as:
 
 ```console
 sbatch --chdir=<remote_project_dir> [sbatch-args] <job_script> [program_args...]
 ```
 
-- The script runs with its working directory set to the project root on the target cluster
-  (`--chdir`), so relative paths inside the script resolve from there.
-- Anything passed after `--` on the `cluv submit` command line is forwarded as positional
-  arguments (`$@`) to the script. The script above just forwards them to `uv run`, so
-  `cluv submit mila scripts/job.sh -- python main.py --lr 0.01` runs
-  `uv run python main.py --lr 0.01` on the cluster.
+- The script runs with its working directory set to the project root on the target cluster (`--chdir`),
+so relative paths inside the script resolve from there.
 
-## Where the script needs to exist
+- Anything passed after `--` on the `cluv submit` command line is forwarded as positional arguments
+(`$@`) to the script, which  just forwards them to `uv run`.
 
-The path you pass to `cluv submit` (or configure via `job_script_path`) must exist **locally**,
-relative to the project root — `cluv` reads it locally to check for a conflicting `--output`
-directive (see below) before submitting. The remote `sbatch` call then references the same
-relative path under the project's remote directory, so the script must also be present there,
-which `cluv sync` takes care of as part of `cluv submit`.
+`cluv submit mila scripts/job.sh -- python main.py --lr 0.01` runs `uv run python main.py --lr 0.01`
+on the cluster. In case of a custom job script, make sure to forward the arguments to your
+program, e.g. `"$@"` in bash.
 
-## Guarding against the project changing under a queued job
+
+## Cluv job scripts
+By default, the [`cluv init`](../../commands.md/#cluv-init) command tries to create two job scripts
+in the `scripts` folder: [`job.sh`](#jobsh) and [`safe_job.sh`](#safe_jobsh).
+
+### `job.sh`
+
+The simplest possible job script where it just forwards its arguments to `uv run`. It's the default
+value for `job_script_path` in your config (see ["Configuring job submission"](config.md#default-job-script)
+page), when no script is used in the CLI.
+
+```bash title="scripts/job.sh"
+--8<-- "scripts/job.sh"
+```
+
+### `safe_job.sh`
+Guarding against the project changing under a queued job.
 
 The simple script above runs directly out of the synced project directory. That's fine for
-short, immediate jobs, but if the job sits in the Slurm queue for a while, a later `cluv sync` (or
-another `cluv submit`) could change the checked-out commit before the job actually starts
-running.
+short, immediate jobs, but if the job sits in the Slurm queue for a while, a later [`cluv sync`](../../commands.md/#cluv-sync)
+(or another [`cluv submit`](../../commands.md#cluv-submit)) could change the checked-out commit
+before the job actually starts running.
 
 The safer pattern is to clone the project into `$SLURM_TMPDIR` and explicitly check out
 `$GIT_COMMIT`, so the job always runs the exact commit it was submitted with, independent of
@@ -50,11 +58,3 @@ what's currently synced in the project root:
 This variant also copies any existing results for `$SLURM_JOB_ID` into `$SLURM_TMPDIR` before
 running (in case of requeue) and rsyncs them back to `results_path` afterwards, matching the
 `{results_path}/{cluster}_%j/` layout that `SBATCH_OUTPUT` uses.
-
-## Summary
-
-- It's a regular `sbatch` script — no special cluv syntax.
-- Forward `"$@"` to your program so arguments after `--` reach it.
-- Don't set `#SBATCH --output`; `cluv` manages it via `results_path`.
-- Use `$GIT_COMMIT` if you want the job to check out a specific commit, which matters most for
-  jobs that might spend a while queued.

--- a/docs/hydra-launcher.md
+++ b/docs/hydra-launcher.md
@@ -1,16 +1,17 @@
 # Using Cluv with Hydra
 
 The Cluv Hydra Launcher lets you run [Hydra](https://hydra.cc/) multi-run sweeps directly on
-remote Slurm clusters, using the same `pyproject.toml`-based config that drives `cluv submit`.
+remote Slurm clusters, using the same `pyproject.toml`-based config that drives
+[`cluv submit`](commands.md/#cluv-submit).
 
 It is a drop-in replacement for the
-[Submitit launcher plugin](https://hydra.cc/docs/plugins/submitit_launcher/) — the same
-`gpus_per_node`, `cpus_per_task`, `mem_gb`, `timeout_min`, etc. parameters all work as-is.
+[Submitit launcher plugin](https://hydra.cc/docs/plugins/submitit_launcher/) (the same
+`gpus_per_node`, `cpus_per_task`, `mem_gb`, `timeout_min`, etc. parameters all work as-is).
 
 What it adds on top of Submitit:
 
 - **Allows using _remote_ clusters**: Cluv allows you to launch jobs on the current cluster as well as remote clusters.
-- **Automatic sync**: the project is synced to the target cluster before submission (via `cluv sync`).
+- **Automatic sync**: the project is synced to the target cluster before submission (via [`cluv sync`](commands.md/#cluv-sync)).
 - **Automatic result fetch**: results are rsynced back locally once jobs finish.
 - **Cluster selection**: set `cluster: mila` (or any cluster in your config) to pick the target. Default is 'first' to use the first cluster that runs the job.
 <div class="annotate" markdown>
@@ -32,7 +33,7 @@ uv add cluster-uv[hydra]
 ## Configure your project
 
 Your `pyproject.toml` needs a `[tool.cluv]` section with at least a `results_path` and
-the clusters you want to target. A minimal setup can be obtained by running `cluv init`.
+the clusters you want to target. A minimal setup can be obtained by running [`cluv init`](commands.md/#cluv-init).
 
 Take a look at the pyproject.toml file of this example:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,8 @@
 # cluv
 
-This is a quick overview. For more information, check out the [introduction](guides/introduction.md).
+A powerful and lightweight CLI tool to sync and submit UV-based Python projects across HPC clusters.
 
+This is a quick overview. For more information, check out the [introduction](guides/introduction.md).
 
 ## Installation
 
@@ -23,6 +24,13 @@ If you want the bleeding edge version from GitHub, use:
 
 ```console
 uv add git+https://github.com/mila-iqia/cluv
+```
+
+### Update
+Run this once in a while to get the latest features and bugfixes.
+
+```console
+uv tool update cluster-uv
 ```
 
 ## Usage
@@ -82,8 +90,8 @@ See the ["Cleaning runs"](guides/cleaning-runs.md) guide for details on how this
 cluv submit rorqual scripts/job.sh --time=00:10:00 -- python main.py
 ```
 
-See the ["Writing a job script"](guides/job-scripts.md) guide for what `job.sh` should contain, and
-["Configuring job submission"](guides/submit-config.md) for how to use the config to submit jobs.
+See the ["Writing a job script"](guides/submit/job-scripts.md) guide for what `job.sh` should contain, and
+["Configuring job submission"](guides/submit/config.md) for how to use the config to submit jobs.
 
 ### Run a command in the synced project a specific cluster
 ```console

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,9 @@ This is a quick overview. For more information, check out the [introduction](gui
 
 ## Installation
 
-Add the package to your project with `uv add` or `pip install`:
+Cluv can be installed on a local machine or on a remote cluster.
+
+Add the package to your project with `uv add`:
 
 ```console
 uv add cluster-uv
@@ -80,7 +82,8 @@ See the ["Cleaning runs"](guides/cleaning-runs.md) guide for details on how this
 cluv submit rorqual scripts/job.sh --time=00:10:00 -- python main.py
 ```
 
-See the ["Configuring job submission"](guides/submit-config.md) guide for details on how to use the config to submit jobs.
+See the ["Writing a job script"](guides/job-scripts.md) guide for what `job.sh` should contain, and
+["Configuring job submission"](guides/submit-config.md) for how to use the config to submit jobs.
 
 ### Run a command in the synced project a specific cluster
 ```console

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -11,7 +11,9 @@ nav:
   - Guides:
       - Introduction: guides/introduction.md
       - Syncing datasets: guides/syncing-datasets.md
-      - Configuring job submission: guides/submit-config.md
+      - Configuring job submission:
+        - Using the config: guides/submit/config.md
+        - Writing a job script: guides/submit/job-scripts.md
       - Cleaning runs: guides/cleaning-runs.md
   - Reference:
       - CLI:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -11,8 +11,8 @@ nav:
   - Guides:
       - Introduction: guides/introduction.md
       - Syncing datasets: guides/syncing-datasets.md
-      - Configuring job submission:
-        - Using the config: guides/submit/config.md
+      - Submitting jobs:
+        - Configuring job submission: guides/submit/config.md
         - Writing a job script: guides/submit/job-scripts.md
       - Cleaning runs: guides/cleaning-runs.md
   - Reference:
@@ -46,11 +46,13 @@ theme:
     - navigation.expand
     - content.code.copy
     - content.code.annotate
-    - navigation.sections
+    - navigation.expand
+    - navigation.footer
     - navigation.path
+    - navigation.sections
+    - search.highlight
     - search.share
     - search.suggest
-    - search.highlight
   icon:
     repo: fontawesome/brands/github
 markdown_extensions:

--- a/scripts/job.sh
+++ b/scripts/job.sh
@@ -3,6 +3,7 @@
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=4G
 #SBATCH --time=0:05:00
+
 # Run the job command passed as an argument when submitting the job ('python main.py' for example)
 echo "Running command: $@"
 srun uv run "$@"

--- a/scripts/safe_job.sh
+++ b/scripts/safe_job.sh
@@ -8,7 +8,6 @@ project_name="cluv"  # to be replaced with the user's project name.
 project_root="$HOME/repos/$project_name" # to be replaced with the path to the user's project in their $HOME.
 results_path="logs" # to be replaced with the path to the results path name. (--output flag above too)
 
-
 echo "GIT_COMMIT=${GIT_COMMIT:?GIT_COMMIT is not set. Use 'cluv submit' to submit this job script.}"
 # Setup the repo in $SLURM_TMPDIR, so the code can change in the project without affecting the job.
 project_root_in_tmpdir="$SLURM_TMPDIR/$project_name"


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Add `Writing a job script` user guide.
* Regroup `Writing a job script` and `Configuring job submission` user guides under the section `Submitting jobs`.
* Add missing links to commands.
* Update `README.md`.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/