### PR TITLE
Don't sync twice with clusters sharing a filesystem

### DIFF
--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -104,9 +104,23 @@ async def sync(
     # TODO: Add an --ignore flag to ignore some clusters?
     console.log(f"[green]Synchronizing with the following clusters:[/green] {clusters}")
 
+    # A cluster that shares a filesystem with another one already being synced (see
+    # `CLUSTERS_SHARING_A_FILESYSTEM`) is the exact same on-disk checkout, so syncing it a second
+    # time would be redundant, and unsafe to do concurrently. It's still kept in `remotes` (the
+    # return value of this function), since it can be a genuinely different Slurm cluster to
+    # submit jobs to (e.g. `trillium`/`trillium-gpu` are the CPU and GPU partitions of the same
+    # cluster) -- only the sync step itself is skipped for it.
+    remotes_to_sync = _remotes_to_actually_sync(remotes)
+    skipped = [r.hostname for r in remotes if r not in remotes_to_sync]
+    if skipped:
+        console.log(
+            f"[yellow]Not syncing separately with {skipped}: shares a filesystem with a cluster "
+            "already being synced.[/yellow]"
+        )
+
     tasks: list[AsyncTaskFn] = []
     task_descriptions: list[str] = []
-    for remote in remotes:
+    for remote in remotes_to_sync:
         tasks.append(functools.partial(sync_task_function, remote=remote))
         task_descriptions.append(f"{here or 'local'} -> {remote.hostname}")
 
@@ -145,7 +159,7 @@ async def sync(
 
     # Display a consolidated summary of all newly-synced runs across all clusters.
     cwd = Path.cwd()
-    for remote, new_runs in zip(remotes, per_cluster_new_runs):
+    for remote, new_runs in zip(remotes_to_sync, per_cluster_new_runs):
         if new_runs:
             console.print(f"[green]Newly synced runs from [bold]{remote.hostname}[/bold]:[/green]")
             for run_path in sorted(new_runs):
@@ -158,10 +172,41 @@ async def sync(
     return remotes
 
 
+# Groups of cluster hostnames that are actually distinct login nodes of the same physical
+# cluster, sharing a single filesystem (confirmed live via SSH: `trillium` and `trillium-gpu`
+# mount the identical NFS export at $HOME). Syncing with more than one cluster in the same group
+# at a time is pointless (it's the same on-disk checkout) and unsafe (concurrent `git`/`uv sync`
+# commands from two hosts race on that shared checkout).
+CLUSTERS_SHARING_A_FILESYSTEM: list[frozenset[str]] = [
+    frozenset({"trillium", "trillium-gpu"}),
+]
+
+
+def _remotes_to_actually_sync(remotes: list[Remote]) -> list[Remote]:
+    """Drops remotes that are just another login node for one already in the list.
+
+    See `CLUSTERS_SHARING_A_FILESYSTEM`. Keeps the first remote seen from each group and
+    preserves the order of `remotes` otherwise.
+    """
+    seen_groups: set[frozenset[str]] = set()
+    to_sync: list[Remote] = []
+    for remote in remotes:
+        group = next((g for g in CLUSTERS_SHARING_A_FILESYSTEM if remote.hostname in g), None)
+        if group is not None:
+            if group in seen_groups:
+                continue
+            seen_groups.add(group)
+        to_sync.append(remote)
+    return to_sync
+
+
 async def get_active_remotes() -> list[Remote]:
     """Returns the Remotes for each cluster which has an active SSH connection.
 
-    Disabled clusters (see `cluv disable`) are excluded.
+    Disabled clusters (see `cluv disable`) are excluded. Note that this can include more than one
+    cluster from the same `CLUSTERS_SHARING_A_FILESYSTEM` group (e.g. both `trillium` and
+    `trillium-gpu`): they're genuinely different Slurm clusters to submit jobs to, even though
+    `sync()` only syncs the underlying (shared) checkout once.
     """
     clusters = get_cluv_config().clusters_names
     if (this_cluster := current_cluster()) and this_cluster in clusters:

--- a/cluv/cli/sync.py
+++ b/cluv/cli/sync.py
@@ -104,25 +104,7 @@ async def sync(
     # TODO: Add an --ignore flag to ignore some clusters?
     console.log(f"[green]Synchronizing with the following clusters:[/green] {clusters}")
 
-    # A cluster that shares a filesystem with another one already being synced (see
-    # `CLUSTERS_SHARING_A_FILESYSTEM`) is the exact same on-disk checkout, so syncing it a second
-    # time would be redundant, and unsafe to do concurrently. It's still kept in `remotes` (the
-    # return value of this function), since it can be a genuinely different Slurm cluster to
-    # submit jobs to (e.g. `trillium`/`trillium-gpu` are the CPU and GPU partitions of the same
-    # cluster) -- only the sync step itself is skipped for it.
-    remotes_to_sync = _remotes_to_actually_sync(remotes)
-    skipped = [r.hostname for r in remotes if r not in remotes_to_sync]
-    if skipped:
-        console.log(
-            f"[yellow]Not syncing separately with {skipped}: shares a filesystem with a cluster "
-            "already being synced.[/yellow]"
-        )
-
-    tasks: list[AsyncTaskFn] = []
-    task_descriptions: list[str] = []
-    for remote in remotes_to_sync:
-        tasks.append(functools.partial(sync_task_function, remote=remote))
-        task_descriptions.append(f"{here or 'local'} -> {remote.hostname}")
+    remotes_to_sync, tasks, task_descriptions = _build_sync_tasks(remotes, here)
 
     token = console_lock.set(asyncio.Lock())
     if (
@@ -198,6 +180,29 @@ def _remotes_to_actually_sync(remotes: list[Remote]) -> list[Remote]:
             seen_groups.add(group)
         to_sync.append(remote)
     return to_sync
+
+
+def _build_sync_tasks(
+    remotes: list[Remote], here: str | None
+) -> tuple[list[Remote], list[AsyncTaskFn], list[str]]:
+    """Builds one sync task per remote, skipping those that just share a filesystem with a
+    remote already in the list (see `_remotes_to_actually_sync`) -- redundant, and unsafe to run
+    concurrently. `remotes` itself is left for the caller to return unfiltered: a skipped remote
+    can still be a genuinely different Slurm cluster to submit jobs to (e.g.
+    `trillium`/`trillium-gpu`).
+
+    Returns `(remotes_to_sync, tasks, task_descriptions)`.
+    """
+    remotes_to_sync = _remotes_to_actually_sync(remotes)
+    skipped = [r.hostname for r in remotes if r not in remotes_to_sync]
+    if skipped:
+        console.log(
+            f"[yellow]Not syncing separately with {skipped}: shares a filesystem with a cluster "
+            "already being synced.[/yellow]"
+        )
+    tasks = [functools.partial(sync_task_function, remote=remote) for remote in remotes_to_sync]
+    task_descriptions = [f"{here or 'local'} -> {remote.hostname}" for remote in remotes_to_sync]
+    return remotes_to_sync, tasks, task_descriptions
 
 
 async def get_active_remotes() -> list[Remote]:

--- a/tests/test_sync_shared_filesystem.py
+++ b/tests/test_sync_shared_filesystem.py
@@ -7,11 +7,11 @@ jobs through `trillium`. So:
 
 - `get_active_remotes()` must still return a `Remote` for *each* of them.
 - `sync()` must still return a `Remote` for each of them (so job submission can target either).
-- But `sync()` must only actually run the sync steps (git clone/checkout, `uv sync`, fetching
-  results) once for the pair, since it's the exact same on-disk checkout -- running it twice is
-  redundant, and running it concurrently is unsafe (this is what made
-  `checkout -B <branch> FETCH_HEAD` fail intermittently in the `cluster=first` hydra launcher
-  integration test).
+- But `_build_sync_tasks()` -- the piece of `sync()` that decides what actually gets synced --
+  must only build one task per shared-filesystem group, since it's the exact same on-disk
+  checkout -- running it twice is redundant, and running it concurrently is unsafe (this is what
+  made `checkout -B <branch> FETCH_HEAD` fail intermittently in the `cluster=first` hydra
+  launcher integration test).
 """
 
 from __future__ import annotations
@@ -27,20 +27,6 @@ from cluv.remote import Remote
 sync_module = importlib.import_module("cluv.cli.sync")
 
 
-@pytest.fixture
-def fake_cache_dir(tmp_path, monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
-    cache_dir = tmp_path / "cache"
-    cache_dir.mkdir()
-    import cluv.cache
-
-    monkeypatch.setattr(
-        cluv.cache,
-        cluv.cache._get_cache_dir.__name__,
-        mock_get_cache_dir := mock.Mock(cluv.cache._get_cache_dir, return_value=cache_dir),
-    )
-    return mock_get_cache_dir
-
-
 @pytest.mark.parametrize(
     ("hostnames", "expected"),
     [
@@ -54,6 +40,23 @@ def test_remotes_to_actually_sync_keeps_only_the_first_per_group(hostnames, expe
     remotes = [Remote(hostname=h) for h in hostnames]
     result = sync_module._remotes_to_actually_sync(remotes)
     assert [r.hostname for r in result] == expected
+
+
+def test_build_sync_tasks_skips_remotes_sharing_a_filesystem():
+    """One task per remote, except `trillium-gpu` shares a filesystem with `trillium` -- and thus
+    gets no task of its own -- while unrelated clusters are untouched.
+    """
+    remotes = [
+        Remote(hostname="trillium"),
+        Remote(hostname="trillium-gpu"),
+        Remote(hostname="narval"),
+    ]
+
+    remotes_to_sync, tasks, task_descriptions = sync_module._build_sync_tasks(remotes, here=None)
+
+    assert [r.hostname for r in remotes_to_sync] == ["trillium", "narval"]
+    assert [task.keywords["remote"].hostname for task in tasks] == ["trillium", "narval"]
+    assert task_descriptions == ["local -> trillium", "local -> narval"]
 
 
 async def test_get_active_remotes_returns_every_active_cluster(monkeypatch: pytest.MonkeyPatch):
@@ -109,10 +112,15 @@ async def test_get_active_remotes_returns_every_active_cluster(monkeypatch: pyte
     mock_get_remote.assert_any_await("narval")
 
 
-async def test_sync_only_syncs_once_but_returns_every_remote(
-    fake_cache_dir: mock.Mock, monkeypatch: pytest.MonkeyPatch
-):
-    """`sync(["trillium", "trillium-gpu"])` must run the sync steps only once, but return both."""
+async def test_sync_only_syncs_once_but_returns_every_remote(monkeypatch: pytest.MonkeyPatch):
+    """`sync(["trillium", "trillium-gpu"])` must run the per-remote sync step only once, but
+    return both remotes.
+
+    The dedup logic itself (which remote "wins" a shared-filesystem group) is already covered by
+    `test_build_sync_tasks_skips_remotes_sharing_a_filesystem`, so here we only need to check
+    that `sync()` wires that decision through correctly, by mocking `sync_task_function` as a
+    single unit rather than each of its internal steps.
+    """
     # sync() skips the "is HEAD up to date" check (and thus _head_is_up_to_date) entirely when
     # GITHUB_ACTIONS is set, which it is in CI but not locally. Force it unset so this test
     # exercises the same branch -- and the same mock.assert_awaited_once() below -- everywhere.
@@ -162,52 +170,25 @@ async def test_sync_only_syncs_once_but_returns_every_remote(
         sync_module.get_active_remotes.__name__,
         mock_get_active_remotes := mock.AsyncMock(sync_module.get_active_remotes, return_value=[]),
     )
-
-    sync_calls: list[str] = []
-
-    async def fake_step(remote, *args, **kwargs):
-        sync_calls.append(remote.hostname)
-        return []
-
     monkeypatch.setattr(
         sync_module,
-        sync_module.install_uv.__name__,
-        mock_install_uv := mock.AsyncMock(sync_module.install_uv, side_effect=fake_step),
-    )
-    monkeypatch.setattr(
-        sync_module,
-        sync_module.clone_project.__name__,
-        mock_clone_project := mock.AsyncMock(sync_module.clone_project, side_effect=fake_step),
-    )
-    monkeypatch.setattr(
-        sync_module,
-        sync_module.run_uv_sync.__name__,
-        mock_run_uv_sync := mock.AsyncMock(sync_module.run_uv_sync, side_effect=fake_step),
-    )
-    monkeypatch.setattr(
-        sync_module,
-        sync_module.fetch_results.__name__,
-        mock_fetch_results := mock.AsyncMock(sync_module.fetch_results, side_effect=fake_step),
+        sync_module.sync_task_function.__name__,
+        mock_sync_task_function := mock.AsyncMock(sync_module.sync_task_function, return_value=[]),
     )
 
     remotes = await sync_module.sync(["trillium", "trillium-gpu"], sync_datasets=False)
 
     # Both clusters are returned (they're genuinely different Slurm targets)...
     assert {r.hostname for r in remotes} == {"trillium", "trillium-gpu"}
-    # ...but the sync steps (install_uv, clone_project, run_uv_sync, fetch_results) only ran for
-    # one of them.
-    assert set(sync_calls) == {"trillium"}
-    mock_install_uv.assert_awaited_once()
-    mock_clone_project.assert_awaited_once()
-    mock_run_uv_sync.assert_awaited_once()
-    mock_fetch_results.assert_awaited_once()
+    # ...but the actual sync work only ran once, for the cluster that "wins" the shared group.
+    mock_sync_task_function.assert_awaited_once()
+    assert mock_sync_task_function.await_args.kwargs["remote"].hostname == "trillium"
 
     # And every collaborator mocked to get there was actually exercised -- otherwise mocking it
     # would be pointless.
     mock_get_active_remotes.assert_awaited_once()
     mock_login.assert_awaited_once_with(["trillium", "trillium-gpu"], disabled={})
     mock_head_is_up_to_date.assert_awaited_once()
-    fake_cache_dir.assert_called()
     mock_get_cluv_config.assert_called()
     mock_current_cluster.assert_called_once()
     mock_get_disabled_clusters.assert_called_once()

--- a/tests/test_sync_shared_filesystem.py
+++ b/tests/test_sync_shared_filesystem.py
@@ -113,6 +113,10 @@ async def test_sync_only_syncs_once_but_returns_every_remote(
     fake_cache_dir: mock.Mock, monkeypatch: pytest.MonkeyPatch
 ):
     """`sync(["trillium", "trillium-gpu"])` must run the sync steps only once, but return both."""
+    # sync() skips the "is HEAD up to date" check (and thus _head_is_up_to_date) entirely when
+    # GITHUB_ACTIONS is set, which it is in CI but not locally. Force it unset so this test
+    # exercises the same branch -- and the same mock.assert_awaited_once() below -- everywhere.
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     config = CluvConfig(
         results_path="/results",
         clusters={

--- a/tests/test_sync_shared_filesystem.py
+++ b/tests/test_sync_shared_filesystem.py
@@ -28,13 +28,17 @@ sync_module = importlib.import_module("cluv.cli.sync")
 
 
 @pytest.fixture
-def fake_cache_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
+def fake_cache_dir(tmp_path, monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
     import cluv.cache
 
-    monkeypatch.setattr(cluv.cache, cluv.cache._get_cache_dir.__name__, lambda: cache_dir)
-    return cache_dir
+    monkeypatch.setattr(
+        cluv.cache,
+        cluv.cache._get_cache_dir.__name__,
+        mock_get_cache_dir := mock.Mock(cluv.cache._get_cache_dir, return_value=cache_dir),
+    )
+    return mock_get_cache_dir
 
 
 @pytest.mark.parametrize(
@@ -62,9 +66,23 @@ async def test_get_active_remotes_returns_every_active_cluster(monkeypatch: pyte
             "narval": PartialClusterConfig(),
         },
     )
-    monkeypatch.setattr(sync_module, sync_module.get_cluv_config.__name__, lambda: config)
-    monkeypatch.setattr(sync_module, sync_module.current_cluster.__name__, lambda: None)
-    monkeypatch.setattr(sync_module, sync_module.get_disabled_clusters.__name__, lambda: {})
+    monkeypatch.setattr(
+        sync_module,
+        sync_module.get_cluv_config.__name__,
+        mock_get_cluv_config := mock.Mock(sync_module.get_cluv_config, return_value=config),
+    )
+    monkeypatch.setattr(
+        sync_module,
+        sync_module.current_cluster.__name__,
+        mock_current_cluster := mock.Mock(sync_module.current_cluster, return_value=None),
+    )
+    monkeypatch.setattr(
+        sync_module,
+        sync_module.get_disabled_clusters.__name__,
+        mock_get_disabled_clusters := mock.Mock(
+            sync_module.get_disabled_clusters, return_value={}
+        ),
+    )
 
     async def fake_get_remote_without_2fa_prompt(hostname: str) -> Remote:
         return Remote(hostname=hostname)
@@ -72,16 +90,27 @@ async def test_get_active_remotes_returns_every_active_cluster(monkeypatch: pyte
     monkeypatch.setattr(
         sync_module,
         sync_module.get_remote_without_2fa_prompt.__name__,
-        fake_get_remote_without_2fa_prompt,
+        mock_get_remote := mock.AsyncMock(
+            sync_module.get_remote_without_2fa_prompt,
+            side_effect=fake_get_remote_without_2fa_prompt,
+        ),
     )
 
     remotes = await sync_module.get_active_remotes()
 
     assert {r.hostname for r in remotes} == {"trillium", "trillium-gpu", "narval"}
+    # Every collaborator was actually consulted -- otherwise mocking it would be pointless.
+    mock_get_cluv_config.assert_called_once()
+    mock_current_cluster.assert_called_once()
+    mock_get_disabled_clusters.assert_called_once()
+    assert mock_get_remote.await_count == 3
+    mock_get_remote.assert_any_await("trillium")
+    mock_get_remote.assert_any_await("trillium-gpu")
+    mock_get_remote.assert_any_await("narval")
 
 
 async def test_sync_only_syncs_once_but_returns_every_remote(
-    fake_cache_dir, monkeypatch: pytest.MonkeyPatch
+    fake_cache_dir: mock.Mock, monkeypatch: pytest.MonkeyPatch
 ):
     """`sync(["trillium", "trillium-gpu"])` must run the sync steps only once, but return both."""
     config = CluvConfig(
@@ -91,19 +120,43 @@ async def test_sync_only_syncs_once_but_returns_every_remote(
             "trillium-gpu": PartialClusterConfig(),
         },
     )
-    monkeypatch.setattr(sync_module, sync_module.get_cluv_config.__name__, lambda: config)
-    monkeypatch.setattr(sync_module, sync_module.current_cluster.__name__, lambda: None)
-    monkeypatch.setattr(sync_module, sync_module.get_disabled_clusters.__name__, lambda: {})
     monkeypatch.setattr(
-        sync_module, sync_module._head_is_up_to_date.__name__, mock.AsyncMock(return_value=True)
+        sync_module,
+        sync_module.get_cluv_config.__name__,
+        mock_get_cluv_config := mock.Mock(sync_module.get_cluv_config, return_value=config),
+    )
+    monkeypatch.setattr(
+        sync_module,
+        sync_module.current_cluster.__name__,
+        mock_current_cluster := mock.Mock(sync_module.current_cluster, return_value=None),
+    )
+    monkeypatch.setattr(
+        sync_module,
+        sync_module.get_disabled_clusters.__name__,
+        mock_get_disabled_clusters := mock.Mock(
+            sync_module.get_disabled_clusters, return_value={}
+        ),
+    )
+    monkeypatch.setattr(
+        sync_module,
+        sync_module._head_is_up_to_date.__name__,
+        mock_head_is_up_to_date := mock.AsyncMock(
+            sync_module._head_is_up_to_date, return_value=True
+        ),
     )
 
     async def fake_login(clusters: list[str], disabled=None) -> list[Remote]:
         return [Remote(hostname=c) for c in clusters]
 
-    monkeypatch.setattr(sync_module, sync_module.login.__name__, fake_login)
     monkeypatch.setattr(
-        sync_module, sync_module.get_active_remotes.__name__, mock.AsyncMock(return_value=[])
+        sync_module,
+        sync_module.login.__name__,
+        mock_login := mock.AsyncMock(sync_module.login, side_effect=fake_login),
+    )
+    monkeypatch.setattr(
+        sync_module,
+        sync_module.get_active_remotes.__name__,
+        mock_get_active_remotes := mock.AsyncMock(sync_module.get_active_remotes, return_value=[]),
     )
 
     sync_calls: list[str] = []
@@ -112,10 +165,26 @@ async def test_sync_only_syncs_once_but_returns_every_remote(
         sync_calls.append(remote.hostname)
         return []
 
-    monkeypatch.setattr(sync_module, sync_module.install_uv.__name__, fake_step)
-    monkeypatch.setattr(sync_module, sync_module.clone_project.__name__, fake_step)
-    monkeypatch.setattr(sync_module, sync_module.run_uv_sync.__name__, fake_step)
-    monkeypatch.setattr(sync_module, "fetch_results", fake_step)
+    monkeypatch.setattr(
+        sync_module,
+        sync_module.install_uv.__name__,
+        mock_install_uv := mock.AsyncMock(sync_module.install_uv, side_effect=fake_step),
+    )
+    monkeypatch.setattr(
+        sync_module,
+        sync_module.clone_project.__name__,
+        mock_clone_project := mock.AsyncMock(sync_module.clone_project, side_effect=fake_step),
+    )
+    monkeypatch.setattr(
+        sync_module,
+        sync_module.run_uv_sync.__name__,
+        mock_run_uv_sync := mock.AsyncMock(sync_module.run_uv_sync, side_effect=fake_step),
+    )
+    monkeypatch.setattr(
+        sync_module,
+        sync_module.fetch_results.__name__,
+        mock_fetch_results := mock.AsyncMock(sync_module.fetch_results, side_effect=fake_step),
+    )
 
     remotes = await sync_module.sync(["trillium", "trillium-gpu"], sync_datasets=False)
 
@@ -124,3 +193,17 @@ async def test_sync_only_syncs_once_but_returns_every_remote(
     # ...but the sync steps (install_uv, clone_project, run_uv_sync, fetch_results) only ran for
     # one of them.
     assert set(sync_calls) == {"trillium"}
+    mock_install_uv.assert_awaited_once()
+    mock_clone_project.assert_awaited_once()
+    mock_run_uv_sync.assert_awaited_once()
+    mock_fetch_results.assert_awaited_once()
+
+    # And every collaborator mocked to get there was actually exercised -- otherwise mocking it
+    # would be pointless.
+    mock_get_active_remotes.assert_awaited_once()
+    mock_login.assert_awaited_once_with(["trillium", "trillium-gpu"], disabled={})
+    mock_head_is_up_to_date.assert_awaited_once()
+    fake_cache_dir.assert_called()
+    mock_get_cluv_config.assert_called()
+    mock_current_cluster.assert_called_once()
+    mock_get_disabled_clusters.assert_called_once()

--- a/tests/test_sync_shared_filesystem.py
+++ b/tests/test_sync_shared_filesystem.py
@@ -1,0 +1,126 @@
+"""Regression tests for clusters that share a filesystem (e.g. `trillium` / `trillium-gpu`).
+
+`trillium` and `trillium-gpu` are separate login nodes of the same physical cluster that share a
+single $HOME (confirmed live via SSH: they mount the identical NFS export) -- but they're
+genuinely different Slurm targets: GPU jobs can only be scheduled through `trillium-gpu`, CPU
+jobs through `trillium`. So:
+
+- `get_active_remotes()` must still return a `Remote` for *each* of them.
+- `sync()` must still return a `Remote` for each of them (so job submission can target either).
+- But `sync()` must only actually run the sync steps (git clone/checkout, `uv sync`, fetching
+  results) once for the pair, since it's the exact same on-disk checkout -- running it twice is
+  redundant, and running it concurrently is unsafe (this is what made
+  `checkout -B <branch> FETCH_HEAD` fail intermittently in the `cluster=first` hydra launcher
+  integration test).
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest import mock
+
+import pytest
+
+from cluv.config import CluvConfig, PartialClusterConfig
+from cluv.remote import Remote
+
+sync_module = importlib.import_module("cluv.cli.sync")
+
+
+@pytest.fixture
+def fake_cache_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    import cluv.cache
+
+    monkeypatch.setattr(cluv.cache, cluv.cache._get_cache_dir.__name__, lambda: cache_dir)
+    return cache_dir
+
+
+@pytest.mark.parametrize(
+    ("hostnames", "expected"),
+    [
+        (["mila", "trillium", "narval", "trillium-gpu"], ["mila", "trillium", "narval"]),
+        (["trillium-gpu", "trillium", "mila"], ["trillium-gpu", "mila"]),
+        (["mila", "narval", "tamia"], ["mila", "narval", "tamia"]),
+        (["trillium"], ["trillium"]),
+    ],
+)
+def test_remotes_to_actually_sync_keeps_only_the_first_per_group(hostnames, expected):
+    remotes = [Remote(hostname=h) for h in hostnames]
+    result = sync_module._remotes_to_actually_sync(remotes)
+    assert [r.hostname for r in result] == expected
+
+
+async def test_get_active_remotes_returns_every_active_cluster(monkeypatch: pytest.MonkeyPatch):
+    """Even clusters sharing a filesystem must all come back: they're distinct Slurm targets."""
+    config = CluvConfig(
+        results_path="/results",
+        clusters={
+            "trillium": PartialClusterConfig(),
+            "trillium-gpu": PartialClusterConfig(),
+            "narval": PartialClusterConfig(),
+        },
+    )
+    monkeypatch.setattr(sync_module, sync_module.get_cluv_config.__name__, lambda: config)
+    monkeypatch.setattr(sync_module, sync_module.current_cluster.__name__, lambda: None)
+    monkeypatch.setattr(sync_module, sync_module.get_disabled_clusters.__name__, lambda: {})
+
+    async def fake_get_remote_without_2fa_prompt(hostname: str) -> Remote:
+        return Remote(hostname=hostname)
+
+    monkeypatch.setattr(
+        sync_module,
+        sync_module.get_remote_without_2fa_prompt.__name__,
+        fake_get_remote_without_2fa_prompt,
+    )
+
+    remotes = await sync_module.get_active_remotes()
+
+    assert {r.hostname for r in remotes} == {"trillium", "trillium-gpu", "narval"}
+
+
+async def test_sync_only_syncs_once_but_returns_every_remote(
+    fake_cache_dir, monkeypatch: pytest.MonkeyPatch
+):
+    """`sync(["trillium", "trillium-gpu"])` must run the sync steps only once, but return both."""
+    config = CluvConfig(
+        results_path="/results",
+        clusters={
+            "trillium": PartialClusterConfig(),
+            "trillium-gpu": PartialClusterConfig(),
+        },
+    )
+    monkeypatch.setattr(sync_module, sync_module.get_cluv_config.__name__, lambda: config)
+    monkeypatch.setattr(sync_module, sync_module.current_cluster.__name__, lambda: None)
+    monkeypatch.setattr(sync_module, sync_module.get_disabled_clusters.__name__, lambda: {})
+    monkeypatch.setattr(
+        sync_module, sync_module._head_is_up_to_date.__name__, mock.AsyncMock(return_value=True)
+    )
+
+    async def fake_login(clusters: list[str], disabled=None) -> list[Remote]:
+        return [Remote(hostname=c) for c in clusters]
+
+    monkeypatch.setattr(sync_module, sync_module.login.__name__, fake_login)
+    monkeypatch.setattr(
+        sync_module, sync_module.get_active_remotes.__name__, mock.AsyncMock(return_value=[])
+    )
+
+    sync_calls: list[str] = []
+
+    async def fake_step(remote, *args, **kwargs):
+        sync_calls.append(remote.hostname)
+        return []
+
+    monkeypatch.setattr(sync_module, sync_module.install_uv.__name__, fake_step)
+    monkeypatch.setattr(sync_module, sync_module.clone_project.__name__, fake_step)
+    monkeypatch.setattr(sync_module, sync_module.run_uv_sync.__name__, fake_step)
+    monkeypatch.setattr(sync_module, "fetch_results", fake_step)
+
+    remotes = await sync_module.sync(["trillium", "trillium-gpu"], sync_datasets=False)
+
+    # Both clusters are returned (they're genuinely different Slurm targets)...
+    assert {r.hostname for r in remotes} == {"trillium", "trillium-gpu"}
+    # ...but the sync steps (install_uv, clone_project, run_uv_sync, fetch_results) only ran for
+    # one of them.
+    assert set(sync_calls) == {"trillium"}


### PR DESCRIPTION
## Summary

`trillium` and `trillium-gpu` are separate login nodes of the same physical cluster that share a single `$HOME` (confirmed live via SSH: they mount the identical NFS export at `$HOME`). `sync()` runs every cluster's setup fully concurrently, so syncing with both at once races on the same on-disk git checkout — e.g. one cluster's `git fetch <ref>` clobbering `.git/FETCH_HEAD` while the other is mid-`checkout -B ... FETCH_HEAD`. This made `test_hydra_example[scripts/job.sh-first]` fail intermittently in CI on #131 (see that PR's history for the investigation).

## Fix

- Added `CLUSTERS_SHARING_A_FILESYSTEM`, an explicit list of known filesystem-sharing cluster groups (currently just `{trillium, trillium-gpu}`).
- `sync()` now only actually runs the sync steps (git clone/checkout, `uv sync`, fetching results) once per group.
- Both clusters are still returned by `sync()` and connected to by `get_active_remotes()`, since they're genuinely different Slurm clusters to submit jobs to (e.g. GPU jobs can only be scheduled through `trillium-gpu`, CPU jobs through `trillium`) — only the redundant/unsafe second sync is skipped.

## Testing

Added `tests/test_sync_shared_filesystem.py`:
- Unit tests for the pure dedup helper.
- `get_active_remotes()` still returns both clusters.
- `sync()` returns both remotes but only runs the sync steps once.

Full unit suite and pre-commit pass locally.

Split out from #131, which is only about enabling the `cluster=first` hydra launcher test; this fix isn't required for that PR to land, but without it the `cluster=first` integration test may intermittently hit the same race if both `trillium` and `trillium-gpu` are active during a sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)