### PR TITLE
Skip wait in `cluv submit` if only one job is pending

### DIFF
--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -206,9 +206,12 @@ async def submit(
         raise
 
     console.print(
-        f"Job {first_running_row.job_id} on cluster {first_running_row.cluster} is running.",
+        f"Successfully submitted job {first_running_row.job_id} on cluster {first_running_row.cluster}.\n"
+        f"Use `[bold]`ssh {first_running_row.cluster} sacct -j {first_running_row.job_id}` to view its "
+        f"status, and `[bold]`cluv sync {first_running_row.cluster}` to fetch results once it is complete.",
         style="green",
     )
+
     job = first_running_row.job
     assert job is not None
     save_job(job)

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -207,8 +207,8 @@ async def submit(
 
     console.print(
         f"Successfully submitted job {first_running_row.job_id} on cluster {first_running_row.cluster}.\n"
-        f"Use `[bold]`ssh {first_running_row.cluster} sacct -j {first_running_row.job_id}` to view its "
-        f"status, and `[bold]`cluv sync {first_running_row.cluster}` to fetch results once it is complete.",
+        f"Use `ssh {first_running_row.cluster} sacct -j {first_running_row.job_id}` to view its "
+        f"status, and `cluv sync {first_running_row.cluster}` to fetch results once it is complete.",
         style="green",
     )
 

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -232,7 +232,14 @@ async def wait_for_first_running_job(
     """
     delay = 1
     while True:
+        all_tasks_done = all(task.done() for task in tasks)
         submitted = [row for row in job_submissions if row.job_id is not None]
+
+        # Skip the wait if only one job is submitted.
+        if all_tasks_done and len(submitted) == 1:
+            console.log("Only one job pending. Skipping wait for a running job.")
+            return submitted[0]
+
         by_cluster = group_by_cluster(submitted)
         if by_cluster:
             states_per_cluster = await asyncio.gather(
@@ -244,14 +251,14 @@ async def wait_for_first_running_job(
             for cluster_rows, states in zip(by_cluster.values(), states_per_cluster):
                 for row, state in zip(cluster_rows, states):
                     row.state = state
-                    if state.startswith(("RUNNING", "COMPLETED")):
+                    if row.state.startswith(("RUNNING", "COMPLETED")):
                         found_running_job.set()
                         return row
 
         all_failed = bool(submitted) and all(
             row.state.startswith(tuple(FAILED_JOB_STATES)) for row in submitted
         )
-        if all(task.done() for task in tasks) and (not submitted or all_failed):
+        if all_tasks_done and (not submitted or all_failed):
             return None
 
         await asyncio.sleep(delay)
@@ -296,7 +303,7 @@ async def wait_for_jobs_to_cancel(
             await asyncio.sleep(delay)
             delay = min(delay * 2, max_wait_time_seconds)
 
-    console.log(f"Cancelled {len(job_submissions)} other job submission(s).")
+    console.log(f"Cancelled {len(job_submissions)} job submission(s).")
 
 
 async def run_scancel(rows: list[SubmissionProgress]) -> None:
@@ -447,7 +454,6 @@ def sbatch_args_from_args_list(sbatch_args_list: list[str]) -> SbatchArgs:
     {'array': '0-3%2', 'a': '0-1%1'}
     """
     # Maybe use argparse, and keep it simple! No need to recreate every single sbatch flag,
-    #
     parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
     parser.add_argument("-c", "--cpus-per-task", dest="cpus-per-task", default=argparse.SUPPRESS)
     parser.add_argument("-t", "--time", dest="time", default=argparse.SUPPRESS)

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -238,12 +238,9 @@ async def wait_for_first_running_job(
         all_tasks_done = all(task.done() for task in tasks)
         submitted = [row for row in job_submissions if row.job_id is not None]
 
-        # Skip the wait if only one job is submitted.
-        if all_tasks_done and len(submitted) == 1:
-            console.log("Only one job pending. Skipping wait for a running job.")
-            return submitted[0]
-
         by_cluster = group_by_cluster(submitted)
+
+        n_pending_jobs = 0
         if by_cluster:
             states_per_cluster = await asyncio.gather(
                 *(
@@ -257,6 +254,14 @@ async def wait_for_first_running_job(
                     if row.state.startswith(("RUNNING", "COMPLETED")):
                         found_running_job.set()
                         return row
+                    elif row.state.startswith(("PENDING")):
+                        n_pending_jobs += 1
+
+        # Skip the wait if only one job is pending (if only one job is submitted or all other jobs
+        # failed).
+        if all_tasks_done and n_pending_jobs == 1:
+            console.log("Only one job pending. Skipping wait for a running job.")
+            return submitted[0]
 
         all_failed = bool(submitted) and all(
             row.state.startswith(tuple(FAILED_JOB_STATES)) for row in submitted

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -261,7 +261,7 @@ async def wait_for_first_running_job(
         # failed).
         if all_tasks_done and n_pending_jobs == 1:
             console.log("Only one job pending. Skipping wait for a running job.")
-            return submitted[0]
+            return next(row for row in submitted if row.state.startswith("PENDING"))
 
         all_failed = bool(submitted) and all(
             row.state.startswith(tuple(FAILED_JOB_STATES)) for row in submitted

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -205,6 +205,9 @@ async def submit(
         await run_scancel(submitted_rows)
         raise
 
+    job = first_running_row.job
+    assert job is not None
+
     console.print(
         f"Successfully submitted job {first_running_row.job_id} on cluster {first_running_row.cluster}.\n"
         f"Use `ssh {first_running_row.cluster} sacct -j {first_running_row.job_id}` to view its "
@@ -212,8 +215,6 @@ async def submit(
         style="green",
     )
 
-    job = first_running_row.job
-    assert job is not None
     save_job(job)
     return job
 


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Skip the wait for a running job in `cluv submit` if only one job is pending. Also cover the case if the user submit only one job.
* Add instructions after a job is correctly submitted.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
* Close #126 