### PR TITLE
Fix short flags parsing when creating the `sbatch` command with `cluv submit`

### DIFF
--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -544,7 +544,7 @@ def sbatch_args_from_dict(d: SbatchArgs) -> list[str]:
             flags.append(f"-{key}" if is_short_flag else f"--{key}")
         else:
             if is_short_flag:
-                flags.append(f"-{key} {value}")
+                flags.extend([f"-{key}", str(value)])
             else:
                 flags.append(f"--{key}={value}")
     return flags

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -529,13 +529,11 @@ def sbatch_args_from_dict(d: SbatchArgs) -> list[str]:
     >>> sbatch_args_from_dict({"exclusive": True})
     ['--exclusive']
     >>> sbatch_args_from_dict({"N": "2"})
-    ['-N=2']
+    ['-N', '2']
     >>> sbatch_args_from_dict({"gpus": "", "requeue": False})
     []
     >>> sbatch_args_from_dict({"n": True})
     ['-n']
-    >>> sbatch_args_from_dict({"f": "config"})
-    ['-f=config']
     """
     flags: list[str] = []
     for key, value in d.items():
@@ -546,7 +544,7 @@ def sbatch_args_from_dict(d: SbatchArgs) -> list[str]:
             flags.append(f"-{key}" if is_short_flag else f"--{key}")
         else:
             if is_short_flag:
-                flags.append(f"-{key}={value}")
+                flags.append(f"-{key} {value}")
             else:
                 flags.append(f"--{key}={value}")
     return flags

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -79,7 +79,7 @@ class TestSbatchArgsFromDict:
         assert sbatch_args_from_dict({"time": "2:00:00"}) == ["--time=2:00:00"]
 
     def test_short_key_string_value(self) -> None:
-        assert sbatch_args_from_dict({"N": "2"}) == ["-N=2"]
+        assert sbatch_args_from_dict({"N": "2"}) == ["-N 2"]
 
     def test_true_long_key_is_bare_flag(self) -> None:
         assert sbatch_args_from_dict({"exclusive": True}) == ["--exclusive"]
@@ -116,7 +116,7 @@ class TestMergeSbatchArgs:
         assert merge_sbatch_args({"t": "1:00:00"}, []) == {"time": "1:00:00"}
 
 
-def test_bug_with_t_flag_and_time_in_config(monkeypatch: pytest.MonkeyPatch):
+def test_bug_with_t_flag_and_time_in_config():
     """Passing -t=00:00:30 while there is a `time: "3:00:00` in the config produces a sbatch command that looks like
     sbatch --time=3:00:00 --t=00:00:30, and this --t is incorrect!.
     """
@@ -143,7 +143,8 @@ def test_order_of_flags_in_sbatch_args_from_cli_is_preserved(
         "-N",
         "2",
         "--foo=first-in-cli",
-        "-f=second-in-cli",
+        "-f",
+        "second-in-cli",
     ]
     expected_sbatch_args_in_command = [
         *([f"--time={time_hours:02d}:00:00"] if not chunking else []),
@@ -153,7 +154,7 @@ def test_order_of_flags_in_sbatch_args_from_cli_is_preserved(
         "--nodes=2",
         "--exclusive",
         "--foo=first-in-cli",  # secretly --foo and -f are the same argument to sbatch (dest=`foo`)
-        "-f=second-in-cli",  # the ordering is preserved.
+        "-f second-in-cli",  # the ordering is preserved.
         *(
             [f"--time={chunking:02d}:00:00", f"--array=0-{time_hours // chunking}%1"]
             if chunking
@@ -220,7 +221,7 @@ class TestGetSbatchCommand:
         sbatch_script = project_dir / "my_script.sh"
         sbatch_script.touch(0o755)
         cluster = "mila"
-        sbatch_args = {"account": "my_account", "mem": "8G"}
+        sbatch_args: SbatchArgs = {"account": "my_account", "mem": "8G"}
         sbatch_command = get_sbatch_command(
             cluster=cluster,
             job_script=sbatch_script,
@@ -709,7 +710,6 @@ async def test_can_submit_on_current_cluster(
     monkeypatch: pytest.MonkeyPatch,
     mock_current_cluster: str,
     cluv_project_dir: Path,
-    no_active_remotes,
 ) -> None:
     dummy_commit = "dummy_git_commit"
     monkeypatch.setattr(

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -710,6 +710,7 @@ async def test_can_submit_on_current_cluster(
     monkeypatch: pytest.MonkeyPatch,
     mock_current_cluster: str,
     cluv_project_dir: Path,
+    no_active_remotes,
 ) -> None:
     dummy_commit = "dummy_git_commit"
     monkeypatch.setattr(

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -79,7 +79,7 @@ class TestSbatchArgsFromDict:
         assert sbatch_args_from_dict({"time": "2:00:00"}) == ["--time=2:00:00"]
 
     def test_short_key_string_value(self) -> None:
-        assert sbatch_args_from_dict({"N": "2"}) == ["-N 2"]
+        assert sbatch_args_from_dict({"N": "2"}) == ["-N", "2"]
 
     def test_true_long_key_is_bare_flag(self) -> None:
         assert sbatch_args_from_dict({"exclusive": True}) == ["--exclusive"]


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
* Fix short flag parsing of `sbatch_args` fields in the config when creating the `sbatch` command with `cluv submit`.
* Fix `sbatch_args_from_dict` to use space instead of equals for short flags. Update related tests.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
* Close #198 