### PR TITLE
Move sbatch args logic

### DIFF
--- a/cluv/cache.py
+++ b/cluv/cache.py
@@ -9,8 +9,8 @@ import platformdirs
 import pydantic
 import yaml
 
-from cluv.config import SbatchArgs
 from cluv.remote import Remote
+from cluv.sbatch_args import SbatchArgs
 from cluv.utils import find_pyproject
 
 logger = logging.getLogger(__name__)

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -1,4 +1,3 @@
-import argparse
 import asyncio
 import dataclasses
 import datetime
@@ -18,8 +17,9 @@ from rich.live import Live
 from cluv.cache import Job, Submission, save_job
 from cluv.cli.submit_utils.chunking import apply_chunking
 from cluv.cli.sync import get_cluster_to_remote, sync_common_part, sync_per_cluster_part
-from cluv.config import SbatchArgs, find_pyproject, get_cluv_config
+from cluv.config import find_pyproject, get_cluv_config
 from cluv.remote import Remote, run
+from cluv.sbatch_args import SbatchArgs, sbatch_args_from_args_list, sbatch_args_to_list
 from cluv.slurm import FAILED_JOB_STATES, run_saccts
 from cluv.utils import console, group_by_cluster
 
@@ -84,7 +84,7 @@ def _short_command(submission: Submission) -> str:
     shown instead is exactly the two things that vary and actually matter: the sbatch flags
     (resources requested) and the program args (what's actually being run).
     """
-    sbatch_flags = shlex.join(sbatch_args_from_dict(submission.sbatch_args))
+    sbatch_flags = shlex.join(sbatch_args_to_list(submission.sbatch_args))
     program_args_str = shlex.join(submission.program_args)
     return f"bash --login -c '(...) {sbatch_flags} -- {program_args_str}'"
 
@@ -439,70 +439,6 @@ def get_submissions(
     return submissions
 
 
-def sbatch_args_from_args_list(sbatch_args_list: list[str]) -> SbatchArgs:
-    """Convert a list of sbatch flags (from the CLI) to a dict of sbatch options.
-
-    Behaves like argparse, where if the flags are passed multiple times, the last value is kept.
-    Aliases for common commands are also kept.
-
-    >>> sbatch_args_from_args_list(["--time=2:00:00", "-t=00:00:30"])
-    {'time': '00:00:30'}
-    >>> sbatch_args_from_args_list(["--time=2:00:00", "--gpus=1"])
-    {'time': '2:00:00', 'gpus': '1'}
-    >>> sbatch_args_from_args_list(["--exclusive"])
-    {'exclusive': True}
-    >>> sbatch_args_from_args_list(["-N", "2"])
-    {'nodes': '2'}
-    >>> sbatch_args_from_args_list(["-f", "2"])
-    {'f': '2'}
-    >>> sbatch_args_from_args_list(["--gpus", "--requeue=False"])
-    {'gpus': True, 'requeue': 'False'}
-    >>> sbatch_args_from_args_list(["-n"])
-    {'n': True}
-    >>> sbatch_args_from_args_list(["--array=0-3%2", "-a=0-1%1"])
-    {'array': '0-3%2', 'a': '0-1%1'}
-    """
-    # Maybe use argparse, and keep it simple! No need to recreate every single sbatch flag,
-    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
-    parser.add_argument("-c", "--cpus-per-task", dest="cpus-per-task", default=argparse.SUPPRESS)
-    parser.add_argument("-t", "--time", dest="time", default=argparse.SUPPRESS)
-    parser.add_argument("-N", "--nodes", dest="nodes", default=argparse.SUPPRESS)
-    parser.add_argument("-A", "--account", dest="account", default=argparse.SUPPRESS)
-    args, unknown = parser.parse_known_args(sbatch_args_list)
-    sbatch_args: SbatchArgs = vars(args)
-
-    # First, join any stragglers like ['-f', '2'] into ['-f=2'] so we can parse them consistently.
-    # Edge case: ['-f', '-g'] stays the same.
-    joined_unknown_args: list[str] = []
-    skip_next = False
-    for i, arg in enumerate(unknown):
-        if skip_next:
-            skip_next = False
-            continue
-        if arg.startswith("-") and i + 1 < len(unknown) and not unknown[i + 1].startswith("-"):
-            joined_unknown_args.append(f"{arg}={unknown[i + 1]}")
-            skip_next = True
-        else:
-            joined_unknown_args.append(arg)
-
-    for value in joined_unknown_args:
-        if value.startswith("--"):
-            key, _, val = value[2:].partition("=")
-        elif value.startswith("-"):
-            value = value.removeprefix("-")
-            key, _, val = value.partition("=")
-        else:
-            continue
-        if not val.strip():
-            val = True  # --exclusive --> {exclusive: True}
-        if val is not None:
-            if key in sbatch_args:
-                # remove the value so the ordering is preserved based on the positioning in `sbatch_args_list`.
-                sbatch_args.pop(key)
-            sbatch_args[key] = val
-    return sbatch_args
-
-
 def merge_sbatch_args(from_config: SbatchArgs, from_cli: list[str]) -> SbatchArgs:
     """Merge the sbatch args from the config and from the CLI, with CLI args taking precedence.
 
@@ -510,44 +446,8 @@ def merge_sbatch_args(from_config: SbatchArgs, from_cli: list[str]) -> SbatchArg
     -t=2:00:00` -- config or CLI, either order -- resolves to a single `time` value (the last
     one written) instead of leaving two separate keys for what's really the same sbatch option.
     """
-    sbatch_args_from_config = sbatch_args_from_dict(from_config)
+    sbatch_args_from_config = sbatch_args_to_list(from_config)
     return sbatch_args_from_args_list(sbatch_args_from_config + from_cli)
-
-
-def sbatch_args_from_dict(d: SbatchArgs) -> list[str]:
-    """Convert a dict of sbatch options to a list of command-line flags.
-
-    Key-to-flag conversion:
-
-    - multi-char key + non-empty string value → ``--key=value``
-    - single-char key + non-empty string value → ``-k value`` (two separate args)
-    - any key + ``True`` → bare flag (``--key`` or ``-k``)
-    - any key + ``""`` or ``False`` → omitted entirely
-
-    >>> sbatch_args_from_dict({"time": "2:00:00", "gpus": "1"})
-    ['--time=2:00:00', '--gpus=1']
-    >>> sbatch_args_from_dict({"exclusive": True})
-    ['--exclusive']
-    >>> sbatch_args_from_dict({"N": "2"})
-    ['-N', '2']
-    >>> sbatch_args_from_dict({"gpus": "", "requeue": False})
-    []
-    >>> sbatch_args_from_dict({"n": True})
-    ['-n']
-    """
-    flags: list[str] = []
-    for key, value in d.items():
-        if value == "" or value is False:
-            continue
-        is_short_flag = len(key) == 1
-        if value is True:
-            flags.append(f"-{key}" if is_short_flag else f"--{key}")
-        else:
-            if is_short_flag:
-                flags.extend([f"-{key}", str(value)])
-            else:
-                flags.append(f"--{key}={value}")
-    return flags
 
 
 def get_sbatch_command(
@@ -576,7 +476,7 @@ def get_sbatch_command(
     env_vars["SBATCH_JOB_NAME"] = f"cluv-{base_name}"
     env_vars["GIT_COMMIT"] = git_commit
 
-    sbatch_flags = sbatch_args_from_dict(sbatch_args)
+    sbatch_flags = sbatch_args_to_list(sbatch_args)
     if not any("--output" in flag for flag in sbatch_flags):
         # Chunked (job array) jobs need `%A`/`%a` (array job id / task id) instead of `%j`.
         if "array" in sbatch_args:

--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -19,7 +19,7 @@ from cluv.cli.submit_utils.chunking import apply_chunking
 from cluv.cli.sync import get_cluster_to_remote, sync_common_part, sync_per_cluster_part
 from cluv.config import find_pyproject, get_cluv_config
 from cluv.remote import Remote, run
-from cluv.sbatch_args import SbatchArgs, sbatch_args_from_args_list, sbatch_args_to_list
+from cluv.sbatch_args import SbatchArgs, sbatch_args_from_list, sbatch_args_to_list
 from cluv.slurm import FAILED_JOB_STATES, run_saccts
 from cluv.utils import console, group_by_cluster
 
@@ -447,7 +447,7 @@ def merge_sbatch_args(from_config: SbatchArgs, from_cli: list[str]) -> SbatchArg
     one written) instead of leaving two separate keys for what's really the same sbatch option.
     """
     sbatch_args_from_config = sbatch_args_to_list(from_config)
-    return sbatch_args_from_args_list(sbatch_args_from_config + from_cli)
+    return sbatch_args_from_list(sbatch_args_from_config + from_cli)
 
 
 def get_sbatch_command(

--- a/cluv/cli/submit_utils/chunking.py
+++ b/cluv/cli/submit_utils/chunking.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 from pathlib import Path
 
-from cluv.config import SbatchArgs
+from cluv.sbatch_args import SbatchArgs
 from cluv.slurm import parse_slurm_time
 
 logger = logging.getLogger(__name__)

--- a/cluv/config.py
+++ b/cluv/config.py
@@ -15,12 +15,10 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.dataclasses import dataclass
 from typing_extensions import TypeVar
 
+from cluv.sbatch_args import SbatchArgs
 from cluv.utils import current_cluster, find_pyproject
 
 logger = logging.getLogger(__name__)
-
-SbatchArgs = dict[str, str | int | float | bool]
-"""A set of sbatch flags, as a mapping from flag name to value."""
 
 
 @dataclass(frozen=True)

--- a/cluv/sbatch_args.py
+++ b/cluv/sbatch_args.py
@@ -1,0 +1,105 @@
+import argparse
+
+SbatchArgs = dict[str, str | int | float | bool]
+"""A set of sbatch flags, as a mapping from flag name to value."""
+
+
+def sbatch_args_to_list(sbatch_args: SbatchArgs) -> list[str]:
+    """Convert a dict of sbatch options to a list of command-line flags.
+
+    Key-to-flag conversion:
+
+    - multi-char key + non-empty string value → ``--key=value``
+    - single-char key + non-empty string value → ``-k value`` (two separate args)
+    - any key + ``True`` → bare flag (``--key`` or ``-k``)
+    - any key + ``""`` or ``False`` → omitted entirely
+
+    >>> sbatch_args_to_list({"time": "2:00:00", "gpus": "1"})
+    ['--time=2:00:00', '--gpus=1']
+    >>> sbatch_args_to_list({"exclusive": True})
+    ['--exclusive']
+    >>> sbatch_args_to_list({"N": "2"})
+    ['-N', '2']
+    >>> sbatch_args_to_list({"gpus": "", "requeue": False})
+    []
+    >>> sbatch_args_to_list({"n": True})
+    ['-n']
+    """
+    flags: list[str] = []
+    for key, value in sbatch_args.items():
+        if value == "" or value is False:
+            continue
+        is_short_flag = len(key) == 1
+        if value is True:
+            flags.append(f"-{key}" if is_short_flag else f"--{key}")
+        else:
+            if is_short_flag:
+                flags.extend([f"-{key}", str(value)])
+            else:
+                flags.append(f"--{key}={value}")
+    return flags
+
+
+def sbatch_args_from_args_list(sbatch_args_list: list[str]) -> SbatchArgs:
+    """Convert a list of sbatch flags (from the CLI) to a dict of sbatch options.
+
+    Behaves like argparse, where if the flags are passed multiple times, the last value is kept.
+    Aliases for common commands are also kept.
+
+    >>> sbatch_args_from_args_list(["--time=2:00:00", "-t=00:00:30"])
+    {'time': '00:00:30'}
+    >>> sbatch_args_from_args_list(["--time=2:00:00", "--gpus=1"])
+    {'time': '2:00:00', 'gpus': '1'}
+    >>> sbatch_args_from_args_list(["--exclusive"])
+    {'exclusive': True}
+    >>> sbatch_args_from_args_list(["-N", "2"])
+    {'nodes': '2'}
+    >>> sbatch_args_from_args_list(["-f", "2"])
+    {'f': '2'}
+    >>> sbatch_args_from_args_list(["--gpus", "--requeue=False"])
+    {'gpus': True, 'requeue': 'False'}
+    >>> sbatch_args_from_args_list(["-n"])
+    {'n': True}
+    >>> sbatch_args_from_args_list(["--array=0-3%2", "-a=0-1%1"])
+    {'array': '0-3%2', 'a': '0-1%1'}
+    """
+    # Parse known args with argparse to handle common aliases and defaults, and leave the rest in `unknown`.
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("-c", "--cpus-per-task", dest="cpus-per-task", default=argparse.SUPPRESS)
+    parser.add_argument("-t", "--time", dest="time", default=argparse.SUPPRESS)
+    parser.add_argument("-N", "--nodes", dest="nodes", default=argparse.SUPPRESS)
+    parser.add_argument("-A", "--account", dest="account", default=argparse.SUPPRESS)
+    args, unknown = parser.parse_known_args(sbatch_args_list)
+    sbatch_args: SbatchArgs = vars(args)
+
+    # First, join any stragglers like ['-f', '2'] into ['-f=2'] so we can parse them consistently.
+    # Edge case: ['-f', '-g'] stays the same.
+    joined_unknown_args: list[str] = []
+    skip_next = False
+    for i, arg in enumerate(unknown):
+        if skip_next:
+            skip_next = False
+            continue
+        if arg.startswith("-") and i + 1 < len(unknown) and not unknown[i + 1].startswith("-"):
+            joined_unknown_args.append(f"{arg}={unknown[i + 1]}")
+            skip_next = True
+        else:
+            joined_unknown_args.append(arg)
+
+    # Then, parse the joined unknown args into the sbatch_args dict.
+    for value in joined_unknown_args:
+        if value.startswith("--"):
+            key, _, val = value[2:].partition("=")
+        elif value.startswith("-"):
+            value = value.removeprefix("-")
+            key, _, val = value.partition("=")
+        else:
+            continue
+        if not val.strip():
+            val = True  # --exclusive --> {exclusive: True}
+        if val is not None:
+            if key in sbatch_args:
+                # remove the value so the ordering is preserved based on the positioning in `sbatch_args_list`.
+                sbatch_args.pop(key)
+            sbatch_args[key] = val
+    return sbatch_args

--- a/cluv/sbatch_args.py
+++ b/cluv/sbatch_args.py
@@ -40,27 +40,27 @@ def sbatch_args_to_list(sbatch_args: SbatchArgs) -> list[str]:
     return flags
 
 
-def sbatch_args_from_args_list(sbatch_args_list: list[str]) -> SbatchArgs:
+def sbatch_args_from_list(sbatch_args_list: list[str]) -> SbatchArgs:
     """Convert a list of sbatch flags (from the CLI) to a dict of sbatch options.
 
     Behaves like argparse, where if the flags are passed multiple times, the last value is kept.
     Aliases for common commands are also kept.
 
-    >>> sbatch_args_from_args_list(["--time=2:00:00", "-t=00:00:30"])
+    >>> sbatch_args_from_list(["--time=2:00:00", "-t=00:00:30"])
     {'time': '00:00:30'}
-    >>> sbatch_args_from_args_list(["--time=2:00:00", "--gpus=1"])
+    >>> sbatch_args_from_list(["--time=2:00:00", "--gpus=1"])
     {'time': '2:00:00', 'gpus': '1'}
-    >>> sbatch_args_from_args_list(["--exclusive"])
+    >>> sbatch_args_from_list(["--exclusive"])
     {'exclusive': True}
-    >>> sbatch_args_from_args_list(["-N", "2"])
+    >>> sbatch_args_from_list(["-N", "2"])
     {'nodes': '2'}
-    >>> sbatch_args_from_args_list(["-f", "2"])
+    >>> sbatch_args_from_list(["-f", "2"])
     {'f': '2'}
-    >>> sbatch_args_from_args_list(["--gpus", "--requeue=False"])
+    >>> sbatch_args_from_list(["--gpus", "--requeue=False"])
     {'gpus': True, 'requeue': 'False'}
-    >>> sbatch_args_from_args_list(["-n"])
+    >>> sbatch_args_from_list(["-n"])
     {'n': True}
-    >>> sbatch_args_from_args_list(["--array=0-3%2", "-a=0-1%1"])
+    >>> sbatch_args_from_list(["--array=0-3%2", "-a=0-1%1"])
     {'array': '0-3%2', 'a': '0-1%1'}
     """
     # Parse known args with argparse to handle common aliases and defaults, and leave the rest in `unknown`.

--- a/tests/test_sbatch_args.py
+++ b/tests/test_sbatch_args.py
@@ -1,0 +1,25 @@
+from cluv.sbatch_args import sbatch_args_to_list
+
+
+class TestSbatchArgsFromDict:
+    def test_long_key_string_value(self) -> None:
+        assert sbatch_args_to_list({"time": "2:00:00"}) == ["--time=2:00:00"]
+
+    def test_short_key_string_value(self) -> None:
+        assert sbatch_args_to_list({"N": "2"}) == ["-N", "2"]
+
+    def test_true_long_key_is_bare_flag(self) -> None:
+        assert sbatch_args_to_list({"exclusive": True}) == ["--exclusive"]
+
+    def test_true_short_key_is_bare_flag(self) -> None:
+        assert sbatch_args_to_list({"n": True}) == ["-n"]
+
+    def test_empty_string_omitted(self) -> None:
+        assert sbatch_args_to_list({"gpus": ""}) == []
+
+    def test_false_omitted(self) -> None:
+        assert sbatch_args_to_list({"requeue": False}) == []
+
+    def test_multiple_flags_in_order(self) -> None:
+        result = sbatch_args_to_list({"time": "2:00:00", "gpus": "1", "exclusive": True})
+        assert result == ["--time=2:00:00", "--gpus=1", "--exclusive"]

--- a/tests/test_sbatch_args.py
+++ b/tests/test_sbatch_args.py
@@ -1,4 +1,4 @@
-from cluv.sbatch_args import sbatch_args_to_list
+from cluv.sbatch_args import sbatch_args_from_args_list, sbatch_args_to_list
 
 
 class TestSbatchArgsFromDict:
@@ -23,3 +23,70 @@ class TestSbatchArgsFromDict:
     def test_multiple_flags_in_order(self) -> None:
         result = sbatch_args_to_list({"time": "2:00:00", "gpus": "1", "exclusive": True})
         assert result == ["--time=2:00:00", "--gpus=1", "--exclusive"]
+
+
+class TestSbatchArgsFromArgsList:
+    def test_long_flag_with_equals(self) -> None:
+        assert sbatch_args_from_args_list(["--gpus=1"]) == {"gpus": "1"}
+
+    def test_short_alias_expands_to_long_name(self) -> None:
+        assert sbatch_args_from_args_list(["-N", "2"]) == {"nodes": "2"}
+
+    def test_short_alias_with_equals_expands_to_long_name(self) -> None:
+        assert sbatch_args_from_args_list(["-t=00:00:30"]) == {"time": "00:00:30"}
+
+    def test_unknown_short_flag_kept_as_is(self) -> None:
+        assert sbatch_args_from_args_list(["-f", "2"]) == {"f": "2"}
+
+    def test_bare_long_flag_is_true(self) -> None:
+        assert sbatch_args_from_args_list(["--exclusive"]) == {"exclusive": True}
+
+    def test_bare_short_flag_is_true(self) -> None:
+        assert sbatch_args_from_args_list(["-n"]) == {"n": True}
+
+    def test_bare_unknown_alias_flag_is_true(self) -> None:
+        assert sbatch_args_from_args_list(["--gpus"]) == {"gpus": True}
+
+    def test_string_value_that_looks_falsy_stays_a_string(self) -> None:
+        assert sbatch_args_from_args_list(["--requeue=False"]) == {"requeue": "False"}
+
+    def test_last_duplicate_known_alias_wins(self) -> None:
+        assert sbatch_args_from_args_list(["--time=2:00:00", "-t=00:00:30"]) == {"time": "00:00:30"}
+
+    def test_last_duplicate_unknown_flag_wins(self) -> None:
+        assert sbatch_args_from_args_list(["--array=0-3%2", "--array=0-1%1"]) == {"array": "0-1%1"}
+
+    def test_duplicate_unknown_flag_preserves_original_position(self) -> None:
+        result = sbatch_args_from_args_list(["--array=0-3%2", "--mem=4G", "--array=0-1%1"])
+        assert list(result.items()) == [("mem", "4G"), ("array", "0-1%1")]
+
+    def test_short_and_long_alias_are_distinct_keys(self) -> None:
+        # `-a` is not treated as an alias of `--array`; both are kept as unknown flags.
+        assert sbatch_args_from_args_list(["--array=0-3%2", "-a=0-1%1"]) == {
+            "array": "0-3%2",
+            "a": "0-1%1",
+        }
+
+    def test_multiple_known_and_unknown_flags_combined(self) -> None:
+        result = sbatch_args_from_args_list(["--time=2:00:00", "--gpus=1", "--exclusive"])
+        assert result == {"time": "2:00:00", "gpus": "1", "exclusive": True}
+
+    def test_empty_list_returns_empty_dict(self) -> None:
+        assert sbatch_args_from_args_list([]) == {}
+
+    def test_two_consecutive_bare_unknown_flags(self) -> None:
+        # Neither flag has a following value, so both stay bare (True).
+        assert sbatch_args_from_args_list(["-f", "-g"]) == {"f": True, "g": True}
+
+    def test_known_flag_default_is_suppressed_when_absent(self) -> None:
+        result = sbatch_args_from_args_list(["--gpus=1"])
+        assert "time" not in result
+        assert "nodes" not in result
+        assert "account" not in result
+        assert "cpus-per-task" not in result
+
+    def test_known_alias_account(self) -> None:
+        assert sbatch_args_from_args_list(["-A", "my-account"]) == {"account": "my-account"}
+
+    def test_known_alias_cpus_per_task(self) -> None:
+        assert sbatch_args_from_args_list(["-c", "4"]) == {"cpus-per-task": "4"}

--- a/tests/test_sbatch_args.py
+++ b/tests/test_sbatch_args.py
@@ -1,4 +1,4 @@
-from cluv.sbatch_args import sbatch_args_from_args_list, sbatch_args_to_list
+from cluv.sbatch_args import sbatch_args_from_list, sbatch_args_to_list
 
 
 class TestSbatchArgsFromDict:
@@ -27,66 +27,66 @@ class TestSbatchArgsFromDict:
 
 class TestSbatchArgsFromArgsList:
     def test_long_flag_with_equals(self) -> None:
-        assert sbatch_args_from_args_list(["--gpus=1"]) == {"gpus": "1"}
+        assert sbatch_args_from_list(["--gpus=1"]) == {"gpus": "1"}
 
     def test_short_alias_expands_to_long_name(self) -> None:
-        assert sbatch_args_from_args_list(["-N", "2"]) == {"nodes": "2"}
+        assert sbatch_args_from_list(["-N", "2"]) == {"nodes": "2"}
 
     def test_short_alias_with_equals_expands_to_long_name(self) -> None:
-        assert sbatch_args_from_args_list(["-t=00:00:30"]) == {"time": "00:00:30"}
+        assert sbatch_args_from_list(["-t=00:00:30"]) == {"time": "00:00:30"}
 
     def test_unknown_short_flag_kept_as_is(self) -> None:
-        assert sbatch_args_from_args_list(["-f", "2"]) == {"f": "2"}
+        assert sbatch_args_from_list(["-f", "2"]) == {"f": "2"}
 
     def test_bare_long_flag_is_true(self) -> None:
-        assert sbatch_args_from_args_list(["--exclusive"]) == {"exclusive": True}
+        assert sbatch_args_from_list(["--exclusive"]) == {"exclusive": True}
 
     def test_bare_short_flag_is_true(self) -> None:
-        assert sbatch_args_from_args_list(["-n"]) == {"n": True}
+        assert sbatch_args_from_list(["-n"]) == {"n": True}
 
     def test_bare_unknown_alias_flag_is_true(self) -> None:
-        assert sbatch_args_from_args_list(["--gpus"]) == {"gpus": True}
+        assert sbatch_args_from_list(["--gpus"]) == {"gpus": True}
 
     def test_string_value_that_looks_falsy_stays_a_string(self) -> None:
-        assert sbatch_args_from_args_list(["--requeue=False"]) == {"requeue": "False"}
+        assert sbatch_args_from_list(["--requeue=False"]) == {"requeue": "False"}
 
     def test_last_duplicate_known_alias_wins(self) -> None:
-        assert sbatch_args_from_args_list(["--time=2:00:00", "-t=00:00:30"]) == {"time": "00:00:30"}
+        assert sbatch_args_from_list(["--time=2:00:00", "-t=00:00:30"]) == {"time": "00:00:30"}
 
     def test_last_duplicate_unknown_flag_wins(self) -> None:
-        assert sbatch_args_from_args_list(["--array=0-3%2", "--array=0-1%1"]) == {"array": "0-1%1"}
+        assert sbatch_args_from_list(["--array=0-3%2", "--array=0-1%1"]) == {"array": "0-1%1"}
 
     def test_duplicate_unknown_flag_preserves_original_position(self) -> None:
-        result = sbatch_args_from_args_list(["--array=0-3%2", "--mem=4G", "--array=0-1%1"])
+        result = sbatch_args_from_list(["--array=0-3%2", "--mem=4G", "--array=0-1%1"])
         assert list(result.items()) == [("mem", "4G"), ("array", "0-1%1")]
 
     def test_short_and_long_alias_are_distinct_keys(self) -> None:
         # `-a` is not treated as an alias of `--array`; both are kept as unknown flags.
-        assert sbatch_args_from_args_list(["--array=0-3%2", "-a=0-1%1"]) == {
+        assert sbatch_args_from_list(["--array=0-3%2", "-a=0-1%1"]) == {
             "array": "0-3%2",
             "a": "0-1%1",
         }
 
     def test_multiple_known_and_unknown_flags_combined(self) -> None:
-        result = sbatch_args_from_args_list(["--time=2:00:00", "--gpus=1", "--exclusive"])
+        result = sbatch_args_from_list(["--time=2:00:00", "--gpus=1", "--exclusive"])
         assert result == {"time": "2:00:00", "gpus": "1", "exclusive": True}
 
     def test_empty_list_returns_empty_dict(self) -> None:
-        assert sbatch_args_from_args_list([]) == {}
+        assert sbatch_args_from_list([]) == {}
 
     def test_two_consecutive_bare_unknown_flags(self) -> None:
         # Neither flag has a following value, so both stay bare (True).
-        assert sbatch_args_from_args_list(["-f", "-g"]) == {"f": True, "g": True}
+        assert sbatch_args_from_list(["-f", "-g"]) == {"f": True, "g": True}
 
     def test_known_flag_default_is_suppressed_when_absent(self) -> None:
-        result = sbatch_args_from_args_list(["--gpus=1"])
+        result = sbatch_args_from_list(["--gpus=1"])
         assert "time" not in result
         assert "nodes" not in result
         assert "account" not in result
         assert "cpus-per-task" not in result
 
     def test_known_alias_account(self) -> None:
-        assert sbatch_args_from_args_list(["-A", "my-account"]) == {"account": "my-account"}
+        assert sbatch_args_from_list(["-A", "my-account"]) == {"account": "my-account"}
 
     def test_known_alias_cpus_per_task(self) -> None:
-        assert sbatch_args_from_args_list(["-c", "4"]) == {"cpus-per-task": "4"}
+        assert sbatch_args_from_list(["-c", "4"]) == {"cpus-per-task": "4"}

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -22,18 +22,17 @@ from cluv.cli.submit import (
     get_sbatch_command,
     get_submissions,
     merge_sbatch_args,
-    sbatch_args_from_dict,
     submit,
 )
 from cluv.cli.submit_utils.chunking import CHUNK_SIZE, apply_chunking
 from cluv.config import (
     CluvConfig,
     PartialClusterConfig,
-    SbatchArgs,
     get_cluv_config,
     load_cluv_config,
 )
 from cluv.remote import Remote
+from cluv.sbatch_args import SbatchArgs
 from cluv.utils import current_cluster
 from tests.test_integration import IN_GITHUB_CLOUD_CI
 
@@ -72,30 +71,6 @@ def cluv_project_dir(project_dir: Path, monkeypatch: pytest.MonkeyPatch) -> Path
 
     cluv.cli.init()
     return project_dir
-
-
-class TestSbatchArgsFromDict:
-    def test_long_key_string_value(self) -> None:
-        assert sbatch_args_from_dict({"time": "2:00:00"}) == ["--time=2:00:00"]
-
-    def test_short_key_string_value(self) -> None:
-        assert sbatch_args_from_dict({"N": "2"}) == ["-N", "2"]
-
-    def test_true_long_key_is_bare_flag(self) -> None:
-        assert sbatch_args_from_dict({"exclusive": True}) == ["--exclusive"]
-
-    def test_true_short_key_is_bare_flag(self) -> None:
-        assert sbatch_args_from_dict({"n": True}) == ["-n"]
-
-    def test_empty_string_omitted(self) -> None:
-        assert sbatch_args_from_dict({"gpus": ""}) == []
-
-    def test_false_omitted(self) -> None:
-        assert sbatch_args_from_dict({"requeue": False}) == []
-
-    def test_multiple_flags_in_order(self) -> None:
-        result = sbatch_args_from_dict({"time": "2:00:00", "gpus": "1", "exclusive": True})
-        assert result == ["--time=2:00:00", "--gpus=1", "--exclusive"]
 
 
 class TestMergeSbatchArgs:


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->
Code extracted from #185 to keep it reviewable. 

* Move `SbatchArgs` type and `sbatch_args_from_dict` and `sbatch_args_from_args_list` functions to `sbatch_args.py`.
* Rename `sbatch_args_from_dict` to `sbatch_args_to_list` and sbatch_args_from_args_list to `sbatch_args_from_list`.
* Remove unused `cluster` in `get_sbatch_command`.
* Update tests.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/