### PR TITLE
Fix environment variable support for chunking

### DIFF
--- a/cluv/cli/submit.py
+++ b/cluv/cli/submit.py
@@ -429,7 +429,7 @@ def get_submissions(
     for job_resources in job_resources_options:
         job_resources = merge_sbatch_args(from_config=job_resources, from_cli=sbatch_args)
         n_chunks, job_resources = apply_chunking(
-            job_resources, job_script=job_script, chunking=chunking
+            job_resources, job_script=job_script, chunking=chunking, env_vars=job_env_vars
         )
         job_resources = add_cluv_sbatch_args(
             job_resources, job_script=job_script, cluster=cluster, cluster_config=cluster_config

--- a/cluv/cli/submit_utils/chunking.py
+++ b/cluv/cli/submit_utils/chunking.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from pathlib import Path
 
@@ -14,7 +13,7 @@ def apply_chunking(
     sbatch_args: SbatchArgs,
     job_script: Path | None,
     chunking: int | None,
-    env_vars: dict[str, str] | None = None,
+    env_vars: dict[str, str],
 ) -> tuple[int | None, SbatchArgs]:
     """Split a job into consecutive chunks of `chunking` hours each, if requested.
 
@@ -49,7 +48,7 @@ def apply_chunking(
             time_limit = val
     # If still not found, use the env vars or the job script header.
     if time_limit is None:
-        time_limit = (env_vars or {}).get("SBATCH_TIMELIMIT") or (
+        time_limit = env_vars.get("SBATCH_TIMELIMIT") or (
             job_script and get_time_from_job_script_header(job_script)
         )
     if not time_limit:
@@ -67,23 +66,6 @@ def apply_chunking(
     sbatch_args_from_config["time"] = f"{chunking:02d}:00:00"
     sbatch_args_from_config["array"] = f"0-{n_chunks - 1}%1"
     return n_chunks, sbatch_args_from_config
-
-
-def get_time_from_sbatch_args(sbatch_args: list[str]) -> str | None:
-    """Return the SLURM time limit from the sbatch args if it exists."""
-    # Last occurrence of --time or -t takes precedence, so we iterate in reverse.
-    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
-    parser.add_argument("-t", "--time", dest="time", default=argparse.SUPPRESS)
-    args, _ = parser.parse_known_args(sbatch_args)
-    return getattr(args, "time", None)
-    # for i, arg in reversed(list(enumerate(sbatch_args))):
-    #     if arg.startswith(("--time=", "-t=")):
-    #         # Like "--time=00:10:00" or "-t=1-02:00:00"
-    #         return arg.split("=")[1]
-    #     if arg.strip() in ("--time", "-t"):
-    #         # Like ["--time", "00:10:00"] or ["-t", "1-02:00:00"]
-    #         return sbatch_args[i + 1] if i + 1 < len(sbatch_args) else None
-    return None
 
 
 def get_time_from_job_script_header(job_script: Path) -> str | None:

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -3,19 +3,20 @@ from pathlib import Path
 import pytest
 
 from cluv.cli.submit_utils.chunking import apply_chunking
+from cluv.config import SbatchArgs
 
 
 class TestApplyChunking:
     def test_chunking_disabled_is_a_passthrough(self) -> None:
-        sbatch_args = {"time": "12:00:00"}
-        n_chunks, result = apply_chunking(sbatch_args, job_script=None, chunking=None)
+        sbatch_args: SbatchArgs = {"time": "12:00:00"}
+        n_chunks, result = apply_chunking(sbatch_args, job_script=None, chunking=None, env_vars={})
         assert n_chunks is None
         assert result == sbatch_args
 
     @pytest.mark.parametrize("time_key", ["time", "t"])
     def test_uses_time_from_sbatch_args(self, time_key: str) -> None:
         n_chunks, result = apply_chunking(
-            {"abc": "123", time_key: "12:00:00"}, job_script=None, chunking=3
+            {"abc": "123", time_key: "12:00:00"}, job_script=None, chunking=3, env_vars={}
         )
         assert n_chunks == 4
         assert result["time"] == "03:00:00"
@@ -28,12 +29,12 @@ class TestApplyChunking:
         public function, so its own tie-break (documented in its docstring: `time` before `t`)
         stays covered directly, independent of that upstream normalization."""
         n_chunks, result = apply_chunking(
-            {"time": "12:00:00", "t": "6:00:00"}, job_script=None, chunking=3
+            {"time": "12:00:00", "t": "6:00:00"}, job_script=None, chunking=3, env_vars={}
         )
         assert n_chunks == 2
         assert result["time"] == "03:00:00"
         n_chunks, result = apply_chunking(
-            {"t": "6:00:00", "time": "12:00:00"}, job_script=None, chunking=3
+            {"t": "6:00:00", "time": "12:00:00"}, job_script=None, chunking=3, env_vars={}
         )
         assert n_chunks == 4
         assert result["time"] == "03:00:00"
@@ -42,7 +43,9 @@ class TestApplyChunking:
         job_script = tmp_path / "my_script"
         job_script.write_text("#SBATCH --time=12:00:00")
 
-        n_chunks, result = apply_chunking({"abc": "123"}, job_script=job_script, chunking=3)
+        n_chunks, result = apply_chunking(
+            {"abc": "123"}, job_script=job_script, chunking=3, env_vars={}
+        )
         assert n_chunks == 4
         assert result["time"] == "03:00:00"
 
@@ -55,6 +58,47 @@ class TestApplyChunking:
         )
         assert n_chunks == 4
         assert result["time"] == "03:00:00"
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            "#SBATCH -t=12:00:00",
+            "#SBATCH --time=12:00:00 # with a trailing comment",
+            "#SBATCH -n 2\n#SBATCH --time=12:00:00",
+            "#!/bin/bash\n#SBATCH --time=12:00:00",
+        ],
+    )
+    def test_various_job_script_header_formats(self, tmp_path: Path, header: str) -> None:
+        job_script = tmp_path / "my_script"
+        job_script.write_text(header)
+
+        n_chunks, result = apply_chunking({}, job_script=job_script, chunking=3, env_vars={})
+        assert n_chunks == 4
+        assert result["time"] == "03:00:00"
+
+    def test_env_vars_take_precedence_over_job_script_header(self, tmp_path: Path) -> None:
+        job_script = tmp_path / "my_script"
+        job_script.write_text("#SBATCH --time=99:00:00")
+
+        n_chunks, _ = apply_chunking(
+            {},
+            job_script=job_script,
+            chunking=3,
+            env_vars={"SBATCH_TIMELIMIT": "12:00:00"},
+        )
+        assert n_chunks == 4
+
+    def test_empty_env_var_falls_back_to_job_script_header(self, tmp_path: Path) -> None:
+        job_script = tmp_path / "my_script"
+        job_script.write_text("#SBATCH --time=12:00:00")
+
+        n_chunks, _ = apply_chunking(
+            {},
+            job_script=job_script,
+            chunking=3,
+            env_vars={"SBATCH_TIMELIMIT": ""},
+        )
+        assert n_chunks == 4
 
     def test_sbatch_args_take_precedence_over_env_vars_and_header(self, tmp_path: Path) -> None:
         job_script = tmp_path / "my_script"
@@ -70,10 +114,12 @@ class TestApplyChunking:
 
     def test_raises_when_no_time_value_found(self) -> None:
         with pytest.raises(ValueError, match="Could not find a time value"):
-            apply_chunking({}, job_script=None, chunking=3)
+            apply_chunking({}, job_script=None, chunking=3, env_vars={})
 
     def test_uses_custom_chunk_size(self) -> None:
-        n_chunks, result = apply_chunking({"time": "12:00:00"}, job_script=None, chunking=6)
+        n_chunks, result = apply_chunking(
+            {"time": "12:00:00"}, job_script=None, chunking=6, env_vars={}
+        )
         assert n_chunks == 2
         assert result["time"] == "06:00:00"
         assert result["array"] == "0-1%1"
@@ -87,6 +133,6 @@ class TestApplyChunking:
         ],
     )
     def test_number_of_chunks_rounds_up(self, time_value: str, expected_array: str) -> None:
-        _, result = apply_chunking({"time": time_value}, job_script=None, chunking=3)
+        _, result = apply_chunking({"time": time_value}, job_script=None, chunking=3, env_vars={})
         assert result["array"] == expected_array
         assert result["time"] == "03:00:00"

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -465,7 +465,10 @@ class TestGetSbatchCommand:
         job_script.write_text("#SBATCH --time=20:00:00")
 
         n_chunks, chunked_args = apply_chunking(
-            {"time": "10:00:00"}, job_script=job_script, chunking=3
+            {"time": "10:00:00"},
+            job_script=job_script,
+            chunking=3,
+            env_vars={"SBATCH_TIMELIMIT": "50:00:00"},
         )
         assert n_chunks == 4
 


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of the feature you're proposing. -->

* Fix environment variable support to chunking.
* Remove unused `get_time_from_sbatch_args` function.
* Add tests for time value in en vars or in job script header.

## Issues
<!-- List any related issues here. If this is a new feature, you can create an issue first and link it here. -->
/